### PR TITLE
chore(workflows): migrate to nozomiishii/workflows v3

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: GitHub Actions
 
 on:
   workflow_dispatch:
@@ -14,7 +14,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  github-actions:
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
 
 jobs:
-  secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  secret-scan:
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,18 @@ on:
       - 'Brewfile'
       - 'scripts/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   install:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -33,6 +41,8 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run install (PR branch)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -8,6 +8,12 @@ on:
     paths:
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-devcontainer
@@ -17,12 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
-      packages: write
+      contents: read  # required by actions/checkout to fetch repository code
+      packages: write  # required by docker/build-push-action to publish the image to GHCR
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Log in to Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -6,6 +6,12 @@ on:
       - 'README.md'
       - 'README.ja.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -14,16 +20,23 @@ jobs:
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pull-requests: read  # required by gh pr diff to list PR files via the GitHub API
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check README sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
+          gh pr diff "$PR_NUMBER" \
+            --repo "$REPO" \
             --name-only \
           | bash scripts/check-readme-sync.sh
 


### PR DESCRIPTION
## Summary

`nozomiishii/workflows` v3.0.0 への migration。

- `_actionlint.yaml` → `_github-actions.yaml` に rename（v3 で `github-actions.yaml` が actionlint + zizmor を集約）
- `_secretlint.yaml` → `_secret-scan.yaml` に rename（v3 で secret-scan に改名）
- `_pull-request.yaml` の SHA 更新

SHA `4114f39af968607bdcef88b48d29605df89728fd` は v3.0.0 release 前の main HEAD で固定。release 後に renovate が実 tag SHA への bump を提案する。

## Required checks

ブランチ保護の required status checks を更新する必要あり:

- `Lint GitHub Actions workflows / lint` → `github-actions / required`
- `Secretlint / scan` → `secret-scan / required`

## Test plan

- [ ] `github-actions / required` 緑
- [ ] `secret-scan / required` 緑
- [ ] `pull-request / validate` 緑
