### PR TITLE
feat(vscode-icons): add swift icon for Mintfile and .swiftformat

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -493,6 +493,20 @@
       "filename": true,
       "format": "svg",
       "extends": "opentofu"
+    },
+    {
+      "icon": "swift",
+      "extensions": ["Mintfile"],
+      "filename": true,
+      "format": "svg",
+      "extends": "swift"
+    },
+    {
+      "icon": "swift",
+      "extensions": [".swiftformat"],
+      "filename": true,
+      "format": "svg",
+      "extends": "swift"
     }
   ],
 

--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -496,14 +496,7 @@
     },
     {
       "icon": "swift",
-      "extensions": ["Mintfile"],
-      "filename": true,
-      "format": "svg",
-      "extends": "swift"
-    },
-    {
-      "icon": "swift",
-      "extensions": [".swiftformat"],
+      "extensions": ["Mintfile", ".swiftformat"],
       "filename": true,
       "format": "svg",
       "extends": "swift"


### PR DESCRIPTION
## 概要

VS Code の material-icon-theme カスタムファイル関連付けに、Swift 系の 2 ファイルを追加。

- `Mintfile` — [Mint](https://github.com/yonaskolb/Mint) のパッケージリスト
- `.swiftformat` — [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) の設定ファイル

どちらも Swift 製ツールの設定なので、`swift` アイコンを当ててエクスプローラ上で識別しやすくする。

## 動作確認

- VS Code を再起動し、`Mintfile` と `.swiftformat` に Swift アイコンが表示されることを確認。
