### PR TITLE
feat: add Bun installation via official installer

### DIFF
--- a/home/.zprofile
+++ b/home/.zprofile
@@ -32,6 +32,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   esac
 fi
 
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
 # vscode
 export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 

--- a/scripts/toolchains/node.sh
+++ b/scripts/toolchains/node.sh
@@ -23,6 +23,12 @@ echo "- 🐉 node $(node --version)"
 echo '- 🐉 Setup corepack'
 corepack enable pnpm yarn npm
 
+echo '- 🐉 Install Bun'
+curl -fsSL https://bun.sh/install | bash
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+echo "- 🐉 bun $(bun --version)"
+
 echo '- 🐉 Setup pnpm global'
 (
     cd /tmp


### PR DESCRIPTION
## Summary
- `scripts/toolchains/node.sh` に公式インストーラー (`https://bun.sh/install`) による Bun のインストール処理を追加
- `home/.zprofile` に `BUN_INSTALL` 環境変数と PATH 設定を追加
- 既存の `.zshrc` の bun completions 設定と整合する構成

## Test plan
- [ ] `bash -n scripts/toolchains/node.sh` で構文エラーがないことを確認
- [ ] `scripts/toolchains/node.sh` を実行して Bun が `~/.bun/` にインストールされることを確認
- [ ] 新しいシェルセッションで `bun --version` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)