### PR TITLE
feat(ghostty): add keybind for pm command

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -48,3 +48,6 @@ keybind = shift+enter=text:\n
 
 # undo
 keybind = super+z=text:\x1f
+
+# pm
+keybind = super+alt+j=text:pm\n


### PR DESCRIPTION
## Summary
- Ghostty に `super+alt+j`（Command+Option+J）キーバインドを追加し、`pm` コマンドを実行できるようにした
