### PR TITLE
feat(lefthook): auto-run make link on post-merge when home/ changes

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -11,6 +11,13 @@
 extends:
   - ./node_modules/@nozomiishii/lefthook-config/index.yaml
 
+post-merge:
+  parallel: true
+  jobs:
+    - name: symlink
+      glob: 'home/**'
+      run: make link
+
 pre-commit:
   parallel: true
   jobs:


### PR DESCRIPTION
## 概要
- post-merge フックに `symlink` ジョブを追加
- `home/` 配下のファイルがマージで変更された場合、自動で `make link` を実行してシンボリックリンクを再作成する
- `parallel: true` で既存の post-merge ジョブと並列実行

## テスト
- [ ] `pnpx lefthook run --verbose post-merge` で symlink ジョブが表示されることを確認
- [ ] `home/` 配下のファイルを含むブランチをマージし、`make link` が自動実行されることを確認
