### PR TITLE
fix(claude): use git status counts for diff segment

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Claude Code statusline:
 #   1: dotfiles[seal] git:(branch) +5 !3 ?2
 #   2: Opus 4.7 | 42% | surface:63

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -10,7 +10,6 @@ while IFS= read -r line; do
   fields+=("$line")
 done < <(jq -r '
   .model.display_name // "Claude",
-  .effort.level // "",
   (.context_window.used_percentage // 0 | floor | tostring),
   .cwd,
   .worktree.branch // "",
@@ -18,11 +17,10 @@ done < <(jq -r '
 ' <<<"$input")
 
 model="${fields[0]}"
-effort="${fields[1]}"
-ctx_pct="${fields[2]}"
-cwd="${fields[3]}"
-branch_from_json="${fields[4]}"
-project_dir="${fields[5]}"
+ctx_pct="${fields[1]}"
+cwd="${fields[2]}"
+branch_from_json="${fields[3]}"
+project_dir="${fields[4]}"
 
 root=$(basename "${project_dir:-$cwd}")
 leaf=$(basename "$cwd")
@@ -79,7 +77,6 @@ git_parts+=("${cyan}${loc}${reset}")
 
 env_parts=()
 env_parts+=("${magenta}${model}${reset}")
-[[ -n "$effort" ]] && env_parts+=("${red}${effort}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
 env_parts+=("${white}${underline}${cursor_link}${reset}")

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,18 +1,16 @@
-#!/usr/bin/env bash
-# Claude Code statusline: model | cwd | git:(branch) | +N -N | ctx% | cmux | [editor]
-# starship 風の表記スタイルに合わせた構成
+#!/bin/bash
+# Claude Code statusline:
+#   1: dotfiles[seal] git:(branch) +5 !3 ?2
+#   2: Opus 4.7 | 42% | surface:63
 
 input=$(cat)
 
-# mapfile is bash 4+. /bin/bash on macOS is 3.2 — read in a loop instead.
 fields=()
 while IFS= read -r line; do
   fields+=("$line")
 done < <(jq -r '
   .model.display_name // "Claude",
   (.context_window.used_percentage // 0 | floor | tostring),
-  (.cost.total_lines_added // 0 | tostring),
-  (.cost.total_lines_removed // 0 | tostring),
   .cwd,
   .worktree.branch // "",
   .workspace.project_dir // ""
@@ -20,11 +18,9 @@ done < <(jq -r '
 
 model="${fields[0]}"
 ctx_pct="${fields[1]}"
-added="${fields[2]}"
-removed="${fields[3]}"
-cwd="${fields[4]}"
-branch_from_json="${fields[5]}"
-project_dir="${fields[6]}"
+cwd="${fields[2]}"
+branch_from_json="${fields[3]}"
+project_dir="${fields[4]}"
 
 root=$(basename "${project_dir:-$cwd}")
 leaf=$(basename "$cwd")
@@ -41,17 +37,21 @@ else
 fi
 
 diff_text=""
-[[ "$added" != "0" ]] && diff_text="+${added}"
-if [[ "$removed" != "0" ]]; then
-  [[ -n "$diff_text" ]] && diff_text="${diff_text} "
-  diff_text="${diff_text}-${removed}"
+porcelain=$(git -C "$cwd" status --porcelain=v1 2>/dev/null)
+if [[ -n "$porcelain" ]]; then
+  staged=$(grep -c '^[MADRC]' <<<"$porcelain")
+  modified=$(grep -c '^.[MD]' <<<"$porcelain")
+  untracked=$(grep -c '^??' <<<"$porcelain")
+  diff_parts=()
+  ((staged > 0)) && diff_parts+=("+${staged}")
+  ((modified > 0)) && diff_parts+=("!${modified}")
+  ((untracked > 0)) && diff_parts+=("?${untracked}")
+  diff_text="${diff_parts[*]}"
 fi
 
 surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null)
 
 esc=$'\033'
-st=$'\033\\'
-
 reset="${esc}[0m"
 red="${esc}[1;31m"
 green="${esc}[1;32m"
@@ -59,14 +59,6 @@ yellow="${esc}[1;33m"
 blue="${esc}[1;34m"
 magenta="${esc}[1;35m"
 cyan="${esc}[1;36m"
-gray="${esc}[90m"
-
-cwd_url="$cwd"
-cwd_url="${cwd_url//%/%25}"
-cwd_url="${cwd_url// /%20}"
-cwd_url="${cwd_url//\#/%23}"
-cwd_url="${cwd_url//\?/%3F}"
-cursor_link="${esc}]8;;cursor://file${cwd_url}${st}[editor]${esc}]8;;${st}"
 
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")
@@ -77,7 +69,6 @@ env_parts=()
 env_parts+=("${magenta}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
-env_parts+=("${gray}${cursor_link}${reset}")
 
 join() {
   local sep="$1"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -10,6 +10,7 @@ while IFS= read -r line; do
   fields+=("$line")
 done < <(jq -r '
   .model.display_name // "Claude",
+  .effort.level // "",
   (.context_window.used_percentage // 0 | floor | tostring),
   .cwd,
   .worktree.branch // "",
@@ -17,10 +18,11 @@ done < <(jq -r '
 ' <<<"$input")
 
 model="${fields[0]}"
-ctx_pct="${fields[1]}"
-cwd="${fields[2]}"
-branch_from_json="${fields[3]}"
-project_dir="${fields[4]}"
+effort="${fields[1]}"
+ctx_pct="${fields[2]}"
+cwd="${fields[3]}"
+branch_from_json="${fields[4]}"
+project_dir="${fields[5]}"
 
 root=$(basename "${project_dir:-$cwd}")
 leaf=$(basename "$cwd")
@@ -72,6 +74,7 @@ git_parts+=("${cyan}${loc}${reset}")
 
 env_parts=()
 env_parts+=("${magenta}${model}${reset}")
+[[ -n "$effort" ]] && env_parts+=("${red}${effort}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
 env_parts+=("${white}${underline}${cursor_link}${reset}")

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -60,7 +60,8 @@ yellow="${esc}[1;33m"
 blue="${esc}[1;34m"
 magenta="${esc}[1;35m"
 cyan="${esc}[1;36m"
-gray="${esc}[90m"
+white="${esc}[1;37m"
+underline="${esc}[4m"
 
 cursor_link="${esc}]8;;cursor://file${cwd}${st}[editor]${esc}]8;;${st}"
 
@@ -73,7 +74,7 @@ env_parts=()
 env_parts+=("${magenta}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
-env_parts+=("${gray}${cursor_link}${reset}")
+env_parts+=("${white}${underline}${cursor_link}${reset}")
 
 join() {
   local sep="$1"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -52,6 +52,7 @@ fi
 surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null)
 
 esc=$'\033'
+st=$'\033\\'
 reset="${esc}[0m"
 red="${esc}[1;31m"
 green="${esc}[1;32m"
@@ -59,6 +60,9 @@ yellow="${esc}[1;33m"
 blue="${esc}[1;34m"
 magenta="${esc}[1;35m"
 cyan="${esc}[1;36m"
+gray="${esc}[90m"
+
+cursor_link="${esc}]8;;cursor://file${cwd}${st}[editor]${esc}]8;;${st}"
 
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")
@@ -69,6 +73,7 @@ env_parts=()
 env_parts+=("${magenta}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
+env_parts+=("${gray}${cursor_link}${reset}")
 
 join() {
   local sep="$1"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -65,7 +65,12 @@ cyan="${esc}[1;36m"
 white="${esc}[1;37m"
 underline="${esc}[4m"
 
-cursor_link="${esc}]8;;cursor://file${cwd}${st}[editor]${esc}]8;;${st}"
+cwd_url="$cwd"
+cwd_url="${cwd_url//%/%25}"
+cwd_url="${cwd_url// /%20}"
+cwd_url="${cwd_url//\#/%23}"
+cwd_url="${cwd_url//\?/%3F}"
+cursor_link="${esc}]8;;cursor://file${cwd_url}${st}[editor]${esc}]8;;${st}"
 
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")


### PR DESCRIPTION
## Summary

PR #858（マージ済み）で実装した statusline の diff 表示が常に過大になっていたので修正する。コミットの過程で `[editor]` ハイパーリンクの可否や `effort.level` 表示を試したが、レビューを踏まえて以下の最終形に落ち着いた:

- diff 表示は `git status --porcelain` ベースの starship 風 `+N !N ?N` に置き換え
- `[editor]` は OSC 8 リンクとして残す（Cmd+Click が macOS の発火条件）
- `[editor]` リンクの cwd は `%`/space/`#`/`?` をパーセントエンコード
- `effort.level` セグメントは追加したが取り下げ（Claude Code 本体の thinking 行と重複するため）

## 修正: diff 表示が常に過大になっていた

### 不具合

PR #858 の diff セグメントは `cost.total_lines_added` / `cost.total_lines_removed` を参照していた。

このフィールドは **Claude Code がそのセッション中に編集した累積行数** であり、現在の working tree の git diff とは無関係。実際、変更が一切ない worktree でも `+160 -83` のような大きな数値が表示されていた（過去に Claude が編集した分が累積するため）。

### 修正

`git -C "$cwd" status --porcelain=v1` で実際の差分を取り、starship git_status 風の file count を表示する：

| 表記 | 意味 | 集計対象 |
|---|---|---|
| `+N` | staged | porcelain 1 文字目が `M` `A` `D` `R` `C` の行数 |
| `!N` | modified (unstaged) | porcelain 2 文字目が `M` `D` の行数 |
| `?N` | untracked | porcelain `??` の行数 |

各カウントが 0 のセグメントは省略、すべて 0 なら diff 表示自体非表示。配色は bold yellow を維持（starship `git_status` と同じ）。

`git status --porcelain` の追加呼び出しで起動時間は **+50ms 程度（合計 ~280ms）**、1 秒制約には十分余裕。

## `[editor]` ハイパーリンクについての経緯

実機で `[editor]` を **通常クリック**したところ、Cursor が起動せず「`copied 6 chars to clipboard`」が表示された。Claude Code TUI は bracketed mouse reporting でマウスイベントを TUI 内部で捕捉しているため、ghostty / cmux の OSC 8 ハンドラまでクリックが届かず、Claude Code 側の選択コピー経路（OSC 52 + toast）に流れたと判明した。

中間コミット (`1f6c31d6`) で一度 `[editor]` を削除したが、ghostty の OSC 8 仕様上 **Cmd+Click が macOS のデフォルト発火条件** であり、修飾キーなしの結果だけで「常に動かない」と断じるのは早計だった（ccstatusline 側の実装も素の OSC 8 を吐くだけで、同じ前提で動いている）。後続コミット (`def2b59c`) で復活。Cmd+Click 経路が機能するかを実機で検証してから、最終的な存続を決める方針。

### URL エンコードの復活

途中のコミットで cursor link の cwd を生のまま埋め込む形にしてしまっていた（コードレビューで指摘）。空白・`#`・`?` を含むパスでは OSC 8 URI として不正になるため、`%25` / `%20` / `%23` / `%3F` のパーセントエンコードを復活させた（`fix(claude): url-encode cwd in cursor link`）。

## `effort.level` を取り下げた理由

途中のコミット (`79ff6ca8`) で `model | effort | ctx%` の順に `effort.level`（low/medium/high/xhigh/max）を bold red で表示するようにしたが、

- Claude Code 本体が thinking 中のステータス行に「`thinking with xhigh effort`」を常時出している
- statusline 側に同じ情報を出すのはノイズ

…という判断で、後続の `revert(claude): drop effort level from statusline` で取り下げた。

## 表示の最終形

変更なしの worktree:
```
dotfiles[stateful-singing-seal] git:(worktree-stateful-singing-seal)
Opus 4.7 | 42% | surface:63 | [editor]
```

staged 1, modified 2, untracked 3:
```
dotfiles[stateful-singing-seal] git:(worktree-stateful-singing-seal) +1 !2 ?3
Opus 4.7 | 42% | surface:63 | [editor]
```

## Test plan

- [x] 変更ありの worktree で `home/.claude/statusline.sh` 自身が ` M` 状態のとき `!1` と表示されることを実機確認
- [x] `cat -v` で OSC 8 シーケンスが想定通り出力されていることを確認
- [x] 起動時間 282ms（< 1 秒）
- [x] 空白・`#`・`?` を含むパスで cursor link が `%20`/`%23`/`%3F` にエンコードされることを確認（`/tmp/path with space/#hash?q` のサンプル JSON で検証）
- [ ] staged + modified + untracked が混在するケースの実機確認
- [ ] **`[editor]` を Cmd+Click したときに Cursor が起動するかの実機検証**（通常クリックは選択コピーになることを確認済み）
- [ ] Cmd+Click でも動かない場合は、別途 slash command や CLI 経路への置き換えを検討

Refs #749
