### PR TITLE
fix(ghostty): add manual shell integration for cmux compatibility

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -32,6 +32,9 @@ font-feature = -calt, -liga, -dlig
 # Show "Quit Ghostty?" dialog
 confirm-close-surface = false
 
+# New windows/tabs open in the same directory as the current terminal
+window-inherit-working-directory = true
+
 # Start Ghostty windows maximized
 maximize = true
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -21,6 +21,13 @@ source "$HOME/.zsh/alias/index.zsh"
 # Functions
 source "$HOME/.zsh/functions.zsh"
 
+# Ghostty shell integration
+# cmux が shell-integration ファイルを同梱していないため手動で読み込む
+# https://github.com/manaflow-ai/cmux/issues/177
+if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
+  builtin source "/Applications/Ghostty.app/Contents/Resources/ghostty/shell-integration/zsh/ghostty-integration"
+fi
+
 # kiro
 [[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"
 


### PR DESCRIPTION
## Summary
- cmux が Ghostty の shell-integration ファイルを同梱していないため、OSC 7 が送信されず `window-inherit-working-directory` が機能しない問題を修正
- `.zshrc` に Ghostty.app から直接 shell integration を読み込むワークアラウンドを追加
- ghostty config に `window-inherit-working-directory = true` とコメントを追加

## Related
- https://github.com/manaflow-ai/cmux/issues/177

## Test plan
- [ ] 新しいターミナルタブで `typeset -f precmd_functions` を実行し、`_ghostty_precmd` が登録されていることを確認
- [ ] `Cmd+T` で新しいタブを開き、作業ディレクトリが引き継がれることを確認
