### PR TITLE
chore(claude): switch default permission mode to auto

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "permissions": {
-    "defaultMode": "acceptEdits",
+    "defaultMode": "auto",
     "allow": [
       "Read",
       "Edit",

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -75,12 +75,10 @@ sandbox のデフォルトではカレントディレクトリとサブディレ
 ### permissions.defaultMode
 
 ```jsonc
-"defaultMode": "acceptEdits"
+"defaultMode": "auto"
 ```
 
-ファイル編集を自動承認するモード。bash コマンドは sandbox の autoAllow が担当するため、この組み合わせで「ファイル編集 = acceptEdits が承認」「bash = sandbox が承認」となり、ほぼ全操作がプロンプトなしで通る。
-
-Auto Mode（2026年3月12日〜リサーチプレビュー）と比較して、追加のトークンコスト・レイテンシがなく、安全性の根拠も LLM 判断ではなく OS レベル分離なのでこちらを採用。
+Auto Mode をデフォルトに設定。バックグラウンドで安全性チェックを行いつつ、ほとんどの操作を自動承認する。sandbox による OS レベル分離と組み合わせることで、二重の安全層を確保している。
 
 ### permissions.allow
 


### PR DESCRIPTION
## 概要
- Claude Code のデフォルト権限モードを `acceptEdits` から `auto` に変更
- `settings.md` のドキュメントも同期更新

## 背景
Auto Mode はバックグラウンドで安全性チェックを行いつつ操作を自動承認する。sandbox による OS レベル分離と組み合わせることで、二重の安全層を確保しつつ作業効率を向上させる。
