### PR TITLE
chore(agents): use /tmp/claude for PR body temp file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,17 +58,17 @@ make link
 - **PR のマージは必ずユーザーが手動で行う。** AI アシスタントが `gh pr merge` や GitHub API 経由でマージを実行してはならない。
 - PR の作成・更新・push は許可するが、マージの最終判断は常にユーザーに委ねること。
 - **PR タイトルは英語で記述し、CI の semantic pull request チェックに従う。** 小文字で始める英数字・記号のみ、末尾にスペースを付けない。例: `feat(darwin): use launchctl for Remote Login`. 詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
-- **PR 作成時は `--body-file` を使用する。** HEREDOC で `--body` に直接渡すと、Markdown の `#` 見出しがコマンドインジェクション検出に引っかかり毎回承認が必要になる。代わりに一時ファイル経由で渡すこと。`cat` と `gh` は別々の Bash 呼び出しで実行する（1つにまとめると HEREDOC 内の `#` が検出される）:
+- **PR 作成時は `--body-file` を使用する。** HEREDOC で `--body` に直接渡すと、Markdown の `#` 見出しがコマンドインジェクション検出に引っかかり毎回承認が必要になる。代わりに一時ファイル経由で渡すこと。`cat` と `gh` は別々の Bash 呼び出しで実行する（1つにまとめると HEREDOC 内の `#` が検出される）。一時ファイルは **sandbox 内/外の両方で同じ絶対パスに解決される固定パス**を使う。`$TMPDIR` は sandbox 内では `/tmp/claude-<uid>`、sandbox 外では `/var/folders/.../T/` と展開先が変わるため `cat` と `gh` をまたぐ用途では使わない。`/tmp/claude` は allowOnly に含まれるためサブディレクトリを掘って使う:
   ```bash
   # Step 1: body を一時ファイルに書き出す（sandbox 内で実行）
-  cat > /private/tmp/claude-<uid>/pr-body.md <<'EOF'
+  mkdir -p /tmp/claude && cat > /tmp/claude/pr-body.md <<'EOF'
   ## Summary
   ...
   EOF
   ```
   ```bash
   # Step 2: --body-file で渡す（gh は sandbox 外で実行される）
-  gh pr create --title "feat: ..." --body-file /private/tmp/claude-<uid>/pr-body.md
+  gh pr create --title "feat: ..." --body-file /tmp/claude/pr-body.md
   ```
 
 ## アーキテクチャ概要


### PR DESCRIPTION
## Summary

PR body 用の一時ファイルパスを `/private/tmp/claude-<uid>/` から `/tmp/claude/` に変更する。

## 背景

実運用で `/private/tmp/claude-<uid>/pr-body.md` が sandbox に弾かれた。原因:

1. **sandbox の `allowOnly` は path-prefix マッチ**。`/private/tmp/claude` は許可されているが `/private/tmp/claude-<uid>` は次の文字が `-` で `/` ではないので別ディレクトリ扱いとなり拒否される。
2. **`$TMPDIR` は sandbox 内外で展開先が異なる**:
   - sandbox 内: `/tmp/claude-<uid>`
   - sandbox 外（`gh` 実行時）: `/var/folders/.../T/`
   `cat`（sandbox 内）で書いて `gh --body-file`（sandbox 外）で読む用途では `$TMPDIR` を直に書くと読み側でファイルが見つからない。

## 解決策

`/tmp/claude` を使う:

- sandbox の `allowOnly` に `/tmp/claude` が明示的に含まれる → sandbox 内で書き込める
- `/tmp/claude` は絶対パスで sandbox 内外どちらも同じ場所を指す → sandbox 外の `gh` からも読める
- `mkdir -p /tmp/claude` を冒頭に入れておけば初回でも安全

両方向で動作確認済み (sandbox 内で `cat > /tmp/claude/test.md`, sandbox 外で `cat /tmp/claude/test.md` が成功)。

## Test plan

- [x] sandbox 内で `mkdir -p /tmp/claude && cat > /tmp/claude/pr-body.md` が成功
- [x] sandbox 外で `cat /tmp/claude/pr-body.md` が成功
- [ ] 本 PR 自体がこの新パターンで作成されている（dogfooding）
