### PR TITLE
refactor: switch claude code to native installer

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -189,8 +189,6 @@ if OS.mac?
   # Anthropic's official Claude AI desktop app https://www.anthropic.com/
   cask "claude"
 
-  # Terminal-based AI coding assistant https://www.anthropic.com/claude-code
-  cask "claude-code"
 
   # Replacement for Docker Desktop https://orbstack.dev/
   cask "orbstack"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ always-on:
 .PHONY: toolchains
 toolchains:
 	bash ./scripts/toolchains/terraform.sh
+	bash ./scripts/toolchains/claude-code.sh
 	bash ./scripts/toolchains/node.sh
 	bash ./scripts/toolchains/python.sh
 	bash ./scripts/toolchains/ruby.sh

--- a/scripts/toolchains/claude-code.sh
+++ b/scripts/toolchains/claude-code.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# -C          : Prevent overwriting files with output redirection
+# -e          : Exit the script if any command returns a non-zero status
+# -u          : Exit the script if an undefined variable is used
+# -o pipefail : Change pipeline exit status to the last non-zero exit
+#               code in the pipeline, or zero if all commands succeed
+# -x          : (Optional) Enable command tracing for easier debugging
+set -Ceuo pipefail
+
+echo '🤖 Claude Code'
+
+# https://docs.anthropic.com/en/docs/claude-code/overview
+echo '- 🤖 Install Claude Code'
+curl -fsSL https://claude.ai/install.sh | bash
+
+echo "- 🤖 claude $(claude --version)"
+
+echo "🤖 Claude Code setup is complete 🎉"


### PR DESCRIPTION
## Summary
- Homebrew cask (`claude-code`) から公式のネイティブインストーラー (`curl -fsSL https://claude.ai/install.sh | bash`) に切り替え
- `scripts/toolchains/claude-code.sh` を新規作成し、`make toolchains` で実行されるように追加
- Brewfile から `cask "claude-code"` を削除

## Test plan
- [x] `make homebrew` で `claude-code` cask がアンインストールされることを確認
- [x] `make toolchains` で Claude Code がネイティブインストールされることを確認
- [x] `claude --version` でインストール後のバージョンを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)