### PR TITLE
chore(claude): tidy statusline.sh declarations and render_top_line

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -82,7 +82,8 @@ starship_at() {
 
 # OSC 8 hyperlink で cwd を Cursor で開ける `[editor]` リンクを返す。
 build_cursor_link() {
-  local url="cursor://file$(urlencode "$cwd")"
+  local url
+  url="cursor://file$(urlencode "$cwd")"
   printf '%s]8;;%s%s[editor]%s]8;;%s' "$esc" "$url" "$st" "$esc" "$st"
 }
 
@@ -97,7 +98,6 @@ render_top_line() {
     IFS= read -r wt_top
   } < <(git -C "$cwd" rev-parse --git-dir --git-common-dir --show-toplevel 2>/dev/null || true)
 
-  local parts=()
   if [[ "$git_dir" == */worktrees/* ]]; then
     local abs_common repo_name wt_dir diff_text
     abs_common=$(cd "$cwd" 2>/dev/null && cd "$git_common" 2>/dev/null && pwd)
@@ -105,20 +105,18 @@ render_top_line() {
     wt_dir=$(basename "$wt_top")
     diff_text=$(starship_at module git_status | sed 's/ *$//')
 
-    parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
+    local parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
     [[ -n "$diff_text" ]] && parts+=("$diff_text")
-  else
-    # starship prompt は 2 行構成 ($directory ... $line_break $character) なので
-    # 1 行目 (cwd 行) のみを採用。2 行目の `→` は statusline には不要。
-    # 親シェル (zsh) から STARSHIP_SHELL が継承されると starship が zsh モードで
-    # %{ ... %} (zero-width マーカー) を埋め込むが、Claude statusline では
-    # 解釈されずリテラル表示されてしまうため sed で除去する。
-    local prompt
-    prompt=$(starship_at prompt --terminal-width=120 | head -1 | sed 's/%[{}]//g')
-    parts=("$prompt")
+    join ' ' "${parts[@]}"
+    return
   fi
 
-  join ' ' "${parts[@]}"
+  # starship prompt は 2 行構成 ($directory ... $line_break $character) なので
+  # 1 行目 (cwd 行) のみを採用。2 行目の `→` は statusline には不要。
+  # 親シェル (zsh) から STARSHIP_SHELL が継承されると starship が zsh モードで
+  # %{ ... %} (zero-width マーカー) を埋め込むが、Claude statusline では
+  # 解釈されずリテラル表示されてしまうため sed で除去する。
+  starship_at prompt --terminal-width=120 | head -1 | sed 's/%[{}]//g'
 }
 
 render_env_line() {


### PR DESCRIPTION
## 概要

`home/.claude/statusline.sh` の小さな後始末。挙動には変化なし。

- `build_cursor_link()`: `local url=$(urlencode ...)` を `local url; url=$(...)` に分割。`local` は exit status が常に 0 になるため `urlencode` の失敗が masked される（shellcheck SC2155）問題を解消。
- `render_top_line()`: worktree 分岐を早期 return にし、非 worktree 分岐は `parts=()` / `join` を経由せず `starship_at prompt` の出力を直接渡すように整理。コメントブロックも非 worktree 分岐の直前に移動。

## 出力差分

`render_top_line` の最終出力は変わらない:

- 旧 (非 worktree): `prompt=$(starship_at ... | head -1 | sed ...)` で trailing newline を剥がし、`join ' ' "${parts[@]}"` 経由で `printf '%s'` 出力
- 新 (非 worktree): `starship_at ... | head -1 | sed ...` を直接出力（pipeline の trailing newline は呼び出し側 `$(render_top_line)` で剥がれる）

worktree 分岐は `parts=()` 構築 → `join ' '` の流れのまま据え置き。

## Statusline before / after

実出力に差分なし。

Worktree 内:

```
dotfiles worktree:(shiny-munching-rose) !1
Opus 4.7 | 12% | surface:63 | [editor]
```

Worktree 外:

```
~/dotfiles on  main !1
Opus 4.7 | 12% | surface:63 | [editor]
```

## Test plan

- [x] `shellcheck home/.claude/statusline.sh` で SC2155 が消えていること（`build_cursor_link` の修正で対象は無くなる）
- [x] worktree 内 / 外それぞれで statusline の出力が変化しないこと
