### PR TITLE
feat(lefthook): auto-run make homebrew on post-merge when Brewfile changes

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -18,6 +18,10 @@ post-merge:
     - name: symlink
       glob: 'home/**'
       run: make link
+    - name: homebrew
+      glob: '{Brewfile,Brewfile.optional}'
+      interactive: true
+      run: make homebrew
 
 pre-push:
   parallel: true


### PR DESCRIPTION
## Summary

- `post-merge` フックに `homebrew` ジョブを追加し、`Brewfile` / `Brewfile.optional` が変更された merge / pull の直後に `make homebrew` を自動実行する。
- `interactive: true` を指定して `/dev/tty` を stdin として割り当てるため、cask インストール時の sudo パスワードプロンプトなどにも応答できる。

## なぜ

Brewfile を更新したあと手動で `make homebrew` を叩き忘れることがあり、複数マシン間でパッケージ状態がズレる。post-merge で自動化すれば、`git pull` / merge 直後に最新の Brewfile が反映される。

## 挙動

1. 既存の `symlink` ジョブ（非interactive）が先に走る。
2. その後 `homebrew` ジョブが tty 接続で実行される（`interactive` ジョブは非interactive ジョブの後に走る仕様）。

## Test plan

- [ ] 別ブランチで Brewfile を変更 → main に merge し、`make homebrew` が自動実行されることを確認
- [ ] Brewfile に無関係な変更だけの merge では `homebrew` ジョブが skip されることを確認
- [ ] `pnpx lefthook run --verbose post-merge` でジョブ定義に構文エラーがないことを確認
