### PR TITLE
docs: add post-installation steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ curl -L https://nozomiishii.dev/dotfiles/install | bash
 
 -L (--location): Enable redirection.
 
+### After installation
+
+1. **Reboot**  
+   Run `sudo reboot` to apply the settings.
+
+2. **(Optional) Homebrew**  
+   To install packages from Brewfile.optional:
+
+   ```shell
+   make homebrew
+   ```
+
+3. **(Optional) Always-on power settings**  
+   To disable sleep and use Wake on LAN etc. ([always_on.sh](scripts/darwin/always_on.sh)):
+
+   ```shell
+   make always-on
+   ```
+
+4. **Clone private repositories after reboot**  
+   After authenticating with GitHub, clone your private repos:
+
+   ```shell
+   gh auth login
+   make repo
+   ```
+
 <a id="install-manually"></a>
 
 <details>
@@ -153,6 +180,8 @@ cd ~ && git clone https://github.com/nozomiishii/dotfiles.git
 ```shell
 sudo reboot
 ```
+
+Then follow the [After installation](#after-installation) steps above.
 
 </details>
 


### PR DESCRIPTION
## 概要
install.sh 完了時に表示される「再起動」「Optional Homebrew」「リポジトリクローン」および `make always-on`（always_on.sh）の手順を、README の Install セクションに「After installation」として追記しました。

## 変更内容
- **Install セクション**: `-L` の説明の直後に「After installation」サブセクションを追加
  - 再起動 (`sudo reboot`)
  - (Optional) `make homebrew`（Brewfile.optional）
  - (Optional) `make always-on`（常時電源設定）
  - 再起動後の `gh auth login` → `make repo`
- **Install Manually**: Restart の後に「Then follow the [After installation](#after-installation) steps above.」を追加し、手順の二重管理を回避

README の該当箇所は英語で記載しています。

Made with [Cursor](https://cursor.com)