### PR TITLE
feat(claude): use white for the model name in statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -24,7 +24,7 @@ red="${esc}[1;31m"
 green="${esc}[1;32m"
 yellow="${esc}[1;33m"
 blue="${esc}[1;34m"
-magenta="${esc}[1;35m"
+white="${esc}[37m"
 cyan="${esc}[1;36m"
 gray="${esc}[38;5;250m"
 
@@ -71,7 +71,7 @@ else
 fi
 
 env_parts=()
-env_parts+=("${magenta}${model}${reset}")
+env_parts+=("${white}${model}${reset}")
 env_parts+=("${yellow}${ctx_pct}%${reset}")
 [[ -n "$surface_ref" ]] && env_parts+=("${blue}${surface_ref}${reset}")
 env_parts+=("${gray}${cursor_link}${reset}")


### PR DESCRIPTION
## Summary

statusline 2行目の model 名の色を `magenta` (bold) から `white` (normal) に変更。

## なぜ

利用中の Ghostty / GitLab Dark テーマでは ANSI bold-magenta (`\033[1;35m`) がピンク (`#fcacc5`) として描画され、他の主張色とぶつかって model 行が読みにくかった。`white` (normal `\033[37m`) にすると本文として落ち着いて読めるバランスになる。

## 変更点

- `magenta` 変数を削除し、`white="${esc}[37m"` を新規定義
- `env_parts` の model セグメントを `${white}` に差し替え
- 他箇所での `magenta` 参照は無し

## Before / After

Before:

```
dotfiles git:(main) !1
\e[1;35mOpus 4.7 (1M context)\e[0m | 12% | surface:69 | [editor]
```

After:

```
dotfiles git:(main) !1
\e[37mOpus 4.7 (1M context)\e[0m | 12% | surface:69 | [editor]
```
