### PR TITLE
chore(claude): allow WebFetch to *.github.com subdomains

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -67,6 +67,7 @@
       "Bash(docker run:*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
+      "WebFetch(domain:*.github.com)",
       "WebFetch(domain:github.blog)",
       "WebFetch(domain:*.npmjs.org)",
       "WebFetch(domain:*.npmjs.com)",


### PR DESCRIPTION
## Summary

- `~/.claude/settings.json` の `permissions.allow` に `WebFetch(domain:*.github.com)` を追加し、`api.github.com` など github.com 配下のすべてのサブドメインへの WebFetch をグローバルに許可

## 背景

worktree 側の `.claude/settings.local.json` に `WebFetch(domain:api.github.com)` のルールが溜まっていて、SessionStart hook (`check-local-settings.sh`) が毎回警告を出していた。グローバル設定に移行するタイミング。

## ワイルドカード化の理由

単一サブドメインの追加であれば bare `api.github.com` でも良いが、既存の `WebFetch(domain:*.npmjs.org)` / `*.npmjs.com` と揃える方向でワイルドカード化した。sandbox の `allowedDomains` にも既に `*.github.com` が入っており、一貫性が取れる。

今後 `gist.github.com` など別の subdomain が必要になっても追加不要。

## 補足

worktree 側の `.claude/settings.local.json` は gitignore 対象なので本 PR の diff には現れない。ローカルファイルは別途削除する。

## Test plan

- [x] `jq -e '.permissions.allow[] | select(. == "WebFetch(domain:*.github.com)")' ~/.claude/settings.json` が該当エントリを返す
- [x] prettier --check が pass
- [ ] マージ後、新セッション起動時に SessionStart hook の settings.local.json 警告が出なくなる
