### PR TITLE
feat(claude): delegate worktree statusline git_status to starship

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -45,21 +45,13 @@ if [[ "$git_dir" == */worktrees/* ]]; then
   wt_top=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
   wt_dir=$(basename "$wt_top")
 
-  diff_text=""
-  porcelain=$(git -C "$cwd" status --porcelain=v1 2>/dev/null)
-  if [[ -n "$porcelain" ]]; then
-    staged=$(grep -c '^[MADRC]' <<<"$porcelain")
-    modified=$(grep -c '^.[MD]' <<<"$porcelain")
-    untracked=$(grep -c '^??' <<<"$porcelain")
-    diff_parts=()
-    ((staged > 0)) && diff_parts+=("+${staged}")
-    ((modified > 0)) && diff_parts+=("!${modified}")
-    ((untracked > 0)) && diff_parts+=("?${untracked}")
-    diff_text="${diff_parts[*]}"
-  fi
+  diff_text=$(cd "$cwd" 2>/dev/null \
+    && STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" \
+       starship module git_status 2>/dev/null \
+    | sed 's/ *$//')
 
   parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
-  [[ -n "$diff_text" ]] && parts+=("${yellow}${diff_text}${reset}")
+  [[ -n "$diff_text" ]] && parts+=("$diff_text")
   IFS=' '
   top_line="${parts[*]}"
   unset IFS


### PR DESCRIPTION
## 概要

worktree 内の statusline で git の差分カウントを自前パースしていたのを、`starship module git_status` 呼び出しに置き換えた。

`home/.config/starship/starship.toml` の `[git_status]` 設定（プレフィックス・色・順序）が worktree 表示にも自動適用されるようになり、設定の二重管理がなくなる。

## 旧実装との挙動差

旧実装（`grep` ベース）には以下の差があった:

- worktree で削除されたファイル（` D file`）が `!N`（modified）に混入
- rename されたファイルが `+N`（staged）に混入
- conflict（`UU` 等）が完全にカウントから漏れる
- `ahead/behind`、`stashed`、`conflicted` は表示されない
- `deleted` / `renamed` が独立した記号で出ない

starship 委譲によりこれらが starship.toml の設定どおりに表示される（`-N` `»N` `*N` `~N` `⇡N⇣N`）。

## Statusline before / after

worktree（`!1` のみのケース。設定が同じなので見た目は変わらない）:

Before:

```
dotfiles worktree:(purring-brewing-hamming) !1
Opus 4.7 | 12% | surface:77 | [editor]
```

After:

```
dotfiles worktree:(purring-brewing-hamming) !1
Opus 4.7 | 12% | surface:77 | [editor]
```

挙動差が出るケース（worktree 削除 + stash + upstream 先行）:

Before:

```
dotfiles worktree:(some-wt) !1
```

After:

```
dotfiles worktree:(some-wt) ⇡2 *1 -1
```

## 動作確認

- worktree 内で `starship module git_status` の出力が末尾スペース除去後に挿入されることを確認
- worktree 外（`else` 分岐）の `starship prompt` 経路に変更がないことを確認
