### PR TITLE
fix(homebrew): resolve brew link conflicts before retrying bundle

### DIFF
--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -21,7 +21,7 @@ OS_NAME="$(uname -s)"
 # ref: https://github.com/nozomiishii/dotfiles/pull/725
 fix_brew_link_conflicts() {
   if [ "${CI:-false}" != "true" ]; then
-    return 1
+    return 0
   fi
   echo "Fixing brew link conflicts on CI..."
   for formula in $(brew list --formula); do
@@ -38,7 +38,7 @@ if [[ "$OS_NAME" == "Darwin" ]]; then
   else
     echo -e "🍺 Homebrew already installed — updating Homebrew and installed packages"
     brew update --force --quiet
-    brew upgrade --quiet || fix_brew_link_conflicts
+    brew upgrade --quiet || { fix_brew_link_conflicts && brew upgrade --quiet; }
   fi
   eval "$(/opt/homebrew/bin/brew shellenv)"
 elif [[ "${OS_NAME}" == "Linux" ]]; then
@@ -49,7 +49,7 @@ elif [[ "${OS_NAME}" == "Linux" ]]; then
   else
     echo -e "🍺 Homebrew already installed — updating Homebrew and installed packages"
     brew update --force --quiet
-    brew upgrade --quiet || fix_brew_link_conflicts
+    brew upgrade --quiet || { fix_brew_link_conflicts && brew upgrade --quiet; }
   fi
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
@@ -72,7 +72,7 @@ while [ "$attempt" -le "$max_attempts" ]; do
     exit 1
   fi
 
-  fix_brew_link_conflicts || true
+  fix_brew_link_conflicts
 
   sleep "$((backoff_base * attempt))"
   attempt="$((attempt + 1))"


### PR DESCRIPTION
## 概要
- GitHub Actions macOS ランナーにプリインストールされた Homebrew パッケージと Brewfile のパッケージがリンク先で競合し、`brew link` がフレーキーに失敗する問題を修正
- `brew bundle` 失敗後、リトライ前に `brew link --overwrite` を全インストール済みフォーミュラに実行し、競合するシンボリックリンクを上書きする

## テストプラン
- [ ] CI の macOS ジョブが安定して通ることを確認
- [ ] ローカルで `make homebrew` が正常に動作することを確認

ref: https://github.com/nozomiishii/dotfiles/actions/runs/23679698905/job/68989448092#step:3:1
