### PR TITLE
ci: remove home/** path trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,12 @@ on:
       - 'Makefile'
       - 'Brewfile'
       - 'scripts/**'
-      - 'home/**'
   pull_request:
     paths:
       - 'install.sh'
       - 'Makefile'
       - 'Brewfile'
       - 'scripts/**'
-      - 'home/**'
 
 jobs:
   install:


### PR DESCRIPTION
## Summary

- CI の `push.paths` と `pull_request.paths` から `home/**` トリガーを削除
- `home/` 配下は GNU Stow でシンボリックリンクを貼るだけであり、`install.sh` の実行テストでは設定ファイルの中身を検証していないため、CI を走らせる意味がない
- 手動実行（`workflow_dispatch`）は引き続き利用可能
