### PR TITLE
fix(ghostty): disable window-save-state and window-inherit-working-directory

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -30,14 +30,15 @@ font-feature = -calt, -liga, -dlig
 # Show "Quit Ghostty?" dialog
 confirm-close-surface = false
 
-# New windows/tabs open in the same directory as the current terminal
-window-inherit-working-directory = true
-
 # Start Ghostty windows maximized
 maximize = true
 
-# Restore window state (size, position, tabs) from the previous session
-window-save-state = always
+# なんかこれ設定してから、CMAXの挙動が良くないような気がしたので一旦Off
+# # Restore window state (size, position, tabs) from the previous session
+# window-save-state = always
+
+# # New windows/tabs open in the same directory as the current terminal
+# window-inherit-working-directory = true
 
 # keybindings
 # shift + enter: claude codeのinputを改行


### PR DESCRIPTION
## Summary

Ghostty の `window-save-state` と `window-inherit-working-directory` を一旦無効化。

これらの設定を有効にしてから CMAX の挙動に問題が出ている可能性があるため、一旦コメントアウトして様子を見る。

## 変更内容

- `window-save-state = always` をコメントアウト（前回セッションのウィンドウ状態復元を無効化）
- `window-inherit-working-directory = true` をコメントアウト（新規タブ/ウィンドウで同じディレクトリを引き継ぐ設定を無効化）
- `confirm-close-surface` と `maximize` の配置を整理
