### PR TITLE
fix: remove killp() function from functions.zsh

### DIFF
--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -32,11 +32,6 @@ rsdt() {
   open "/Applications/duet.app"
 }
 
-# Kill Port
-killp() {
-  kill -9 $(lsof -ti:$1) && echo "killed Port $1"
-}
-
 # Git checkout remote branch
 gcr() {
   git fetch origin $1


### PR DESCRIPTION
## Summary
- 使用していない `killp()` 関数を `home/.zsh/functions.zsh` から削除
- この関数は引数なしで実行すると全ネットワーク接続中のプロセスを強制終了する危険性があった

Closes #679

## Test plan
- [ ] `source ~/.zsh/functions.zsh` がエラーなく読み込まれることを確認
- [ ] 他の関数（`mkcd`, `lh`, `oplh` 等）が影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)