### PR TITLE
feat(hooks): add pre-push check to block push to merged/closed PR branches

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,6 +8,7 @@
 #   pnpx lefthook run --verbose pre-commit
 #   pnpx lefthook run --verbose commit-msg
 #   pnpx lefthook run --verbose post-merge
+#   pnpx lefthook run --verbose pre-push
 extends:
   - ./node_modules/@nozomiishii/lefthook-config/index.yaml
 
@@ -17,6 +18,12 @@ post-merge:
     - name: symlink
       glob: 'home/**'
       run: make link
+
+pre-push:
+  parallel: true
+  jobs:
+    - name: check-pr-not-merged
+      run: bash scripts/check-pr-not-merged.sh
 
 pre-commit:
   parallel: true

--- a/scripts/check-pr-not-merged.sh
+++ b/scripts/check-pr-not-merged.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# check-pr-not-merged.sh - Block push to branches with MERGED/CLOSED PRs
+#
+# Prevents accidental pushes to branches whose pull request has already
+# been merged or closed. Skips gracefully when gh CLI is unavailable,
+# unauthenticated, or no PR exists for the current branch.
+#
+# Usage:
+#   bash scripts/check-pr-not-merged.sh   # lefthook (pre-push)
+#
+set -euo pipefail
+
+# Skip if gh CLI is not installed
+if ! command -v gh &>/dev/null; then
+  exit 0
+fi
+
+# Skip if gh is not authenticated
+if ! gh auth status &>/dev/null; then
+  exit 0
+fi
+
+# Get current branch name
+branch=$(git branch --show-current)
+
+# Skip on detached HEAD
+if [ -z "$branch" ]; then
+  exit 0
+fi
+
+# Skip on default branches
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  exit 0
+fi
+
+# Check PR state for this branch
+state=$(gh pr view --json state --jq '.state' 2>/dev/null) || exit 0
+
+if [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ]; then
+  echo "ERROR: PR for branch '$branch' is already $state."
+  echo ""
+  echo "Create a new branch for additional changes:"
+  echo "  git checkout -b <new-branch> origin/main"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

マージ済み/クローズ済みのPRがあるブランチへの push を pre-push フックでブロックする仕組みを追加。

- `scripts/check-pr-not-merged.sh`: `gh pr view` でPR状態を確認し、MERGED/CLOSED なら push を阻止
- `lefthook.yaml`: `pre-push` セクションを追加

## 背景

同じセッション内でPR作成→マージ後に、古いブランチに追加 push してしまうケースが発生した。仕組みで防ぐ。

## スキップ条件

以下の場合は push をブロックしない:
- `gh` CLI 未インストール / 未認証
- detached HEAD
- main / master ブランチ
- PRが存在しないブランチ

## Test plan

- [ ] MERGED な PR のブランチで `git push` → ブロックされることを確認
- [ ] PR がないブランチで `git push` → 通ることを確認
- [ ] `pnpx lefthook run --verbose pre-push` で動作確認
