### PR TITLE
chore(claude): migrate fullscreen renderer from env var to settings.tui

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -179,5 +179,6 @@
   "spinnerTipsEnabled": false,
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
-  "model": "opus[1m]"
+  "model": "opus[1m]",
+  "tui": "fullscreen"
 }

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -268,6 +268,16 @@ Max/Team/Enterprise プランでは `"model": "opus"` だけで自動的に 1M c
 
 将来 #45574 が確実に修正されたらこの注意書きは削除する。
 
+### tui
+
+```jsonc
+"tui": "fullscreen"  // フルスクリーン (alt screen) レンダラをデフォルトに
+```
+
+Claude Code 2.1.110 で追加された TUI レンダラの選択。`"default"` は通常の inline レンダリング、`"fullscreen"` は alt screen バッファを使ったちらつきの少ない描画。`fullscreen` モードでのみ `/focus` が有効になる。セッション内では `/tui default` / `/tui fullscreen` で切り替え可能。
+
+旧来の `CLAUDE_CODE_NO_FLICKER=1` 環境変数の置き換え。`/tui` 実行時に `CLAUDE_CODE_NO_FLICKER` は明示的に unset されるため、env var は将来的に廃止される見込み。settings の `tui` キーが env var より優先される。
+
 ## 使い方
 
 ```bash

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -31,9 +31,6 @@ export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
 
-# Claude Code
-export CLAUDE_CODE_NO_FLICKER=1
-
 # direnv
 if command -v direnv >/dev/null; then
   eval "$(direnv hook zsh)"


### PR DESCRIPTION
Claude Code 2.1.110 で /tui コマンドが導入され、TUI レンダラが
settings.json の "tui" キーで指定できるようになった。/tui 実行時に
CLAUDE_CODE_NO_FLICKER は明示的に unset されるため、env var は廃止
される見込み。

- home/.zshrc から `export CLAUDE_CODE_NO_FLICKER=1` を削除
- home/.claude/settings.json に `"tui": "fullscreen"` を追加
- home/.claude/settings.md に tui キーの解説セクションを追加