### PR TITLE
feat: add PlemolJP Console NF font

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -64,6 +64,9 @@ if OS.mac?
   # Terminal emulator that uses platform-native UI and GPU acceleration https://ghostty.org/
   cask "ghostty"
 
+  # Japanese programming font based on IBM Plex and Inconsolata with Nerd Fonts https://github.com/yuru7/PlemolJP
+  cask "font-plemol-jp-nf"
+
   # Dictation tool including LLM reformatting https://superwhisper.com/
   cask "superwhisper"
 

--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -23,6 +23,7 @@ theme = Gitlab Dark
 font-size = 14
 
 # Font Family
+font-family = "PlemolJP Console NF"
 font-family = "Monaco"
 
 # turn off ligature https://ghostty.org/docs/config/reference#font-feature


### PR DESCRIPTION
## Summary
- Brewfile に `font-plemol-jp-nf`（PlemolJP Console Nerd Font）を追加
- Ghostty の設定にフォントファミリーとして `PlemolJP Console NF` を追加

## Test plan
- [ ] `brew bundle --file=Brewfile` でフォントがインストールされること
- [ ] Ghostty で PlemolJP Console NF が適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)