### PR TITLE
chore(claude): allow deleting gitignored files without confirmation

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -16,7 +16,7 @@
 - Edit / Write を呼ぶ前に、対象ファイルを必ず Read で読んでおくこと。Read していないファイルへの Edit / Write は「File must be read first」エラーで失敗し、作業が中断する。
 - 既に編集済みのファイルでも、長い作業で context が圧縮された後に再編集する場合や、sub-agent から親が作ったファイルを編集する場合は、改めて Read してから Edit を呼ぶこと。
 - もし「File must be read first」エラーが出たら、すぐに対象ファイルを Read してから Edit / Write を再試行すること。エラーをそのまま受け流して別の方向に進まない。
-- **削除許可の例外**: `.gitignore` で除外されているファイルや git 追跡外のローカルファイル（例: `.claude/settings.local.json`、`.DS_Store`、ローカル lock ファイル、ビルド成果物など）は、ユーザーの確認なしに削除・編集してよい。`.claude/settings.local.json` のように sandbox の `denyWithinAllow` で保護されているものは `dangerouslyDisableSandbox: true` で実行する（理由は `description` に明記）。git 追跡対象のファイルはこれまで通り、削除や大規模変更の前にユーザー確認を取ること。
+- **削除許可の例外**: `.gitignore` で除外されているファイルや git 追跡外のローカルファイル（例: `.claude/settings.local.json`、`.DS_Store`、ローカル lock ファイル、ビルド成果物など）は、ユーザーの確認なしに**削除**してよい。`.claude/settings.local.json` のように sandbox の `denyWithinAllow` で保護されているものは `dangerouslyDisableSandbox: true` で実行する（理由は `description` に明記）。**編集**は git 追跡対象と同様にユーザー確認を取ること。編集は削除よりステルス性が高く、git 履歴がないため復元できないため。
 
 ## Git
 

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -16,6 +16,7 @@
 - Edit / Write を呼ぶ前に、対象ファイルを必ず Read で読んでおくこと。Read していないファイルへの Edit / Write は「File must be read first」エラーで失敗し、作業が中断する。
 - 既に編集済みのファイルでも、長い作業で context が圧縮された後に再編集する場合や、sub-agent から親が作ったファイルを編集する場合は、改めて Read してから Edit を呼ぶこと。
 - もし「File must be read first」エラーが出たら、すぐに対象ファイルを Read してから Edit / Write を再試行すること。エラーをそのまま受け流して別の方向に進まない。
+- **削除許可の例外**: `.gitignore` で除外されているファイルや git 追跡外のローカルファイル（例: `.claude/settings.local.json`、`.DS_Store`、ローカル lock ファイル、ビルド成果物など）は、ユーザーの確認なしに削除・編集してよい。`.claude/settings.local.json` のように sandbox の `denyWithinAllow` で保護されているものは `dangerouslyDisableSandbox: true` で実行する（理由は `description` に明記）。git 追跡対象のファイルはこれまで通り、削除や大規模変更の前にユーザー確認を取ること。
 
 ## Git
 


### PR DESCRIPTION
## 概要

`~/.claude/CLAUDE.md`（このリポジトリでは `home/.claude/CLAUDE.md`）の「## ファイル編集」セクションに、`.gitignore` で除外されているローカルファイルの**削除許可**ルールを追加する。

## 背景

`.claude/settings.local.json` のような git 追跡外のローカル作業ファイルを削除するたびにユーザーの確認を取るのは冗長。一方で sandbox の `denyWithinAllow` で保護されているケース（例: `.claude/settings.local.json`）があり、そのままでは削除できない。

今後はアシスタント側で判断して `dangerouslyDisableSandbox: true` を使い、確認なしで削除してよいというルールを明文化する。

## ルールの範囲（安全性レビュー後）

「削除」と「編集」を当初は両方許可する案にしていたが、以下の観点から**削除のみに限定**した:

- **編集はステルス性が高い**: 削除なら `ls` で気付けるが、編集は内容が変わるだけでユーザーが気付きにくい
- **復元できない**: gitignore 対象は git 履歴がないため、編集前の状態を取り戻せない
- **意図しないローカル設定の改ざんリスク**: `.env.local` や `*.local.yaml` のような追跡外設定ファイルが対象に含まれる可能性
- **編集の必要性が薄い**: 実例（settings.local.json の整理など）は「ファイルごと削除」で完結する

## 追加するルール

- `.gitignore` で除外されているファイルや git 追跡外のローカルファイル（例: `.claude/settings.local.json`、`.DS_Store`、ローカル lock ファイル、ビルド成果物など）はユーザー確認なしに**削除**してよい
- sandbox の `denyWithinAllow` で保護されているものは `dangerouslyDisableSandbox: true` で実行する（理由は `description` に明記）
- **編集は git 追跡対象と同様にユーザー確認を取る**（編集はステルス性が高く、git 履歴がないため復元できないため）
