### PR TITLE
refactor: unify make link with symlink.sh for idempotency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ repo:
 
 .PHONY: link
 link:
-	stow --verbose --restow --adopt --target="$$HOME" home
+	bash ./scripts/symlink.sh


### PR DESCRIPTION
## Summary

- `make link` が `stow` を直接実行する代わりに `scripts/symlink.sh` を呼ぶように変更
- `make link` と `install.sh` で同じスクリプトを使い、べき等性を確保
- `--adopt` オプションを廃止し、`symlink.sh` の安全なアプローチ（競合ファイル削除 + stow + スキルリンク作成）に統一

## Test plan

- [ ] `make link` を複数回実行して同じ結果になることを確認
- [ ] スキルシンボリックリンクが正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)