### PR TITLE
feat(claude): show git branch in worktree statusline when it differs from auto pattern

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -99,13 +99,19 @@ render_top_line() {
   } < <(git -C "$cwd" rev-parse --git-dir --git-common-dir --show-toplevel 2>/dev/null || true)
 
   if [[ "$git_dir" == */worktrees/* ]]; then
-    local abs_common repo_name wt_dir diff_text
+    local abs_common repo_name wt_dir diff_text branch
     abs_common=$(cd "$cwd" 2>/dev/null && cd "$git_common" 2>/dev/null && pwd)
     repo_name=$(basename "$(dirname "$abs_common")")
     wt_dir=$(basename "$wt_top")
     diff_text=$(starship_at module git_status | sed 's/ *$//')
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
 
     local parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
+    # claude -w 自動生成は branch = worktree-{wt_dir} で情報重複するので省略。
+    # 手動で別ブランチを切った worktree のときだけ git:() を追加。
+    if [[ -n "$branch" && "$branch" != "worktree-${wt_dir}" ]]; then
+      parts+=("${blue}git:(${red}${branch}${reset}${blue})${reset}")
+    fi
     [[ -n "$diff_text" ]] && parts+=("$diff_text")
     join ' ' "${parts[@]}"
     return


### PR DESCRIPTION
## Summary

- worktree モードの statusline で、worktree のブランチ名が `worktree-{wt_dir}` の自動生成パターンと一致しない場合のみ `git:(...)` を追加表示するようにした。
- `claude -w` で自動生成した worktree（branch = `worktree-{wt_dir}`）は情報重複なので非表示のまま。
- `git worktree add -b feat/foo ...` のように手動で別ブランチを切った worktree でだけブランチ名が出るので、シグナルだけ拾って行幅を圧迫しない。

## Statusline before / after

`claude -w` 自動生成 worktree（branch 一致）— 変化なし:

Before:

```
dotfiles worktree:(purring-meandering-ember) !1
Opus 4.7 | 12% | surface:91 | [editor]
```

After:

```
dotfiles worktree:(purring-meandering-ember) !1
Opus 4.7 | 12% | surface:91 | [editor]
```

手動でブランチを切った worktree（branch 不一致）— `git:(...)` が出るようになる:

Before:

```
dotfiles worktree:(cleanup-opentofu)
Opus 4.7 | 12% | surface:91 | [editor]
```

After:

```
dotfiles worktree:(cleanup-opentofu) git:(chore/remove-opentofu-version-workaround)
Opus 4.7 | 12% | surface:91 | [editor]
```

## Test plan

- [x] 自動生成 worktree（`worktree-{wt_dir}`）で `git:()` が省略されることを確認
- [x] 手動 worktree（branch 不一致）で `git:()` が表示されることを確認
- [ ] worktree 外の通常リポジトリで挙動が変わらないこと（既存の starship prompt 経路）を実環境で確認
