### PR TITLE
chore(claude): document scope ban in PR title rule

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -24,7 +24,7 @@
 
 ## GitHub / PR
 
-- **PR タイトル**: Conventional Commits 形式（英語）で `<type>: <subject>` と書く。許可 type は `feat` / `fix` / `chore`（リポジトリで追加されている場合はそれに従う）。subject は小文字始まり / ASCII のみ / 末尾スペース禁止。これは nozomiishii/workflows の semantic pull request チェック（amannn/action-semantic-pull-request）と同じ規則で、違反すると CI が落ちる。
+- **PR タイトル**: Conventional Commits 形式（英語）で `<type>: <subject>` と書く。許可 type は `feat` / `fix` / `chore`（リポジトリで追加されている場合はそれに従う）。**scope は付けない**（`feat(api): ...` ではなく `feat: ...`）。caller 側で nozomiishii/workflows の `pull-request.yaml` に `scopes` input を渡している repo に限り scope 可（その場合は input で許可された scope のみ）。subject は小文字始まり / ASCII のみ / 末尾スペース禁止。これは nozomiishii/workflows の semantic pull request チェック（amannn/action-semantic-pull-request）と同じ規則で、違反すると CI が落ちる。
 - **PR 本文**: プルリクエストの本文（body）は日本語で記述する。
 - **PR マージ**: マージは必ずユーザーが手動で行う。AI が `gh pr merge` や GitHub API 経由でマージを実行してはならない。
 - **PR 作成・更新・push**: これらは AI が実行してよい。マージの最終判断のみ常にユーザーに委ねる。


### PR DESCRIPTION
## Summary

global CLAUDE.md の **PR タイトル** ルールに以下を追記:

- **scope は付けない** (`feat(api): ...` ではなく `feat: ...`)
- caller 側で nozomiishii/workflows の `pull-request.yaml` に `scopes` input を渡している repo に限り scope 可（その場合は input で許可された scope のみ）

## Why

nozomiishii/workflows#45 で `pull-request.yaml` の default が「PR title の scope を全禁止」に変わる。caller 側で意図的に opt-in しない限り scope 付き title は CI で弾かれるようになるため、Claude が PR を作る時のデフォルト挙動も「scope なし」に揃える必要がある。

## Test plan

- [ ] 次に Claude が PR を作る時、`<type>: <subject>` 形式（scope なし）で作成されること
- [ ] 例外的に scope を付ける際は、caller repo の workflow に `scopes` input が渡っているかを Claude が事前に確認するようになっていること
