### PR TITLE
fix: allow github.com in sandbox network for SSH git push

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -13,5 +13,10 @@
   "model": "opus",
   "enabledPlugins": {
     "telegram@claude-plugins-official": true
+  },
+  "sandbox": {
+    "network": {
+      "allowedDomains": ["github.com"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Claude Code のサンドボックス設定に `github.com` を許可ドメインとして追加
- SSH 経由の `git push` がサンドボックス有効のまま実行可能に
- 毎回の `git push` 時にサンドボックス解除の許可プロンプトが不要になる

## Test plan
- [ ] `make link` で symlink を更新
- [ ] Claude Code を再起動
- [ ] サンドボックス有効のまま `git push` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)