### PR TITLE
feat(vscode-icons): add opentofu icon for .opentofu-version

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -486,6 +486,13 @@
       "filename": true,
       "format": "svg",
       "extends": "brew"
+    },
+    {
+      "icon": "opentofu",
+      "extensions": [".opentofu-version"],
+      "filename": true,
+      "format": "svg",
+      "extends": "opentofu"
     }
   ],
 


### PR DESCRIPTION
## 概要

OpenTofu のバージョンピンファイル `.opentofu-version` に opentofu アイコンを関連付ける VS Code 設定を追加します。

## 背景

`.opentofu-version` は OpenTofu の version manager である [tofuenv](https://github.com/tofuutils/tofuenv) と [tenv](https://github.com/tofuutils/tenv) が読み込むバージョン固定ファイルで、`.python-version` (pyenv) や `.ruby-version` (rbenv) に相当するコミュニティ慣習です。OpenTofu プロジェクトで広く使われていますが、上流の vscode-icons には未対応でした。

## 上流 (vscode-icons) の状況

- OpenTofu 本体アイコンは [vscode-icons/vscode-icons#3646](https://github.com/vscode-icons/vscode-icons/pull/3646) で追加済み（対応拡張子: `tofu`, `tofu.json`, `tofutest.hcl`, `tofutest.json` のみ）
- `.opentofu-version` 関連の issue / PR は存在しなかったため、本変更と並行して Icon Request を起票: [vscode-icons/vscode-icons#4029](https://github.com/vscode-icons/vscode-icons/issues/4029)
- 上流対応までの暫定対応として、このリポの `vsicons.associations.files` に `extends: "opentofu"` で追加

## 変更内容

`home/Library/Application Support/Code/User/settings.json` の `vsicons.associations.files` に以下を追加。

```json
{
  "icon": "opentofu",
  "extensions": [".opentofu-version"],
  "filename": true,
  "format": "svg",
  "extends": "opentofu"
}
```

## 動作確認

VS Code 再起動 / `Reload Icon Pack` 後、`.opentofu-version` ファイルに OpenTofu アイコンが表示されることを確認済み。

## 関連

- 上流 issue: vscode-icons/vscode-icons#4029
- 上流先行 PR: vscode-icons/vscode-icons#3646
- 過去の同種 PR: #831 (`feat(vscode-icons): add brew icon for Brewfile.optional`)
