### PR TITLE
feat(zsh): add ct alias for claude teleport and remove cwr

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -46,8 +46,8 @@ z!() {
 # ----------------------------------------------------------------
 alias c="claude"
 alias cr="claude --resume"
+alias ct="claude --teleport"
 alias cw="claude --worktree"
-alias cwr="claude --worktree --resume"
 
 # ----------------------------------------------------------------
 # git


### PR DESCRIPTION
## Summary
- 不要な `cwr` (`claude --worktree --resume`) エイリアスを削除
- `ct` (`claude --teleport`) エイリアスを追加
- `--resume` 単体で worktree セッションにも復帰できるため `cwr` は不要

## Test plan
- [ ] `source ~/.zshrc` 後に `ct` が `claude --teleport` として動作する
- [ ] `cwr` が未定義になっている
