### PR TITLE
feat(darwin): auto-move Downloads to Desktop via LaunchAgent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,12 @@ make link
   gh pr create --title "feat: ..." --body-file /private/tmp/claude-<uid>/pr-body.md
   ```
 
+## ポータビリティ
+
+- **ユーザー名をハードコードしない。** dotfiles は複数の Mac で異なるユーザー名で運用されるため、plist・スクリプト・設定ファイルで `/Users/<name>/...` と直書きせず `$HOME` / `~` を使うこと。
+  - LaunchAgent plist で `$HOME` 展開が必要な場合は `bash -l -c 'exec "$HOME/..."'` を経由する（参考: [home/Library/LaunchAgents/local.brew-update.plist](home/Library/LaunchAgents/local.brew-update.plist)）。
+  - `bash -l` は `/etc/profile` 経由で `path_helper` を動かし、`/etc/paths.d/homebrew` の `/opt/homebrew/bin` を PATH に取り込む役割も兼ねる。
+
 ## アーキテクチャ概要
 
 macOS と Linux で開発環境のセットアップを自動化する dotfiles リポジトリです。**GNU Stow** でシンボリックリンクを管理し、Make ターゲットで統一されたインターフェースを提供します。

--- a/Brewfile
+++ b/Brewfile
@@ -176,6 +176,9 @@ if OS.mac?
   # A CLI for configuring 'Night Shift' on macOS https://github.com/smudge/nightlight
   brew "smudge/smudge/nightlight"
 
+  # File change monitor used by the Downloads -> Desktop LaunchAgent https://github.com/emcrisostomo/fswatch
+  brew "fswatch"
+
   # Dependency manager for Cocoa projects https://cocoapods.org/
   brew "cocoapods"
 

--- a/home/.local/bin/downloads-to-desktop.sh
+++ b/home/.local/bin/downloads-to-desktop.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# ~/Downloads に入ったファイルを ~/Desktop へ自動移動する。
+# AirDrop の保存先を変更できない macOS の制約を回避する用途。
+# fswatch でイベント監視し、ダウンロード途中の一時ファイルは除外する。
+
+set -uo pipefail
+
+SRC="$HOME/Downloads"
+DST="$HOME/Desktop"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+# ダウンロード途中とみなす拡張子・パターン
+is_temp_file() {
+  local name="$1"
+  case "$name" in
+    .*) return 0 ;;          # ドット始まり（.DS_Store 等）
+    *.crdownload) return 0 ;; # Chromium
+    *.download) return 0 ;;   # Safari
+    *.part) return 0 ;;       # Firefox
+    *~) return 0 ;;           # エディタ等のバックアップ
+    *) return 1 ;;
+  esac
+}
+
+# サイズが安定するまで待つ（書き込み中のファイル対策）
+wait_until_stable() {
+  local path="$1"
+  local prev=-1 curr=0 tries=0
+  while [ "$prev" != "$curr" ] && [ "$tries" -lt 20 ]; do
+    prev="$curr"
+    sleep 0.5
+    if [ ! -e "$path" ]; then
+      return 1
+    fi
+    curr=$(stat -f '%z' "$path" 2>/dev/null || echo 0)
+    tries=$((tries + 1))
+  done
+  return 0
+}
+
+# 同名衝突時に " (2)"," (3)" を付ける
+resolve_destination() {
+  local base="$1"
+  local target="$DST/$base"
+  if [ ! -e "$target" ]; then
+    printf '%s\n' "$target"
+    return
+  fi
+
+  local name="${base%.*}"
+  local ext=""
+  if [ "$name" != "$base" ]; then
+    ext=".${base##*.}"
+  fi
+
+  local i=2
+  while [ -e "$DST/${name} (${i})${ext}" ]; do
+    i=$((i + 1))
+  done
+  printf '%s\n' "$DST/${name} (${i})${ext}"
+}
+
+handle_path() {
+  local path="$1"
+
+  # SRC 直下のファイルのみ対象（サブディレクトリ配下のイベントは無視）
+  local parent
+  parent="$(dirname "$path")"
+  [ "$parent" = "$SRC" ] || return 0
+
+  [ -e "$path" ] || return 0
+
+  local name
+  name="$(basename "$path")"
+
+  if is_temp_file "$name"; then
+    return 0
+  fi
+
+  # ディレクトリは対象外（AirDrop 単ファイル運用）
+  if [ -d "$path" ]; then
+    return 0
+  fi
+
+  if ! wait_until_stable "$path"; then
+    log "disappeared before stable: $path"
+    return 0
+  fi
+
+  local dest
+  dest="$(resolve_destination "$name")"
+
+  if mv -- "$path" "$dest" 2>/dev/null; then
+    log "moved: $path -> $dest"
+  else
+    log "failed to move: $path"
+  fi
+}
+
+if ! command -v fswatch >/dev/null 2>&1; then
+  log "fswatch not found in PATH; install via 'brew install fswatch'"
+  exit 127
+fi
+
+mkdir -p "$DST"
+
+log "watching $SRC -> $DST"
+
+# -0: NULL 区切り / 作成・移動・リネームを監視
+fswatch -0 \
+  --event Created \
+  --event MovedTo \
+  --event Renamed \
+  "$SRC" |
+  while IFS= read -r -d '' path; do
+    handle_path "$path"
+  done

--- a/home/.local/bin/downloads-to-desktop.sh
+++ b/home/.local/bin/downloads-to-desktop.sh
@@ -3,6 +3,10 @@
 # ~/Downloads に入ったファイルを ~/Desktop へ自動移動する。
 # AirDrop の保存先を変更できない macOS の制約を回避する用途。
 # fswatch でイベント監視し、ダウンロード途中の一時ファイルは除外する。
+#
+# 注: ディレクトリは対象外。
+# - iOS/iPadOS → Mac の AirDrop はフォルダが zip 化されて届くので単一ファイル扱いとなり移動される。
+# - Mac ↔ Mac のフォルダ AirDrop は ~/Downloads にフォルダのまま残る（想定運用外）。
 
 set -uo pipefail
 

--- a/home/Library/LaunchAgents/local.downloads-to-desktop.plist
+++ b/home/Library/LaunchAgents/local.downloads-to-desktop.plist
@@ -8,7 +8,8 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>-lc</string>
+    <string>-l</string>
+    <string>-c</string>
     <!-- fswatch を Homebrew PATH で解決するためログインシェルで起動 -->
     <string>exec "$HOME/.local/bin/downloads-to-desktop.sh"</string>
   </array>

--- a/home/Library/LaunchAgents/local.downloads-to-desktop.plist
+++ b/home/Library/LaunchAgents/local.downloads-to-desktop.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>local.downloads-to-desktop</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <!-- fswatch を Homebrew PATH で解決するためログインシェルで起動 -->
+    <string>exec "$HOME/.local/bin/downloads-to-desktop.sh"</string>
+  </array>
+
+  <!-- ログイン時に自動起動し、落ちたら再起動 -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/downloads-to-desktop.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/downloads-to-desktop.log</string>
+</dict>
+</plist>

--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -275,6 +275,17 @@ launchctl bootout "gui/$UID" "$local_keymap_plist" 2>/dev/null || true
 launchctl bootstrap "gui/$UID" "$local_keymap_plist"
 
 # ----------------------------------------------------------------
+# Downloads -> Desktop
+# ----------------------------------------------------------------
+# AirDrop の保存先は変更不可のため、~/Downloads に入ったファイルを
+# ~/Desktop へ自動移動する LaunchAgent を常駐させる
+echo "- 📥 Downloads -> Desktop"
+
+local_d2d_plist="$HOME/Library/LaunchAgents/local.downloads-to-desktop.plist"
+launchctl bootout "gui/$UID" "$local_d2d_plist" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" "$local_d2d_plist"
+
+# ----------------------------------------------------------------
 # Network
 # ----------------------------------------------------------------
 echo "- 📡 Network"


### PR DESCRIPTION
## Summary

macOS の AirDrop は保存先を変更できず ~/Downloads 固定のため、~/Downloads に入ったファイルを ~/Desktop へ自動移動する LaunchAgent を追加する。AirDrop 経由だけでなくブラウザ等のダウンロードも Desktop へ集約される（Downloads フォルダを使わない運用）。

## 変更内容

- home/.local/bin/downloads-to-desktop.sh: fswatch で ~/Downloads 直下を監視し、~/Desktop へ mv する常駐スクリプト
  - 一時拡張子 (.crdownload / .download / .part / *~ / ドット始まり) は除外
  - stat でサイズ安定待ち（最大 10 秒）してから移動
  - 同名衝突時は ' (2)' ' (3)' と連番付与
- home/Library/LaunchAgents/local.downloads-to-desktop.plist: RunAtLoad + KeepAlive で常駐、ログは /tmp/downloads-to-desktop.log
- Brewfile: fswatch を追加
- scripts/darwin/macos.sh: 既存の local.keymap.plist と同じパターンで launchctl bootout → bootstrap

## Test plan

- [ ] brew bundle で fswatch がインストールされる
- [ ] make link で plist とスクリプトがシンボリックリンクされる
- [ ] bash scripts/darwin/macos.sh 実行後、launchctl print "gui/$UID/local.downloads-to-desktop" で running
- [ ] touch ~/Downloads/test.txt → ~/Desktop/test.txt に移動
- [ ] touch ~/Downloads/foo.crdownload → 除外され移動されない
- [ ] 同名ファイルを続けて作成 → foo.txt と foo (2).txt になる
- [ ] 他デバイスから AirDrop 受信 → Desktop に届く
- [ ] /tmp/downloads-to-desktop.log にエラーが出ない
