### PR TITLE
chore(readme): drop unused app prefs and fix mixed-language English README

### DIFF
--- a/Brewfile.optional
+++ b/Brewfile.optional
@@ -12,12 +12,6 @@ cask "notion"
 # Video communication and virtual meeting platform https://www.zoom.us/
 cask "zoom"
 
-# Color picking application. https://colorsnapper.com
-cask "colorsnapper"
-
-# Automated organization https://www.noodlesoft.com/
-cask "hazel"
-
 # Wallet desktop application to maintain multiple cryptocurrencies https://www.ledgerwallet.com/live
 cask "ledger-wallet"
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -191,10 +191,6 @@ sudo reboot
 
 ## アプリの設定
 
-### ⛓ Karabiner-Elements
-
-- ログインしてください
-
 ### 🔑 1Password
 
 - Preferences > Security > Unlock using >  
@@ -288,34 +284,6 @@ Finder Sidebar
 ```shell
 make repo
 ```
-
-### 🧹 Hazel
-
-- License... >  
-  ライセンスを有効化してください
-- Folder > Rule Sync Settings... > Use existing sync file... >  
-  "~/dotfiles/apps/Hazel" を選択
-- Preferences... > General >  
-  「Show Hazel in the menu bar」のチェックを外してください
-- Preferences... > Trash >  
-  「Delete files sitting in the Trash for more than 1 Day」にチェック
-
-### 🎨 ColorSnapper2
-
-- ライセンスを有効化してください
-- General
-  - Hotkeys:  
-    Pick Color: ⌃ + ⌥ + C
-  - Clipboard Format >
-    「Choose from Colors & Formats after picking」にチェック
-- Appearance
-  - Magnification >
-    15x
-- Code Style
-  - Hex >
-    「Uppercase」にチェック
-  - CSS Hex >
-    「Uppercase」にチェック
 
 ### 🐘 TablePlus
 
@@ -554,13 +522,6 @@ for x in {1..10}; do time zsh -i -c exit; done
 
 - 🐘 TablePlus  
   TablePlus > ライセンスを登録（解除）
-
-- 🎨 ColorSnapper2  
-  About ColorSnapper... >  
-  ライセンスを無効化してください
-
-- 🧹 Hazel  
-  License... > Remove
 
 5: すべてのコンテンツを消去
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ curl -L https://nozomiishii.dev/dotfiles/install | bash
 curl -L https://nozomiishii.dev/dotfiles/install | bash -s -- --full
 ``` -->
 
-<!-- これにするのが目標
-
-```shell
-curl -L dot.nozomiishii.dev | sh
-``` -->
-
 </details>
 
 ## Development
@@ -191,10 +185,6 @@ Then follow the [After installation](#after-installation) steps above.
 
 ## App preferences
 
-### ⛓ Karabiner-Elements
-
-- Login
-
 ### 🔑 1Password
 
 - Preferences > Security > Unlock using >  
@@ -212,7 +202,7 @@ Then follow the [After installation](#after-installation) steps above.
 - Log in 1PasswordX
 - (Optional)
 
-  - [Gmail notification](https://support.google.com/mail/answer/1075549?hl=ja&co=GENIE.Platform%3DDesktop)
+  - [Gmail notification](https://support.google.com/mail/answer/1075549?hl=en&co=GENIE.Platform%3DDesktop)
   - [Show working hours on your calendar](https://support.google.com/a/users/answer/9308669)
   - [Send email to Slack](https://slack.com/help/articles/206819278-Send-emails-to-Slack#:~:text=address%20to%20confirm.-,Use%20an%20email%20add%2Don,-Gmail)
 
@@ -236,9 +226,9 @@ Then follow the [After installation](#after-installation) steps above.
     - [Screenshot YouTube](https://chromewebstore.google.com/detail/gjoijpfmdhbjkkgnmahganhoinjjpohk)
     - [Requestly](https://chromewebstore.google.com/detail/mdnleldcmiljblolnjhpnblkcekpdkpa)
     - [Linkumori (URLs Cleaner) ](https://chromewebstore.google.com/detail/jchobbjgibcahbheicfocecmhocglkco)
-      - URL のクエリパラメータを自動削除
+      - Automatically removes tracking query parameters from URLs
     - [Amazon URL Shortener](https://chromewebstore.google.com/detail/bonkcfmjkpdnieejahndognlbogaikdg)
-      - amazon の URL 短くしてくれる
+      - Shortens Amazon product URLs
     - [Speechify Text to Speech Voice Reader](https://chromewebstore.google.com/detail/ljflmlehinmoeknoonhibbjpldiijjmm)
       - Shortcut
         - Activate the extension: `⌃Q`
@@ -288,34 +278,6 @@ Finder Sidebar
 ```shell
 make repo
 ```
-
-### 🧹 Hazel
-
-- License... >  
-  Activate the License
-- Folder > Rule Sync Settings... > Use existing sync file... >  
-  Select "~/dotfiles/apps/Hazel"
-- Preferences... > General >  
-  Uncheck "Show Hazel in the menu bar"
-- Preferences... > Trash >  
-  Check "Delete files sitting in the Trash for more than 1 Day"
-
-### 🎨 ColorSnapper2
-
-- Activate the license
-- General
-  - Hotkeys:  
-    Pick Color: ⌃ + ⌥ + C
-  - Clipboard Format >
-    Check "Choose from Colors & Formats after picking"
-- Appearance
-  - Magnification >
-    15x
-- Code Style
-  - Hex >
-    check "Uppercase"
-  - CSS Hex >
-    check "Uppercase"
 
 ### 🐘 TablePlus
 
@@ -557,13 +519,6 @@ for x in {1..10}; do time zsh -i -c exit; done
 - **🐘 TablePlus**  
   TablePlus > Register license
 
-- **🎨 ColorSnapper2**  
-  About ColorSnapper... >  
-  Deactivate license
-
-- **🧹 Hazel**  
-  License... > Remove
-
 5: Erase All Content
 
 - Erase All Content - [Japanese](https://support.apple.com/ja-jp/HT201065) | [English](https://support.apple.com/en-gb/HT201065)
@@ -577,7 +532,7 @@ for x in {1..10}; do time zsh -i -c exit; done
 ### Tutorials
 
 - [Dotfiles from Start to Finish-ish](https://www.udemy.com/course/dotfiles-from-start-to-finish-ish)
-- [dotfiles + GitHub を使って開発環境をコマンド１発で構築する方法](https://www.youtube.com/watch?v=QZr33TQnIRk&t=9s)
+- [How to set up a dev environment with one command using dotfiles + GitHub (Japanese)](https://www.youtube.com/watch?v=QZr33TQnIRk&t=9s)
 
 ### Dotfiles
 


### PR DESCRIPTION
## 概要

- 使わなくなった Karabiner-Elements / Hazel / ColorSnapper2 の手順を `README.md` と `README.ja.md` の App preferences・Reinstall macOS のライセンス解除セクションから削除。
- 同じく不要になった `colorsnapper` / `hazel` の cask を `Brewfile.optional` から削除。
- `README.md` の英語版に混ざっていた日本語を整理:
  - Linkumori と Amazon URL Shortener の Chrome 拡張説明を英訳。
  - Gmail 通知ヘルプリンクの `hl=ja` を `hl=en` に。
  - 日本語動画のリンクには `(Japanese)` 注記を付与。
  - 古い下書きの HTML コメント (`これにするのが目標`) を削除。

## テスト

- [ ] `pnpm run lint` でドキュメントの lint が通ること
- [ ] `pnpm run prettier` でフォーマットエラーが出ないこと
