### PR TITLE
chore(claude): tidy statusline.sh helpers and structure

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+# --- colors ---
+
+esc=$'\033'
+st=$'\033\\'
+reset="${esc}[0m"
+red="${esc}[1;31m"
+green="${esc}[1;32m"
+yellow="${esc}[1;33m"
+blue="${esc}[1;34m"
+white="${esc}[37m"
+cyan="${esc}[1;36m"
+gray="${esc}[38;5;250m"
+
 # --- helpers ---
 
 join() {
@@ -66,19 +79,6 @@ surface_ref=""
 if command -v cmux >/dev/null 2>&1; then
   surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null || true)
 fi
-
-# --- colors ---
-
-esc=$'\033'
-st=$'\033\\'
-reset="${esc}[0m"
-red="${esc}[1;31m"
-green="${esc}[1;32m"
-yellow="${esc}[1;33m"
-blue="${esc}[1;34m"
-white="${esc}[37m"
-cyan="${esc}[1;36m"
-gray="${esc}[38;5;250m"
 
 # --- cursor link ---
 

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
 
+# --- helpers ---
+
+join() {
+  local sep="$1"
+  shift
+  local out="$1"
+  shift
+  local p
+  for p in "$@"; do
+    out="${out}${sep}${p}"
+  done
+  printf '%s' "$out"
+}
+
+urlencode() {
+  local s="$1"
+  s="${s//%/%25}"
+  s="${s// /%20}"
+  s="${s//\#/%23}"
+  s="${s//\?/%3F}"
+  printf '%s' "$s"
+}
+
+starship_at() {
+  STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" starship "$@" 2>/dev/null
+}
+
+# --- input parsing ---
+
 input=$(cat)
 
 fields=()
@@ -15,7 +44,15 @@ model="${fields[0]}"
 ctx_pct="${fields[1]}"
 cwd="${fields[2]}"
 
-surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null)
+cd "$cwd" 2>/dev/null
+
+# cmux が無い環境では fork ごと省略
+surface_ref=""
+if command -v cmux >/dev/null 2>&1; then
+  surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null)
+fi
+
+# --- colors ---
 
 esc=$'\033'
 st=$'\033\\'
@@ -28,56 +65,55 @@ white="${esc}[37m"
 cyan="${esc}[1;36m"
 gray="${esc}[38;5;250m"
 
-cwd_url="$cwd"
-cwd_url="${cwd_url//%/%25}"
-cwd_url="${cwd_url// /%20}"
-cwd_url="${cwd_url//\#/%23}"
-cwd_url="${cwd_url//\?/%3F}"
-cursor_url="cursor://file${cwd_url}"
+# --- cursor link ---
+
+cursor_url="cursor://file$(urlencode "$cwd")"
 cursor_link="${esc}]8;;${cursor_url}${st}[editor]${esc}]8;;${st}"
 
-# 1行目: worktree内ならカスタム表示、それ以外は starship に丸投げ
-git_dir=$(git -C "$cwd" rev-parse --git-dir 2>/dev/null)
-if [[ "$git_dir" == */worktrees/* ]]; then
-  common=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)
-  abs_common=$(cd "$cwd" 2>/dev/null && cd "$common" 2>/dev/null && pwd)
-  repo_name=$(basename "$(dirname "$abs_common")")
-  wt_top=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
-  wt_dir=$(basename "$wt_top")
+# --- renderers ---
 
-  diff_text=$(cd "$cwd" 2>/dev/null \
-    && STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" \
-       starship module git_status 2>/dev/null \
-    | sed 's/ *$//')
+# 1行目: worktree内ならカスタム表示、それ以外は starship prompt に丸投げ。
+# 末尾 extras は両ブランチで append される拡張点。
+render_top_line() {
+  local extras=("$@")
+  local git_dir="" git_common="" wt_top=""
+  {
+    IFS= read -r git_dir
+    IFS= read -r git_common
+    IFS= read -r wt_top
+  } < <(git rev-parse --git-dir --git-common-dir --show-toplevel 2>/dev/null)
 
-  parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
-  [[ -n "$diff_text" ]] && parts+=("$diff_text")
-  IFS=' '
-  top_line="${parts[*]}"
-  unset IFS
-else
-  top_line=$(cd "$cwd" 2>/dev/null \
-    && STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" \
-       starship prompt --terminal-width=120 2>/dev/null \
-    | head -1 | sed 's/%[{}]//g')
-fi
+  local parts=()
+  if [[ "$git_dir" == */worktrees/* ]]; then
+    local abs_common repo_name wt_dir diff_text
+    abs_common=$(cd "$git_common" 2>/dev/null && pwd)
+    repo_name=$(basename "$(dirname "$abs_common")")
+    wt_dir=$(basename "$wt_top")
+    diff_text=$(starship_at module git_status | sed 's/ *$//')
 
-env_parts=()
-env_parts+=("${white}${model}${reset}")
-env_parts+=("${yellow}${ctx_pct}%${reset}")
-[[ -n "$surface_ref" ]] && env_parts+=("${blue}${surface_ref}${reset}")
-env_parts+=("${gray}${cursor_link}${reset}")
+    parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
+    [[ -n "$diff_text" ]] && parts+=("$diff_text")
+  else
+    # starship prompt の先頭行のみ採用し、zsh のプロンプトエスケープ %{ %} を除去
+    local prompt
+    prompt=$(starship_at prompt --terminal-width=120 | head -1 | sed 's/%[{}]//g')
+    parts=("$prompt")
+  fi
 
-join() {
-  local sep="$1"
-  shift
-  local out="$1"
-  shift
-  local p
-  for p in "$@"; do
-    out="${out}${sep}${p}"
-  done
-  printf '%s' "$out"
+  parts+=("${extras[@]}")
+  join ' ' "${parts[@]}"
 }
 
-printf '%s\n%s' "${top_line}" "$(join ' | ' "${env_parts[@]}")"
+render_env_line() {
+  local parts=()
+  parts+=("${white}${model}${reset}")
+  parts+=("${yellow}${ctx_pct}%${reset}")
+  [[ -n "$surface_ref" ]] && parts+=("${blue}${surface_ref}${reset}")
+  parts+=("${gray}${cursor_link}${reset}")
+  join ' | ' "${parts[@]}"
+}
+
+# --- output ---
+
+top_extras=()
+printf '%s\n%s' "$(render_top_line "${top_extras[@]}")" "$(render_env_line)"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
+set -uo pipefail
 
 # --- helpers ---
 
 join() {
   local sep="$1"
   shift
+  (($# == 0)) && return
   local out="$1"
   shift
   local p
@@ -14,17 +16,32 @@ join() {
   printf '%s' "$out"
 }
 
+# RFC 3986 unreserved + / 以外を percent-encode する。
+# LC_ALL=C で UTF-8 マルチバイト文字を byte 単位で正しくエンコード。
 urlencode() {
   local s="$1"
-  s="${s//%/%25}"
-  s="${s// /%20}"
-  s="${s//\#/%23}"
-  s="${s//\?/%3F}"
-  printf '%s' "$s"
+  local out="" i char
+  local LC_ALL=C
+  for ((i = 0; i < ${#s}; i++)); do
+    char="${s:$i:1}"
+    case "$char" in
+      [a-zA-Z0-9._~/-]) out+="$char" ;;
+      *)
+        printf -v char '%%%02X' "'$char"
+        out+="$char"
+        ;;
+    esac
+  done
+  printf '%s' "$out"
 }
 
+# starship は CWD 依存なので subshell で cd してから呼ぶ。
+# subshell 終了で親プロセスの PWD には漏れない。
 starship_at() {
-  STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" starship "$@" 2>/dev/null
+  (
+    cd "$cwd" 2>/dev/null || exit 0
+    STARSHIP_CONFIG="$HOME/.config/starship/starship.toml" starship "$@" 2>/dev/null
+  )
 }
 
 # --- input parsing ---
@@ -37,19 +54,17 @@ while IFS= read -r line; do
 done < <(jq -r '
   .model.display_name // "Claude",
   (.context_window.used_percentage // 0 | floor | tostring),
-  .cwd
+  .cwd // ""
 ' <<<"$input")
 
-model="${fields[0]}"
-ctx_pct="${fields[1]}"
-cwd="${fields[2]}"
-
-cd "$cwd" 2>/dev/null
+model="${fields[0]:-Claude}"
+ctx_pct="${fields[1]:-0}"
+cwd="${fields[2]:-$HOME}"
 
 # cmux が無い環境では fork ごと省略
 surface_ref=""
 if command -v cmux >/dev/null 2>&1; then
-  surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null)
+  surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null || true)
 fi
 
 # --- colors ---
@@ -73,20 +88,18 @@ cursor_link="${esc}]8;;${cursor_url}${st}[editor]${esc}]8;;${st}"
 # --- renderers ---
 
 # 1行目: worktree内ならカスタム表示、それ以外は starship prompt に丸投げ。
-# 末尾 extras は両ブランチで append される拡張点。
 render_top_line() {
-  local extras=("$@")
   local git_dir="" git_common="" wt_top=""
   {
     IFS= read -r git_dir
     IFS= read -r git_common
     IFS= read -r wt_top
-  } < <(git rev-parse --git-dir --git-common-dir --show-toplevel 2>/dev/null)
+  } < <(git -C "$cwd" rev-parse --git-dir --git-common-dir --show-toplevel 2>/dev/null || true)
 
   local parts=()
   if [[ "$git_dir" == */worktrees/* ]]; then
     local abs_common repo_name wt_dir diff_text
-    abs_common=$(cd "$git_common" 2>/dev/null && pwd)
+    abs_common=$(cd "$cwd" 2>/dev/null && cd "$git_common" 2>/dev/null && pwd)
     repo_name=$(basename "$(dirname "$abs_common")")
     wt_dir=$(basename "$wt_top")
     diff_text=$(starship_at module git_status | sed 's/ *$//')
@@ -100,7 +113,6 @@ render_top_line() {
     parts=("$prompt")
   fi
 
-  parts+=("${extras[@]}")
   join ' ' "${parts[@]}"
 }
 
@@ -115,5 +127,10 @@ render_env_line() {
 
 # --- output ---
 
-top_extras=()
-printf '%s\n%s' "$(render_top_line "${top_extras[@]}")" "$(render_env_line)"
+# cwd が消えた場合（git worktree remove 等）は警告のみ表示して env_line は維持
+if [[ ! -d "$cwd" ]]; then
+  printf '%s(stale cwd: %s)%s\n%s' "$red" "$cwd" "$reset" "$(render_env_line)"
+  exit 0
+fi
+
+printf '%s\n%s' "$(render_top_line)" "$(render_env_line)"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -107,7 +107,11 @@ render_top_line() {
     parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
     [[ -n "$diff_text" ]] && parts+=("$diff_text")
   else
-    # starship prompt の先頭行のみ採用し、zsh のプロンプトエスケープ %{ %} を除去
+    # starship prompt は 2 行構成 ($directory ... $line_break $character) なので
+    # 1 行目 (cwd 行) のみを採用。2 行目の `→` は statusline には不要。
+    # 親シェル (zsh) から STARSHIP_SHELL が継承されると starship が zsh モードで
+    # %{ ... %} (zero-width マーカー) を埋め込むが、Claude statusline では
+    # 解釈されずリテラル表示されてしまうため sed で除去する。
     local prompt
     prompt=$(starship_at prompt --terminal-width=120 | head -1 | sed 's/%[{}]//g')
     parts=("$prompt")

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -14,6 +14,29 @@ white="${esc}[37m"
 cyan="${esc}[1;36m"
 gray="${esc}[38;5;250m"
 
+# --- input parsing ---
+
+input=$(cat)
+
+fields=()
+while IFS= read -r line; do
+  fields+=("$line")
+done < <(jq -r '
+  .model.display_name // "Claude",
+  (.context_window.used_percentage // 0 | floor | tostring),
+  .cwd // ""
+' <<<"$input")
+
+model="${fields[0]:-Claude}"
+ctx_pct="${fields[1]:-0}"
+cwd="${fields[2]:-$HOME}"
+
+# cmux が無い環境では fork ごと省略
+surface_ref=""
+if command -v cmux >/dev/null 2>&1; then
+  surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null || true)
+fi
+
 # --- helpers ---
 
 join() {
@@ -57,33 +80,11 @@ starship_at() {
   )
 }
 
-# --- input parsing ---
-
-input=$(cat)
-
-fields=()
-while IFS= read -r line; do
-  fields+=("$line")
-done < <(jq -r '
-  .model.display_name // "Claude",
-  (.context_window.used_percentage // 0 | floor | tostring),
-  .cwd // ""
-' <<<"$input")
-
-model="${fields[0]:-Claude}"
-ctx_pct="${fields[1]:-0}"
-cwd="${fields[2]:-$HOME}"
-
-# cmux が無い環境では fork ごと省略
-surface_ref=""
-if command -v cmux >/dev/null 2>&1; then
-  surface_ref=$(cmux identify 2>/dev/null | jq -r '.caller.surface_ref // empty' 2>/dev/null || true)
-fi
-
-# --- cursor link ---
-
-cursor_url="cursor://file$(urlencode "$cwd")"
-cursor_link="${esc}]8;;${cursor_url}${st}[editor]${esc}]8;;${st}"
+# OSC 8 hyperlink で cwd を Cursor で開ける `[editor]` リンクを返す。
+build_cursor_link() {
+  local url="cursor://file$(urlencode "$cwd")"
+  printf '%s]8;;%s%s[editor]%s]8;;%s' "$esc" "$url" "$st" "$esc" "$st"
+}
 
 # --- renderers ---
 
@@ -125,7 +126,7 @@ render_env_line() {
   parts+=("${white}${model}${reset}")
   parts+=("${yellow}${ctx_pct}%${reset}")
   [[ -n "$surface_ref" ]] && parts+=("${blue}${surface_ref}${reset}")
-  parts+=("${gray}${cursor_link}${reset}")
+  parts+=("${gray}$(build_cursor_link)${reset}")
   join ' | ' "${parts[@]}"
 }
 


### PR DESCRIPTION
## Summary

- `home/.claude/statusline.sh` を多角的にリファクタリング。表示は変更なし、内部構造のみ整理
- helper 関数を切り出し、git fork を削減し、関数ベースの render 構造に置き換え
- `cwd` 不在ガード / `set -uo pipefail` / urlencode の RFC 3986 化など堅牢化を併せて実施

## 変更点

### リファクタ

- **helper 関数化**: `join` / `urlencode` / `starship_at` をスクリプト先頭に集約
- **git fork 削減**: worktree判定内の `rev-parse` 3回を1回に (`--git-dir --git-common-dir --show-toplevel` を一括取得)
- **inline join を関数に統一**: `IFS=' '` / `unset IFS` のパターンを撤廃し既存 `join` を再利用
- **render 関数化**: 1行目/2行目を `render_top_line` / `render_env_line` 関数に分離
- **`cmux` 不在時の fork 省略**: `command -v cmux` で skip
- **意図コメント追加**: `head -1 | sed 's/%[{}]//g'` の役割 (zsh プロンプトエスケープ除去) を1行で説明

### 堅牢化

- **`cwd` 不在ガード**: `git worktree remove` 等で cwd が消えた場合、赤で `(stale cwd: ...)` 警告を表示し、env_line（model / ctx% / surface_ref / cursor link）は維持
- **`set -uo pipefail`**: jq 出力で `// "Claude"`, `// 0`, `// ""` の null-safe デフォルト + bash 側で `:-$HOME` fallback。空入力でも壊れない
- **urlencode 全文字対応**: RFC 3986 unreserved + `/` 以外を全て percent-encode。`LC_ALL=C` で UTF-8 マルチバイトを byte 単位処理（`&`, `[`, `]`, `+`, スペース, 日本語パスを安全にエンコード）
- **`git -C` 維持**: `cd "$cwd"` 案を撤回し `git -C "$cwd"` を継続。starship のみ subshell `(cd "$cwd" && starship ...)` で隔離

## Statusline before / after

リファクタリングのため Before / After は同一:

Worktree内:

```
dotfiles worktree:(jiggly-discovering-garden) !1
Opus 4.7 | 12% | surface:77 | [editor]
```

非Worktree:

```
~
Opus 4.7 | 12% | surface:77 | [editor]
```

cwd 不在時 (新規):

```
(stale cwd: /tmp/removed-worktree)
Opus 4.7 | 12% | surface:77 | [editor]
```

## Test plan

- [x] worktree 内で起動 → repo + worktree:(dir) + git_status (`!1`) が表示される
- [x] 非worktree (`$HOME`) で起動 → starship prompt の1行目が表示される
- [x] 2行目 (model / ctx% / surface_ref / cursor link) が従来通り表示される
- [x] cwd が存在しないディレクトリの場合 → 1行目に赤で `(stale cwd: ...)` 警告
- [x] cwd フィールド欠落 / null / 空 stdin でクラッシュしない (`set -uo pipefail` 下)
- [x] urlencode: `&`, `[`, `]`, スペース, 日本語パスを RFC 3986 準拠で percent-encode
