### PR TITLE
feat(duti): add pem extension to Cursor default apps

### DIFF
--- a/scripts/default_apps.sh
+++ b/scripts/default_apps.sh
@@ -35,6 +35,7 @@ cursor_extensions=(
   ts
   tsx
   svg
+  pem
 )
 
 for ext in "${cursor_extensions[@]}"; do


### PR DESCRIPTION
## 概要
- `.pem` ファイルを Cursor で開くように `duti` の設定に追加

## テスト
- [ ] `make macos` または `./scripts/default_apps.sh` を実行して `.pem` ファイルが Cursor に関連付けられることを確認
