### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,18 @@ on:
       - 'Brewfile'
       - 'scripts/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   install:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -33,6 +41,8 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run install (PR branch)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -8,6 +8,12 @@ on:
     paths:
       - '.devcontainer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-devcontainer
@@ -17,12 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
-      packages: write
+      contents: read  # required by actions/checkout to fetch repository code
+      packages: write  # required by docker/build-push-action to publish the image to GHCR
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Log in to Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -6,6 +6,12 @@ on:
       - 'README.md'
       - 'README.ja.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -14,16 +20,23 @@ jobs:
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pull-requests: read  # required by gh pr diff to list PR files via the GitHub API
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check README sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
+          gh pr diff "$PR_NUMBER" \
+            --repo "$REPO" \
             --name-only \
           | bash scripts/check-readme-sync.sh
 


### PR DESCRIPTION
## Summary

Migration PR (#837) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes
- `_github-actions.yaml` / `_pull-request.yaml`: permissions justification コメント
- `ci.yaml` / `devcontainer.yaml` / `readme-sync.yaml`: top-level `permissions: {}` + job 最小 permissions + `concurrency:` block + `persist-credentials: false`
- `readme-sync.yaml`: `${{ }}` を `env:` 経由に refactor（template-injection）

## Test plan
- [ ] `github-actions / required` 緑
- [ ] `secret-scan / secretlint` 緑
- [ ] `pull-request / validate` 緑
