### PR TITLE
fix(brew): use cask for cmux installation

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -62,7 +62,7 @@ if OS.mac?
   cask "1Password"
 
   # Ghostty-based terminal with vertical tabs and notifications for AI coding agents
-  brew "manaflow-ai/cmux/cmux"
+  cask "manaflow-ai/cmux/cmux"
 
   # Terminal emulator that uses platform-native UI and GPU acceleration https://ghostty.org/
   cask "ghostty"


### PR DESCRIPTION
## Summary

- cmux は Cask として配布されているため、`brew` → `cask` に修正
- CI で `brew bundle` が cmux のインストールに失敗していた問題を解消

## Test plan

- [ ] CI の `brew bundle` が成功することを確認