### PR TITLE
chore(lefthook): only re-stow when paths added or deleted under home/

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -20,6 +20,11 @@ post-merge:
   jobs:
     - name: symlink
       glob: 'home/**'
+      # Only re-stow when a path is added or removed under home/. Edits to
+      # existing files don't need re-linking — the symlink already points at
+      # them. Deletions still trigger make link so stow can clean up the
+      # dangling symlink.
+      files: git diff-tree -r --name-only --no-commit-id --diff-filter=AD ORIG_HEAD HEAD
       run: make link
     - name: homebrew
       glob: '{Brewfile,Brewfile.optional}'


### PR DESCRIPTION
## Summary

post-merge の symlink job は `home/` 配下のファイルが「変更」されるたびに `make link` を実行していたが、既存ファイルの編集では symlink を貼り直す必要はない。`git diff-tree` に `--diff-filter=AD` を追加し、ファイルの新規追加 / 削除のときだけ `make link` が走るようにした。

## Why

`make link` が毎回走ると post-merge が遅くて面倒だったため。

- **A (Added)**: 新規ファイル → 新しい symlink が必要なので実行
- **D (Deleted)**: 削除されたファイル → stow が dangling symlink を掃除できるよう実行
- **M (Modified)**: 既存ファイルの編集 → symlink は既に正しいパスを指しているのでスキップ

`git diff-tree` はデフォルトで rename / copy 検出 OFF なので、ファイル移動は `A + D` として現れて拾える。

## Test plan

- [ ] `home/` 配下のファイルを編集だけしたコミットを merge → symlink job がスキップされること
- [ ] `home/` 配下に新規ファイルを追加したコミットを merge → `make link` が走ること
- [ ] `home/` 配下のファイルを削除したコミットを merge → `make link` が走り、dangling symlink が掃除されること
