### PR TITLE
chore(gitignore): ignore claude worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lefthook-local.yaml
 # claude
 **/.claude/settings.local.json
 **/CLAUDE.local.md
+**/.claude/worktrees/
 
 # Logs
 *.log


### PR DESCRIPTION
## 概要

Claude Code が作成する `.claude/worktrees/` を Git の差分・未追跡として扱わないよう、`.gitignore` に追加する。

## 背景

ローカルで worktree が生成されると `git status` に未追跡ファイルとして表示され、ノイズになるため無視する。