### PR TITLE
fix(claude): detect stale project_dir in statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -148,10 +148,4 @@ if [[ ! -d "$project_dir" ]]; then
   exit 0
 fi
 
-# project_dir は生きているが /add-dir 先など現在の cwd が消えたレアケース
-if [[ ! -d "$cwd" ]]; then
-  printf '%s(stale cwd: %s)%s\n%s' "$red" "$cwd" "$reset" "$(render_env_line)"
-  exit 0
-fi
-
 printf '%s\n%s' "$(render_top_line)" "$(render_env_line)"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -24,12 +24,17 @@ while IFS= read -r line; do
 done < <(jq -r '
   .model.display_name // "Claude",
   (.context_window.used_percentage // 0 | floor | tostring),
-  .cwd // ""
+  .cwd // "",
+  .workspace.project_dir // .cwd // ""
 ' <<<"$input")
 
 model="${fields[0]:-Claude}"
 ctx_pct="${fields[1]:-0}"
 cwd="${fields[2]:-$HOME}"
+# project_dir は claude 起動時に固定。cwd は /add-dir や cd で動的に変わり、
+# worktree 削除時は Claude Code 側で別ディレクトリに自動 recover されるため、
+# stale 判定には fixed な project_dir を使う。
+project_dir="${fields[3]:-$cwd}"
 
 # cmux が無い環境では fork ごと省略
 surface_ref=""
@@ -136,7 +141,14 @@ render_env_line() {
 
 # --- output ---
 
-# cwd が消えた場合（git worktree remove 等）は警告のみ表示して env_line は維持
+# project_dir (claude 起動時の固定 cwd) が消えた場合 (git worktree remove 等)
+# は警告のみ表示して env_line は維持。cwd は recover されるためここでは見ない。
+if [[ ! -d "$project_dir" ]]; then
+  printf '%s(stale project_dir: %s)%s\n%s' "$red" "$project_dir" "$reset" "$(render_env_line)"
+  exit 0
+fi
+
+# project_dir は生きているが /add-dir 先など現在の cwd が消えたレアケース
 if [[ ! -d "$cwd" ]]; then
   printf '%s(stale cwd: %s)%s\n%s' "$red" "$cwd" "$reset" "$(render_env_line)"
   exit 0


### PR DESCRIPTION
## 背景

worktree が `git worktree remove` 等で削除されたセッションで statusline の stale 警告 (`(stale cwd: ...)`) が出るはずなのに表示されない事象を発見。

## 原因

statusline の payload schema を [公式 docs](https://code.claude.com/docs/en/statusline.md) で確認したところ:

| フィールド | 性質 | 意味 |
|---|---|---|
| `cwd` / `workspace.current_dir` | **dynamic** | 現在のプロセスの作業ディレクトリ |
| `workspace.project_dir` | **fixed** | claude 起動時のディレクトリ |

旧実装は `.cwd` の存在チェックで stale 判定していたが、worktree 削除時 Claude Code は `cwd` を別の存在するディレクトリ (HOME 等) に自動 recover するため、`[[ -d "$cwd" ]]` を通り抜けてしまう。

## 修正

stale 判定を `.workspace.project_dir`（claude 起動時に固定、Claude Code は書き換えない）に切り替え。`cwd` 側の判定は `/add-dir` 先が消えたレアケース用の fallback として残した。`workspace` フィールドを持たない古い payload に対する後方互換も `// .cwd` で確保。

## 検証

3 ケースを手動 stub で確認:

| ケース | 結果 |
|---|---|
| project_dir = 削除済み worktree, cwd = HOME | ✅ `(stale project_dir: ...)` 表示 |
| project_dir = cwd = HOME (通常) | ✅ 通常 prompt (`~`) |
| `workspace` フィールドなし (旧 payload 後方互換) | ✅ cwd へ fallback して通常表示 |
