### PR TITLE
chore: trim derivable sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,6 @@ macOS と Linux で開発環境のセットアップを自動化する dotfiles 
 - **Git フック**: lefthook で管理（`lefthook.yaml` で設定）。
 - **コード品質**: Prettier（フォーマット）、commitlint（コミットメッセージ）、markdownlint（ドキュメント）。
 
-### 主要ファイル
-
-- `install.sh`: 新規システムセットアップのエントリポイント
-- `Brewfile`: Homebrew パッケージ、cask、Mac App Store アプリの定義
-- `.github/workflows/test-install.yaml`: macOS と Ubuntu でのインストールテスト用 CI 設定
-- `.mcp.json`: AI アシスタント連携用 MCP サーバー設定
-
 ### 新規設定の追加手順
 
 1. `home/` 配下の適切なサブディレクトリに dotfiles を配置


### PR DESCRIPTION
## Summary

`CLAUDE.md` の追加トリム第 2 弾。先行 PR でコマンドリストを削った後、見直して **「ファイル一覧 / ディレクトリ列挙 / format-lint コマンドの再記述」** など、`ls` / `package.json` / `Makefile` / `.github/workflows/` を読めば自明な記述をさらに削除する。

## 変更内容（repo によって異なる）

- 「アーキテクチャ概要」配下の主要ディレクトリ列挙
- 「重要なパターン」内の "format / lint コマンドを使え" 系の箇条書き
- workflow ファイル列挙（`.github/workflows/` を読めば自明）
- ファイル名と短い説明だけのリスト

## 動機

`package.json` scripts / `Makefile` / ファイル一覧を `CLAUDE.md` に重複して保持すると drift する。WHY や非自明な制約は残し、それ以外は正本（コード・スクリプト・設定）に一本化する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] WHY (理由) を含む記述は残っている
