### PR TITLE
fix(claude): show plain cursor:// url instead of osc8 link in statusline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,25 @@ make link
 
 - **PR タイトルは英語で記述し、CI の semantic pull request チェックに従う。** 小文字で始める英数字・記号のみ、末尾にスペースを付けない。例: `feat(darwin): use launchctl for Remote Login`. 詳細は [.github/workflows/_pull-request.yaml](.github/workflows/_pull-request.yaml) を参照。
 - **コミットメッセージ（subject と body）は英語で記述する。** PR 本文（description）は日本語でよい。
+- **`home/.claude/statusline.sh` を変更する PR では、本文に修正前後の statusline 表示例を載せる。** ソース側にコメントで形式を残すと実装と乖離してメンテ漏れが起きるため、PR 本文側に書く。例:
+
+  ````markdown
+  ## Statusline before / after
+
+  Before:
+
+  ```
+  dotfiles[shiny-munching-rose] git:(main) !1
+  Opus 4.7 | 12% | surface:63 | [editor]
+  ```
+
+  After:
+
+  ```
+  dotfiles[shiny-munching-rose] git:(main) !1 cursor://file/Users/nozomiishii/dotfiles/.claude/worktrees/shiny-munching-rose
+  Opus 4.7 | 12% | surface:63
+  ```
+  ````
 
 ## ポータビリティ
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ make link
   After:
 
   ```
-  dotfiles[shiny-munching-rose] git:(main) !1 cursor://file/Users/nozomiishii/dotfiles/.claude/worktrees/shiny-munching-rose
+  cursor://file/Users/nozomiishii/dotfiles/.claude/worktrees/shiny-munching-rose
+  dotfiles[shiny-munching-rose] git:(main) !1
   Opus 4.7 | 12% | surface:63
   ```
   ````

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -68,18 +68,18 @@ cwd_url="${cwd_url//%/%25}"
 cwd_url="${cwd_url// /%20}"
 cwd_url="${cwd_url//\#/%23}"
 cwd_url="${cwd_url//\?/%3F}"
-cursor_link="${esc}]8;;cursor://file${cwd_url}${st}[editor]${esc}]8;;${st}"
+cursor_url="cursor://file${cwd_url}"
 
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")
 [[ -n "$branch" ]] && git_parts+=("${blue}git:(${red}${branch}${reset}${blue})${reset}")
 [[ -n "$diff_text" ]] && git_parts+=("${yellow}${diff_text}${reset}")
+git_parts+=("${white}${underline}${cursor_url}${reset}")
 
 env_parts=()
 env_parts+=("${magenta}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
-env_parts+=("${white}${underline}${cursor_link}${reset}")
 
 join() {
   local sep="$1"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Claude Code statusline:
-#   1: dotfiles[seal] git:(branch) +5 !3 ?2
-#   2: Opus 4.7 | 42% | surface:63
 
 input=$(cat)
 

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -67,11 +67,12 @@ cwd_url="${cwd_url//\#/%23}"
 cwd_url="${cwd_url//\?/%3F}"
 cursor_url="cursor://file${cwd_url}"
 
+cursor_line="${white}${underline}${cursor_url}${reset}"
+
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")
 [[ -n "$branch" ]] && git_parts+=("${blue}git:(${red}${branch}${reset}${blue})${reset}")
 [[ -n "$diff_text" ]] && git_parts+=("${yellow}${diff_text}${reset}")
-git_parts+=("${white}${underline}${cursor_url}${reset}")
 
 env_parts=()
 env_parts+=("${magenta}${model}${reset}")
@@ -90,4 +91,4 @@ join() {
   printf '%s' "$out"
 }
 
-printf '%s\n%s' "$(join ' ' "${git_parts[@]}")" "$(join ' | ' "${env_parts[@]}")"
+printf '%s\n%s\n%s' "$cursor_line" "$(join ' ' "${git_parts[@]}")" "$(join ' | ' "${env_parts[@]}")"


### PR DESCRIPTION
## Summary

statusline の `[editor]` リンクをクリックしてもエディタが開かず、表示テキスト「editor」がクリップボードにコピーされるだけになっていた。原因は OSC 8 ハイパーリンクの非対応:

- ccstatusline の Link Widget と全く同じ OSC 8 形式 (`\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`) を使っていたためコード自体は正しい
- ただし Claude Code の TUI では statusline の OSC 8 がパススルーされない既知バグが残っている ([anthropics/claude-code#26356](https://github.com/anthropics/claude-code/issues/26356))。v2.1.3 で破損 → v2.1.42 で IDE terminal のみ部分修復 → 最新 (2.1.79+) でも未解決
- さらに cmux 上で動作していると、Claude Code の alternate buffer + mouse capture によりクリックが TUI 側で吸われ、表示テキストの選択コピーになってしまう

## Changes

- OSC 8 ハイパーリンクをやめ、生の `cursor://file<path>` URL 文字列をそのまま出力
- ホスト側ターミナル (Ghostty/cmux 等) の URL 自動検出に任せて Cmd+Click で開けるようにする
- URL は長いので独立した最上段に配置し、3 段構成に変更
- ヘッダの形式コメントは実装と乖離しやすいので削除し、CLAUDE.md に「statusline 変更 PR は本文に before/after を載せる」ルールを追記

## Statusline before / after

Before:

```
dotfiles[shiny-munching-rose] git:(main) !1
Opus 4.7 | 12% | surface:63 | [editor]
```

After:

```
cursor://file/Users/nozomiishii/dotfiles/.claude/worktrees/shiny-munching-rose
dotfiles[shiny-munching-rose] git:(main) !1
Opus 4.7 | 12% | surface:63
```

## Test plan

- [ ] Claude Code 再起動後、statusline 最上段に `cursor://file/...` が表示される
- [ ] Cmd+Click (もしくは設定ターミナルのリンクオープン操作) で Cursor が現在の作業ディレクトリで開く
