### PR TITLE
feat(claude): add git -C instruction and remove stale MCP config

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -14,6 +14,7 @@
 ## Git
 
 - git 操作の前にブランチを確認し、main への直接コミットを避けること。
+- `cd <path> && git` の複合コマンドは使わず、`git -C <path>` を使用すること（bare repository attack 防止の sandbox 制約を回避するため）。
 
 ## 設定管理
 

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -140,7 +140,7 @@
     "pr": "",
     "commit": ""
   },
-  "enabledMcpjsonServers": ["context7"],
+  "enabledMcpjsonServers": [],
   "alwaysThinkingEnabled": true,
   "cleanupPeriodDays": 90
 }


### PR DESCRIPTION
## Summary

- CLAUDE.md に `git -C <path>` を使う指示を追加。`cd <path> && git` の複合コマンドは bare repository attack 防止のため sandbox 外扱いになり毎回確認が出るため、回避策として `git -C` の使用を指示
- CLI スキル版に移行済みだった context7 を `enabledMcpjsonServers` から削除。MCP 版が残っていたことで不要なツール使用確認が発生していた

## Test plan

- [ ] 新規セッションで worktree 内の git 操作が sandbox 内で実行されることを確認
- [ ] context7 の MCP ツール確認ダイアログが出ないことを確認
- [ ] `find-docs` スキル経由でドキュメント検索が正常に動作することを確認