### PR TITLE
fix(darwin): log brew-update stdout to file instead of /dev/null

### DIFF
--- a/home/Library/LaunchAgents/local.brew-update.plist
+++ b/home/Library/LaunchAgents/local.brew-update.plist
@@ -23,7 +23,7 @@
   </dict>
 
   <key>StandardOutPath</key>
-  <string>/dev/null</string>
+  <string>/tmp/brew-update.log</string>
   <key>StandardErrorPath</key>
   <string>/tmp/brew-update.log</string>
 </dict>


### PR DESCRIPTION
## Summary
- launchd の `local.brew-update` ジョブで `StandardOutPath` が `/dev/null` に設定されており、`brew_update.sh` の stdout 出力（タイムスタンプ付き進捗メッセージ）が破棄されていた
- `StandardOutPath` を `/tmp/brew-update.log` に変更し、stderr と同じファイルに stdout も出力されるようにした

## Test plan
- [ ] `make link` でシンボリックリンクを更新
- [ ] `launchctl unload ~/Library/LaunchAgents/local.brew-update.plist && launchctl load ~/Library/LaunchAgents/local.brew-update.plist` でリロード
- [ ] 手動で `~/dotfiles/scripts/darwin/brew_update.sh` を実行し、`/tmp/brew-update.log` に stdout が記録されることを確認
