### PR TITLE
chore(claude): require commit messages in English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ make link
 ## Git・GitHub 運用ルール
 
 - **PR タイトルは英語で記述し、CI の semantic pull request チェックに従う。** 小文字で始める英数字・記号のみ、末尾にスペースを付けない。例: `feat(darwin): use launchctl for Remote Login`. 詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
+- **コミットメッセージ（subject と body）は英語で記述する。** PR 本文（description）は日本語でよい。
 
 ## ポータビリティ
 


### PR DESCRIPTION
## 概要

プロジェクト `CLAUDE.md` の「Git・GitHub 運用ルール」に、コミットメッセージの言語ルールを追記する。

## 背景

PR #832 で Claude Code が書いたコミット body が日本語になっていたことがきっかけ。原因を辿ると、project `CLAUDE.md` ではこれまで **PR タイトルの言語しか明記されていなかった**。Claude Code は会話言語（日本語）に引っ張られて body も日本語で書いてしまう挙動があり、これを行動指示レベルで止めるために一文追加する。

なお、`@nozomiishii/commitlint-config` 側にも `body-ascii-only` ルール追加を進めている（[configs#2094](https://github.com/nozomiishii/configs/pull/2094)）。ドキュメント（本 PR）とツール（別 PR）の二段構えで運用を固める。

## 追加行

```markdown
- **コミットメッセージ（subject と body）は英語で記述する。** PR 本文（description）は日本語でよい。
```

## 整合性

| 対象 | 言語 | 出典 |
|---|---|---|
| PR タイトル | English | project CLAUDE.md（既存） |
| コミット subject / body | **English** | project CLAUDE.md（本 PR で追加） |
| PR 本文（description） | 日本語 | global CLAUDE.md（既存） |

## Test plan

- [ ] 次回 Claude Code 経由でコミットを作成する際、subject/body が英語で書かれることを確認
- [ ] `configs#2094` マージ後、`pnpm update @nozomiishii/commitlint-config` で `body-ascii-only` による機械強制が効くことを別途確認
