### PR TITLE
fix(brewfile): disable mas xcode entry

### DIFF
--- a/Brewfile.optional
+++ b/Brewfile.optional
@@ -68,7 +68,9 @@ brew "qemu"
 brew "mas"
 
 # Apple's integrated development environment for macOS. https://developer.apple.com/xcode/
-mas "Xcode", id: 497799835
+# Disabled: current Xcode is not installed via MAS (no _MASReceipt), so `mas upgrade`
+# fails with "Failed to copy receipt" on every run. Update Xcode manually for now.
+# mas "Xcode", id: 497799835
 
 # Interface for reading and syncing eBooks. https://www.amazon.com/gp/digital/fiona/kcp-landing-page
 mas "Kindle", id: 302584613


### PR DESCRIPTION
## Summary

LaunchAgent `local.brew-update`（毎朝 07:00 に `make homebrew` を実行）が毎日失敗していた問題の暫定対応。`Brewfile.optional` の `mas "Xcode", id: 497799835` をコメントアウトする。

## 原因

- 現在の `/Applications/Xcode.app` は MAS 非経由でインストールされたもの（`root:wheel` 所有、`_MASReceipt/` ディレクトリ無し）
- `mas upgrade` が Apple のレシートを書き込もうとして `Operation not permitted` で失敗
- `brew bundle` 全体が途中で止まり、その先の処理も実行されない状態

## 実績

`/tmp/brew-update.log` より、過去 16 日の実行結果:

| 指標 | 件数 |
|---|---|
| 実行 | 16 |
| 成功 | 5 |
| 失敗 | 11（失敗率 69%） |

該当エラー:
```
Error: Failed to copy receipt for Xcode (26.4.1) from
  '...NSIRD_mas_UI6rkE/497799835-receipt' to
  '/Applications/Xcode.app/Contents/_MASReceipt/receipt':
Error Domain=NSCocoaErrorDomain Code=513
  "You don't have permission to save the file "_MASReceipt" in the folder "Contents"."
```

## 対応

- `mas "Xcode", id: 497799835` をコメントアウト（復活しやすいように行自体は残す）
- Xcode は当面、Apple Developer Portal / `xcodes` CLI 等で手動更新
- Kindle / LINE は `_MASReceipt` が存在し、ログ上も正常に更新されているので **現状維持**

## 参考

- mas-cli/mas#1209 — 空レシートファイルの扱い（6.0.0 で改善）
- mas-cli/mas#1177 — 非標準 umask での `_MASReceipt` 権限問題
- いずれも「_MASReceipt ディレクトリ自体が無い」本ケースはカバーしない（MAS 非経由アプリを `mas upgrade` する構造的制約）

## Test plan

- [ ] ローカルで `make homebrew` を実行し、Xcode 関連のエラーが出ないことを確認
- [ ] 次回の LaunchAgent 実行 (明日 07:00 JST) で通知が発生しないこと
- [ ] 将来 MAS 版 Xcode を入れ直す or `xcodes` CLI に移行する方針を別途検討
