### PR TITLE
chore(vscode-icons): remove .opentofu-version workaround

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -486,13 +486,6 @@
       "filename": true,
       "format": "svg",
       "extends": "brew"
-    },
-    {
-      "icon": "opentofu",
-      "extensions": [".opentofu-version"],
-      "filename": true,
-      "format": "svg",
-      "extends": "opentofu"
     }
   ],
 


### PR DESCRIPTION
## ⏸ DO NOT MERGE YET

これは upstream のマージ待ち cleanup PR。下記条件が揃ってから ready for review に切り替えてマージする。

## マージ条件（チェックリスト）

- [ ] upstream PR がマージ済み: https://github.com/vscode-icons/vscode-icons/pull/4031
- [ ] vscode-icons 拡張の新バージョンが Marketplace に出ている
  - https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons
- [ ] ローカル VS Code の vscode-icons 拡張が新バージョンに更新済み
- [ ] `.opentofu-version` ファイルを開いて、workaround を消した状態でも opentofu アイコンが出ることを目視確認

最後の目視確認を先に済ませる手順:
```bash
# このブランチに一時切り替えして VS Code を開き直す
git -C ~/dotfiles checkout chore/remove-opentofu-version-workaround
# .opentofu-version をエディタで開いてアイコン確認
# OK なら main に戻して PR を ready にしてマージ
git -C ~/dotfiles checkout main
```

## 背景

upstream マージ待ちの間、ローカル VS Code でも `.opentofu-version` に opentofu アイコンが出るよう、`home/Library/Application Support/Code/User/settings.json` に手動 mapping を追加していた（#852, commit `048616e5`）。

upstream (#4031) がマージ・リリースされれば vscode-icons 拡張本体が `.opentofu-version` を直接サポートするので、この workaround は不要になる → 上流ソースに依存する形に戻す。

## 関連

- upstream Issue: https://github.com/vscode-icons/vscode-icons/issues/4029
- upstream PR: https://github.com/vscode-icons/vscode-icons/pull/4031
- workaround 投入 PR: #852
