### PR TITLE
feat(claude): restore osc8 link and tweak statusline colors

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -52,13 +52,11 @@ esc=$'\033'
 st=$'\033\\'
 reset="${esc}[0m"
 red="${esc}[1;31m"
-green="${esc}[1;32m"
 yellow="${esc}[1;33m"
 blue="${esc}[1;34m"
 magenta="${esc}[1;35m"
 cyan="${esc}[1;36m"
-white="${esc}[1;37m"
-underline="${esc}[4m"
+gray="${esc}[38;5;250m"
 
 cwd_url="$cwd"
 cwd_url="${cwd_url//%/%25}"
@@ -66,8 +64,7 @@ cwd_url="${cwd_url// /%20}"
 cwd_url="${cwd_url//\#/%23}"
 cwd_url="${cwd_url//\?/%3F}"
 cursor_url="cursor://file${cwd_url}"
-
-cursor_line="${white}${underline}${cursor_url}${reset}"
+cursor_link="${esc}]8;;${cursor_url}${st}[editor]${esc}]8;;${st}"
 
 git_parts=()
 git_parts+=("${cyan}${loc}${reset}")
@@ -77,7 +74,8 @@ git_parts+=("${cyan}${loc}${reset}")
 env_parts=()
 env_parts+=("${magenta}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
-[[ -n "$surface_ref" ]] && env_parts+=("${green}${surface_ref}${reset}")
+[[ -n "$surface_ref" ]] && env_parts+=("${blue}${surface_ref}${reset}")
+env_parts+=("${gray}${cursor_link}${reset}")
 
 join() {
   local sep="$1"
@@ -91,4 +89,4 @@ join() {
   printf '%s' "$out"
 }
 
-printf '%s\n%s\n%s' "$cursor_line" "$(join ' ' "${git_parts[@]}")" "$(join ' | ' "${env_parts[@]}")"
+printf '%s\n%s' "$(join ' ' "${git_parts[@]}")" "$(join ' | ' "${env_parts[@]}")"


### PR DESCRIPTION
## Summary

PR #862 では「OSC 8 ハイパーリンクが Claude Code 内で機能しない」と判断して生 URL に変更していた。しかしその後の検証で、cmux/Ghostty 環境では **`Cmd+Shift+Click`** によって OSC 8 リンクがちゃんとリンクとして開けることが判明した（普通の `Cmd+Click` は Claude Code TUI のテキスト選択コピーに吸われるが、`Shift` を加えると terminal のリンクハンドラまで届く）。これにより OSC 8 リンクが実用可能なので、コンパクトな `[editor]` 表記を復活させる。

合わせて、Claude Code 自体のフッター表示 (`(shift+tab to cycle)` 部分) のソースコードを確認したところ、Ink の `dimColor` (`\x1b[2m`) で描画されていることが分かった。これに近い見た目にするため `[editor]` の色を 256-color の明るめグレー (`\x1b[38;5;250m`) に変更し、underline は削除した。

合わせて `surface_ref` の色を緑から青に変更（好み）。未使用になった `green` / `white` / `underline` 変数も削除。

## Statusline before / after

Before:

```
cursor://file/Users/nozomiishii/dotfiles/.claude/worktrees/shiny-munching-rose
dotfiles[shiny-munching-rose] git:(main) !1
Opus 4.7 | 12% | surface:63
```

(URL は white + underline で 1 段目に独立、`surface:63` は緑)

After:

```
dotfiles[shiny-munching-rose] git:(main) !1
Opus 4.7 | 12% | surface:63 | [editor]
```

(`[editor]` は OSC 8 リンク・明るめグレー (`38;5;250`)・underline なし、`surface:63` は青、Cmd+Shift+Click で `cursor://file/<cwd>` を開く)

## Test plan

- [ ] Claude Code 再起動後、`[editor]` が明るめグレーで表示される
- [ ] `Cmd+Shift+Click` で Cursor が現在の作業ディレクトリで開く
- [ ] `surface:N` が青で表示される
