### PR TITLE
feat(claude): add branch state check to /ta skill

### DIFF
--- a/home/.config/skills/ta/SKILL.md
+++ b/home/.config/skills/ta/SKILL.md
@@ -14,13 +14,13 @@ description: >-
 現在のブランチが `main` でない場合、そのブランチに紐づく PR の状態を確認する:
 
 - `gh pr view --json state` を実行
-- **MERGED / CLOSED**: `main` に切り替えて新規ブランチを作成する
+- **MERGED / CLOSED**: `origin/main` から新規ブランチを作成する（`git checkout -b <branch> origin/main`）
 - **OPEN**: 既存ブランチ・PR を再利用し、追加コミットとして push する（新規 PR は作成しない）
 - **PR が存在しない**: そのブランチをそのまま使い、新規 PR を作成する
 
 ## 1. ブランチ作成（必要な場合のみ）
 
-ステップ 0 で新規作成が必要と判断された場合、`main` から変更内容に適したブランチを新規作成する。
+ステップ 0 で新規作成が必要と判断された場合、`origin/main` から変更内容に適したブランチを新規作成する。worktree でも動作するよう `git checkout main` は使わず、`git fetch origin main && git checkout -b <branch> origin/main` を使用する。
 
 ## 2. コミット・push
 


### PR DESCRIPTION
## 概要

`/ta` スキルにブランチ状態チェック（ステップ 0）を追加。

- マージ済み/クローズ済みの PR があるブランチにいる場合、main に切り替えて新規ブランチを作成する
- OPEN な PR がある場合は既存ブランチ・PR を再利用し、追加コミットとして push する
- PR が存在しない場合はそのまま新規 PR を作成する

## 背景

これまで、マージ済みブランチに対して誤って新しいコミットを積んでしまうケースがあった。ブランチの PR 状態を事前にチェックすることで、この問題を防止する。

## テストプラン

- [ ] マージ済みブランチで `/ta` を実行し、新規ブランチが作成されることを確認
- [ ] OPEN な PR があるブランチで `/ta` を実行し、既存 PR に追加コミットされることを確認
- [ ] main ブランチで `/ta` を実行し、新規ブランチ・PR が作成されることを確認
