### PR TITLE
chore(homebrew): remove brooklyn cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -241,9 +241,6 @@ if OS.mac?
   # Lock/unlock Apple computers using the proximity of a bluetooth low energy device https://github.com/ts1/BLEUnlock
   cask "bleunlock"
 
-  # Screen Saver by Pedro Carrasco. https://github.com/pedrommcarrasco/Brooklyn
-  cask "brooklyn"
-
   # Tool for using an iPad as a second display https://www.duetdisplay.com/
   cask "duet"
 


### PR DESCRIPTION
## 概要
- Brewfile から `brooklyn` cask（スクリーンセーバー）を削除
