### PR TITLE
chore(claude): run pnpm install on session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm install"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Claude Code の `SessionStart` hook で `pnpm install` を毎セッション開始時に実行する設定を `.claude/settings.json` に追加
- worktree / main リポジトリどちらでも、セッション開始時に依存関係が自動で同期される

## Background

worktree や main リポジトリでセッションを開くたびに手動で `pnpm install` を叩いていたのを自動化したい。`SessionStart` hook で発火させるのが一番シンプル。

worktree のときだけ走らせる仕組み（`git rev-parse --git-dir != --git-common-dir` で判定）も検討したが、main リポジトリ側でも常に依存を最新化したいので、worktree 判定なしで一律 `pnpm install` のみを実行する方針にした。

## Test plan

- [x] worktree でセッション再開し、SessionStart hook 経由で `pnpm install` が走ることを確認済み
- [ ] main リポジトリ側のセッション開始時にも同じ hook が動くことを merge 後に確認
