### PR TITLE
chore(claude): make /ta and /tad skills tool-agnostic for cloud compatibility

### DIFF
--- a/home/.claude/skills/ta/SKILL.md
+++ b/home/.claude/skills/ta/SKILL.md
@@ -9,28 +9,29 @@ description: >-
 
 ta — thanks, mate. ありがとう！議論して、一緒に作り上げた変更を仕上げて届ける。
 
+ユーザーが `/ta` を実行した時点で、コミット・push・PR 作成の明示依頼とみなす。
+
 変更内容を確認し、以下を順番に実行する:
 
-## 0. ブランチ状態チェック
+## 0. ブランチ判定
 
-現在のブランチが `main` でない場合、そのブランチに紐づく PR の状態を確認する:
+現在のブランチを確認する:
 
-- `gh pr view --json state` を実行
-- **MERGED / CLOSED**: `origin/main` から新規ブランチを作成する（`git checkout -b <branch> origin/main`）
-- **OPEN**: 既存ブランチ・PR を再利用し、追加コミットとして push する（新規 PR は作成しない）
-- **PR が存在しない**: そのブランチをそのまま使い、新規 PR を作成する
+- **`main` 以外のブランチにいる場合**: そのブランチに紐づく PR の状態を確認する
+  - **MERGED / CLOSED**: `origin/main` から新規ブランチを作成する
+  - **OPEN**: 既存ブランチ・PR を再利用し、追加コミットとして push する（新規 PR は作成しない）
+  - **PR が存在しない**: そのブランチをそのまま使い、新規 PR を作成する
+- **`main` にいる場合**: 変更内容に適した新規ブランチを `origin/main` から作成する
 
-## 1. ブランチ作成（必要な場合のみ）
+ブランチ作成時は worktree でも動作するよう `git checkout main` は使わず、`git fetch origin main && git checkout -b <branch> origin/main` を使用する。
 
-ステップ 0 で新規作成が必要と判断された場合、`origin/main` から変更内容に適したブランチを新規作成する。worktree でも動作するよう `git checkout main` は使わず、`git fetch origin main && git checkout -b <branch> origin/main` を使用する。
-
-## 2. コミット・push
+## 1. コミット・push
 
 変更をステージしてコミットし、リモートへ push する。
 
-## 3. PR 作成（必要な場合のみ）
+## 2. PR 作成（必要な場合のみ）
 
-既存の OPEN な PR がない場合、`gh pr create` で PR を作成する。
+既存の OPEN な PR がない場合、PR を作成する。
 
 ## 制約
 

--- a/home/.claude/skills/tad/SKILL.md
+++ b/home/.claude/skills/tad/SKILL.md
@@ -7,4 +7,4 @@ description: >-
 
 # /tad
 
-/ta を実行する。ただし `gh pr create` 実行時に `--draft` フラグを付与してドラフト PR として作成すること。
+/ta を実行する。ただし PR 作成時はドラフト PR として作成すること。


### PR DESCRIPTION
## 概要

`/ta` と `/tad` skill からツール固有の記述（`gh` CLI コマンド）を除去し、ツール非依存（tool-agnostic）な指示に書き換える。Claude が実行環境に応じて適切なツール（ローカルなら `gh` CLI、Claude Code on the web なら GitHub MCP）を自動選択できるようになる。

## 変更内容

### `/ta` (`home/.claude/skills/ta/SKILL.md`)

- `gh pr view --json state` → 「PR の状態を確認する」（ツール名を除去、意図のみ記述）
- `gh pr create` → 「PR を作成する」（同上）
- ステップ 0（ブランチ状態チェック）と 1（ブランチ作成）を「ブランチ判定」に統合
  - `main` 以外にいる → そのブランチの PR 状態を見て判断
  - `main` にいる → 新規ブランチを作成
- 「ユーザーが `/ta` を実行した時点でコミット・push・PR 作成の明示依頼とみなす」を冒頭に追記

### `/tad` (`home/.claude/skills/tad/SKILL.md`)

- `` `gh pr create` 実行時に `--draft` フラグを付与して `` → 「PR 作成時はドラフト PR として作成すること」に抽象化

## 背景

Claude Code on the web では `gh` CLI が使えず、GitHub 操作は MCP ツール（`mcp__github__*`）経由になる。従来の `/ta` は `gh pr view`, `gh pr create` を明示指定していたためクラウドで動作しなかった。skill を「何をするか」の意図だけに抽象化することで、環境差を吸収できる。

## テスト計画

- [ ] ローカル CLI で `/ta` 実行時に `gh` CLI が使われることを確認
- [ ] Claude Code on the web で `/ta` 実行時に MCP ツールが使われることを確認
- [ ] `/tad` でドラフト PR が正しく作成されることを確認
