### PR TITLE
feat(zsh): add cwr alias for claude worktree resume

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -49,6 +49,7 @@ alias cc="claude --continue"
 alias cr="claude --resume"
 alias ct="claude --teleport"
 alias cw="claude --worktree"
+alias cwr="claude --worktree --resume"
 alias cwt="claude --worktree --teleport"
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
## 概要

`claude --worktree --resume` を一発で叩けるよう `cwr` エイリアスを追加。

## 変更内容

- `home/.zsh/alias/alias.zsh` の Claude セクションに `alias cwr="claude --worktree --resume"` を追加
- `cw` と `cwt` の間（アルファベット順）に挿入

## 背景

既存のエイリアス構成:

| alias | コマンド |
|-------|---------|
| `c` | `claude` |
| `cc` | `claude --continue` |
| `cr` | `claude --resume` |
| `ct` | `claude --teleport` |
| `cw` | `claude --worktree` |
| `cwt` | `claude --worktree --teleport` |

worktree でのセッション再開を頻繁に行うため、`cw` + `--resume` の組み合わせを 1 つの短縮形にした。
