### PR TITLE
chore(deps): bump pnpm from 10.33.2 to 11.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,15 @@
     "lefthook": "2.1.6",
     "markdownlint-cli2": "0.22.1"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": "24.15.0"
   },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@evilmartians/lefthook"
-    ]
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.15.0",
+      "onFail": "download"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       markdownlint-cli2:
         specifier: 0.22.1
         version: 0.22.1
+      node:
+        specifier: runtime:24.15.0
+        version: runtime:24.15.0
 
 packages:
 
@@ -661,6 +664,127 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node@runtime:24.15.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
+            prefix: node-v24.15.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
+            prefix: node-v24.15.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-MemKqWCgZ9qR7f/V2TvEZle10qgClhLDWfXyrABgFSo=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-9Vr1vUicU0exE8pllMrgClSzC6V6xYdTJDEb/G9HYuM=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.15.0
+    hasBin: true
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1534,6 +1658,8 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
+
+  node@runtime:24.15.0: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,11 @@
 # pnpm config list
 # ```
 
-# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
-# パッケージ自身の install スクリプト実行は不要
-allowBuilds:
-  lefthook: false
+# build script は未記載のものはデフォルトで実行しない (v11 の挙動)。
+# strictDepBuilds: false で「未記載＝warning」に格下げし、
+# install を止めずに済ませる。本当に build が必要なものだけ
+# allowBuilds に true で明示する
+strictDepBuilds: false
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:
@@ -17,3 +18,6 @@ publicHoistPattern:
 
 # pinバージョンでインストールする
 savePrefix: ''
+
+# ログ出力形式をカスタマイズ
+reporter: append-only

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,11 +4,10 @@
 # pnpm config list
 # ```
 
-# build script は未記載のものはデフォルトで実行しない (v11 の挙動)。
-# strictDepBuilds: false で「未記載＝warning」に格下げし、
-# install を止めずに済ませる。本当に build が必要なものだけ
-# allowBuilds に true で明示する
-strictDepBuilds: false
+# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
+# パッケージ自身の install スクリプト実行は不要
+allowBuilds:
+  lefthook: false
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,10 @@
 # pnpm config list
 # ```
 
-# 使用するNode.jsのバージョン
-useNodeVersion: 24.15.0
+# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
+# パッケージ自身の install スクリプト実行は不要
+allowBuilds:
+  lefthook: false
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:
@@ -15,12 +17,3 @@ publicHoistPattern:
 
 # pinバージョンでインストールする
 savePrefix: ''
-
-# 公開から3日未満のバージョンをインストールしない（サプライチェーン攻撃対策）
-# https://pnpm.io/settings#minimumreleaseage
-# NOTE: transitive dependency の再解決時にフォールバックが効かない pnpm のバグにより一時無効化
-# https://github.com/pnpm/pnpm/issues/11068
-# minimumReleaseAge: 4320
-
-# ログ出力形式をカスタマイズ
-reporter: append-only

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,11 @@
 # pnpm config list
 # ```
 
-# lefthook のフック登録は @nozomiishii/postinstall 経由で行うため、
-# パッケージ自身の install スクリプト実行は不要
+# install スクリプトのポリシー: 実際に build/postinstall が動作に必要なら true、
+# 不要・別経路で代替できるなら false。推移依存はコメントで導入経路を明記する
 allowBuilds:
-  lefthook: false
+  # ── 直接依存 ──
+  lefthook: false # フック登録は @nozomiishii/postinstall 経由で行うため不要
 
 # 依存解決のうまくいっていないdependenciesのdependenciesをrootのnode_modulesまで巻き上げる
 publicHoistPattern:


### PR DESCRIPTION
## 概要

pnpm を v10.33.2 から v11.0.8 にバージョン更新。v11 はサプライチェーン保護のデフォルト ON や設定スキーマの整理など破壊的変更が多いため、それに合わせて設定ファイルを追従させる。

## 主な変更

- `package.json`
  - `packageManager`: `pnpm@10.33.2` → `pnpm@11.0.8`
  - `useNodeVersion`（v11 で削除）の代替として `devEngines.runtime` を追加。`onFail: download` で従来の Node 自動取得挙動を維持
  - `pnpm.ignoredBuiltDependencies` ブロックを削除（`allowBuilds` に移行）
- `pnpm-workspace.yaml`
  - `useNodeVersion`、`reporter`、`minimumReleaseAge` のコメントブロックを削除（v11 で削除 or デフォルト 1 日に変更）
  - `allowBuilds.lefthook: false` を追加。lefthook のフック登録は `@nozomiishii/postinstall` 経由で行うため install スクリプト実行は不要
- `pnpm-lock.yaml` 更新（`node@runtime:24.15.0` 追加など）

## v11 主要破壊的変更（参考）

- Node.js 22+ 必須（本リポジトリは 24.15.0 なので影響なし）
- `useNodeVersion` 設定削除 → `devEngines.runtime` で代替
- `onlyBuiltDependencies` / `neverBuiltDependencies` / `ignoredBuiltDependencies` / `ignoreDepScripts` を `allowBuilds` マップに統合
- `.npmrc` は auth/registry のみへ縮小
- 環境変数 prefix が `npm_config_*` → `pnpm_config_*` に
- `minimumReleaseAge` のデフォルトが 1440 分（1 日）に

## 動作確認

- ローカルで `CI=true pnpm install` がエラー・警告なしで成功
- postinstall（lefthook フック登録）も従来通り動作
