### PR TITLE
feat(zsh): adopt carapace and fzf-tab completion stack

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -38,9 +38,6 @@ cask "jump-desktop-connect"
 # Command-line fuzzy finder written in Go https://github.com/junegunn/fzf
 brew "fzf"
 
-# Smarter cd with frecency-based directory jumping https://github.com/ajeetdsouza/zoxide
-brew "zoxide"
-
 # ----------------------------------------------------------------
 # macOS-only packages
 # ----------------------------------------------------------------

--- a/Brewfile
+++ b/Brewfile
@@ -38,6 +38,9 @@ cask "jump-desktop-connect"
 # Command-line fuzzy finder written in Go https://github.com/junegunn/fzf
 brew "fzf"
 
+# Smarter cd with frecency-based directory jumping https://github.com/ajeetdsouza/zoxide
+brew "zoxide"
+
 # ----------------------------------------------------------------
 # macOS-only packages
 # ----------------------------------------------------------------

--- a/Brewfile
+++ b/Brewfile
@@ -17,6 +17,9 @@ brew "zsh-syntax-highlighting"
 # Multi-shell multi-command argument completer https://carapace.sh
 brew "carapace"
 
+# Real-time type-ahead completion for zsh https://github.com/marlonrichert/zsh-autocomplete
+brew "zsh-autocomplete"
+
 # Cross-shell prompt for astronauts https://starship.rs
 brew "starship"
 

--- a/Brewfile
+++ b/Brewfile
@@ -17,8 +17,8 @@ brew "zsh-syntax-highlighting"
 # Multi-shell multi-command argument completer https://carapace.sh
 brew "carapace"
 
-# Real-time type-ahead completion for zsh https://github.com/marlonrichert/zsh-autocomplete
-brew "zsh-autocomplete"
+# Replace zsh tab completion menu with fzf https://github.com/Aloxaf/fzf-tab
+brew "fzf-tab"
 
 # Cross-shell prompt for astronauts https://starship.rs
 brew "starship"

--- a/Brewfile
+++ b/Brewfile
@@ -14,6 +14,9 @@ brew "stow"
 # Fish shell like syntax highlighting for zsh https://github.com/zsh-users/zsh-syntax-highlighting
 brew "zsh-syntax-highlighting"
 
+# Multi-shell multi-command argument completer https://carapace.sh
+brew "carapace"
+
 # Cross-shell prompt for astronauts https://starship.rs
 brew "starship"
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -8,9 +8,10 @@ zmodload -i zsh/complist
 compinit
 
 # carapace - multi-shell completion engine
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
 zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
 if command -v carapace >/dev/null; then
-  source <(carapace _carapace zsh)
+  source <(carapace _carapace)
 fi
 
 # Syntax Highlighting

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -14,6 +14,11 @@ if command -v carapace >/dev/null; then
   source <(carapace _carapace)
 fi
 
+# zoxide - smarter cd with frecency
+if command -v zoxide >/dev/null; then
+  eval "$(zoxide init --cmd cd zsh)"
+fi
+
 # zsh-autocomplete - real-time type-ahead menu
 source "$(brew --prefix)/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -15,7 +15,7 @@ fi
 
 # fzf-tab - replace zsh tab completion with fzf preview menu
 # Must be sourced after compinit and before zsh-syntax-highlighting.
-source "$(brew --prefix)/share/fzf-tab/fzf-tab.plugin.zsh"
+source "$(brew --prefix)/share/fzf-tab/fzf-tab.zsh"
 zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza -1 --color=always $realpath'
 
 # Syntax Highlighting (must be sourced last)

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -9,7 +9,6 @@ compinit
 
 # carapace - multi-shell completion engine
 export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
-zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
 if command -v carapace >/dev/null; then
   source <(carapace _carapace)
 fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -13,8 +13,10 @@ if command -v carapace >/dev/null; then
   source <(carapace _carapace)
 fi
 
-# zsh-autocomplete - real-time type-ahead menu
-source "$(brew --prefix)/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
+# fzf-tab - replace zsh tab completion with fzf preview menu
+# Must be sourced after compinit and before zsh-syntax-highlighting.
+source "$(brew --prefix)/share/fzf-tab/fzf-tab.plugin.zsh"
+zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza -1 --color=always $realpath'
 
 # Syntax Highlighting (must be sourced last)
 source "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -14,7 +14,10 @@ if command -v carapace >/dev/null; then
   source <(carapace _carapace)
 fi
 
-# Syntax Highlighting
+# zsh-autocomplete - real-time type-ahead menu
+source "$(brew --prefix)/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
+
+# Syntax Highlighting (must be sourced last)
 source "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 # Config

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -7,6 +7,12 @@ autoload -Uz compinit
 zmodload -i zsh/complist
 compinit
 
+# carapace - multi-shell completion engine
+zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
+if command -v carapace >/dev/null; then
+  source <(carapace _carapace zsh)
+fi
+
 # Syntax Highlighting
 source "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
@@ -41,16 +47,7 @@ if command -v fnm >/dev/null; then
   eval "$(fnm env --use-on-cd --shell zsh)"
 fi
 
-# bun completions
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
 # Ruby
 if command -v rbenv >/dev/null; then
   eval "$(rbenv init -)"
-fi
-
-# Python(uv)
-if command -v uv >/dev/null; then
-  eval "$(uv generate-shell-completion zsh)"
-  eval "$(uvx --generate-shell-completion zsh)"
 fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -14,11 +14,6 @@ if command -v carapace >/dev/null; then
   source <(carapace _carapace)
 fi
 
-# zoxide - smarter cd with frecency
-if command -v zoxide >/dev/null; then
-  eval "$(zoxide init --cmd cd zsh)"
-fi
-
 # zsh-autocomplete - real-time type-ahead menu
 source "$(brew --prefix)/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 


### PR DESCRIPTION
## Summary

- carapace を補完エンジンとして導入し、ツール個別の completion eval (uv / uvx / bun) を carapace 一本に統一
- zsh の Tab 補完を fzf-tab に置き換え、`cd <Tab>` で eza ベースのディレクトリ preview を表示
- carapace の `CARAPACE_BRIDGES` を有効化し、spec 未収録コマンドのフォールバック経路を確保

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `Brewfile` | `carapace`, `fzf-tab` を追加 |
| `home/.zshrc` | `compinit` 後に carapace と fzf-tab を初期化、`zsh-syntax-highlighting` を最後に維持。uv / uvx / bun の個別 completion eval を削除 |

## 試行錯誤の経緯

履歴に試行錯誤の commit が残っています。マージ時は **Squash merge** を推奨します。

- carapace 導入 → carapace 公式 setup に揃える
- zsh-autocomplete を試したが、cd の補完で local-directories が並ばない既知挙動 ([zsh-autocomplete#837](https://github.com/marlonrichert/zsh-autocomplete/issues/837), [#432](https://github.com/marlonrichert/zsh-autocomplete/issues/432)) で要件と噛み合わず
- zoxide を試したが、`--cmd cd` モードでは DB が空のうちは候補ゼロになって体験が損なわれたため revert
- 最終的に fzf-tab に切替え。Tab で fzf preview menu が出る運用に着地

## 動作確認

- [ ] `git <Tab>` で carapace の説明付きサブコマンド一覧
- [ ] `docker <Tab>` で carapace の構造化候補
- [ ] `cd <Tab>` で fzf preview メニュー（左に候補、右に eza でディレクトリ内容）
- [ ] `uv pip install <Tab>` で carapace 経由の補完
