### PR TITLE
chore(claude): switch default permission mode to plan

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "permissions": {
-    "defaultMode": "auto",
+    "defaultMode": "plan",
     "allow": [
       "Read",
       "Edit",

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -75,10 +75,10 @@ sandbox のデフォルトではカレントディレクトリとサブディレ
 ### permissions.defaultMode
 
 ```jsonc
-"defaultMode": "auto"
+"defaultMode": "plan"
 ```
 
-Auto Mode をデフォルトに設定。バックグラウンドで安全性チェックを行いつつ、ほとんどの操作を自動承認する。sandbox による OS レベル分離と組み合わせることで、二重の安全層を確保している。
+Plan Mode をデフォルトに設定。セッション開始時は読み取り専用で議論・計画に集中し、実装準備ができたら `shift+tab` で実行モードに切り替える。議論→仕様固め→実装のワークフローに最適化。
 
 ### permissions.allow
 


### PR DESCRIPTION
## 概要
- Claude Code のデフォルト権限モードを `auto` から `plan` に変更
- `settings.md` のドキュメントも同期更新

## 背景
議論・仕様固めを先に行うワークフローに合わせ、セッション開始時は Plan Mode（読み取り専用）で起動するよう変更。実装準備ができたら `shift+tab` で実行モードに切り替える運用。
