### PR TITLE
feat(vscode-icons): add brew icon for Brewfile.optional

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -479,6 +479,15 @@
   // vscode-icons
   // ----------------------------------------------------------------
   "vsicons.dontShowNewVersionMessage": true,
+  "vsicons.associations.files": [
+    {
+      "icon": "brew",
+      "extensions": ["Brewfile.optional"],
+      "filename": true,
+      "format": "svg",
+      "extends": "brew"
+    }
+  ],
 
   // ----------------------------------------------------------------
   // vitest


### PR DESCRIPTION
## Summary

- `Brewfile.optional` に vscode-icons のビールアイコンを関連付ける設定を追加
- 既存の `brew` アイコン定義を `extends` で継承し、`Brewfile.optional` をファイル名マッチで追加