### PR TITLE
feat(ghostty): add window-save-state config to restore previous session

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -36,6 +36,9 @@ window-inherit-working-directory = true
 # Start Ghostty windows maximized
 maximize = true
 
+# Restore window state (size, position, tabs) from the previous session
+window-save-state = always
+
 # keybindings
 # shift + enter: claude codeのinputを改行
 keybind = shift+enter=text:\n


### PR DESCRIPTION
## Summary
- Ghostty の設定に `window-save-state = always` を追加
- 前回セッションのウィンドウ状態（サイズ・位置・タブ）が常に復元されるようになる
