### PR TITLE
chore: add FUNDING.yaml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,0 +1,1 @@
+github: nozomiishii


### PR DESCRIPTION
## Summary
GitHub Sponsors のスポンサーボタンをリポジトリページに表示するための `FUNDING.yaml` を追加。
