### PR TITLE
feat: add 5-hour and weekly rate limit percentages to statusline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@
 
 - 色や見た目を決める作業は、候補をまとめて実環境にレンダリングして比較すること。テキストとして ANSI エスケープを眺めても色は判別できない。
 - 例: statusline の色を選ぶとき、`home/.claude/statusline.sh` の出力を一時的に複数行にし、各行で異なる色コード + ラベルを並べて出す。Claude Code を再描画すれば全候補を同時に見比べられる。決まったら本番形（1行）に戻す。
+- **worktree で編集する場合、main repo (`~/dotfiles/home/.claude/statusline.sh`) にも同じ変更を反映する。** Claude Code が読むのは `~/.claude/statusline.sh` で、これは GNU Stow で main repo の `home/` に張られたシンボリックリンク。worktree 側の `home/` は参照されないので、色候補を一時並べたとき・本番形に戻すときの両方で、worktree と main repo に同じ編集を入れる必要がある。同様のことは `home/.claude/` 配下の他のファイル（hooks、skills、settings.json 等）や `home/.config/` 配下にも当てはまる。
 - 同様の手法は `home/.config/starship/starship.toml` や terminal config の調整にも使える。
 
 ## ポータビリティ

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -3,15 +3,22 @@ set -uo pipefail
 
 # --- colors ---
 
+# 命名規則: <color> は non-bold、<color>_bold は bold 版。
 esc=$'\033'
 st=$'\033\\'
 reset="${esc}[0m"
-red="${esc}[1;31m"
-green="${esc}[1;32m"
-yellow="${esc}[1;33m"
-blue="${esc}[1;34m"
+red="${esc}[31m"
+red_bold="${esc}[1;31m"
+green="${esc}[32m"
+green_bold="${esc}[1;32m"
+yellow="${esc}[33m"
+yellow_bold="${esc}[1;33m"
+blue="${esc}[34m"
+blue_bold="${esc}[1;34m"
 white="${esc}[37m"
-cyan="${esc}[1;36m"
+white_bold="${esc}[1;37m"
+cyan="${esc}[36m"
+cyan_bold="${esc}[1;36m"
 gray="${esc}[38;5;250m"
 
 # --- input parsing ---
@@ -25,7 +32,9 @@ done < <(jq -r '
   .model.display_name // "Claude",
   (.context_window.used_percentage // 0 | floor | tostring),
   .cwd // "",
-  .workspace.project_dir // .cwd // ""
+  .workspace.project_dir // .cwd // "",
+  (.rate_limits.five_hour.used_percentage // empty | floor | tostring),
+  (.rate_limits.seven_day.used_percentage // empty | floor | tostring)
 ' <<<"$input")
 
 model="${fields[0]:-Claude}"
@@ -35,6 +44,10 @@ cwd="${fields[2]:-$HOME}"
 # worktree 削除時は Claude Code 側で別ディレクトリに自動 recover されるため、
 # stale 判定には fixed な project_dir を使う。
 project_dir="${fields[3]:-$cwd}"
+# 5h / 7d rate limit は Claude.ai 購読者のみ、最初の API 応答後に出現する。
+# 未取得の間は空文字で、env_line では該当パートを省略する。
+five_hour_pct="${fields[4]:-}"
+seven_day_pct="${fields[5]:-}"
 
 # cmux が無い環境では fork ごと省略
 surface_ref=""
@@ -111,11 +124,11 @@ render_top_line() {
     diff_text=$(starship_at module git_status | sed 's/ *$//')
     branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
 
-    local parts=("${cyan}${repo_name}${reset}" "${green}worktree:(${red}${wt_dir}${reset}${green})${reset}")
+    local parts=("${cyan_bold}${repo_name}${reset}" "${green_bold}worktree:(${red_bold}${wt_dir}${reset}${green_bold})${reset}")
     # claude -w 自動生成は branch = worktree-{wt_dir} で情報重複するので省略。
     # 手動で別ブランチを切った worktree のときだけ git:() を追加。
     if [[ -n "$branch" && "$branch" != "worktree-${wt_dir}" ]]; then
-      parts+=("${blue}git:(${red}${branch}${reset}${blue})${reset}")
+      parts+=("${blue_bold}git:(${red_bold}${branch}${reset}${blue_bold})${reset}")
     fi
     [[ -n "$diff_text" ]] && parts+=("$diff_text")
     join ' ' "${parts[@]}"
@@ -133,8 +146,10 @@ render_top_line() {
 render_env_line() {
   local parts=()
   parts+=("${white}${model}${reset}")
-  parts+=("${yellow}${ctx_pct}%${reset}")
-  [[ -n "$surface_ref" ]] && parts+=("${blue}${surface_ref}${reset}")
+  parts+=("${yellow_bold}${ctx_pct}%${reset}")
+  [[ -n "$five_hour_pct" ]] && parts+=("${yellow}h ${five_hour_pct}%${reset}")
+  [[ -n "$seven_day_pct" ]] && parts+=("${yellow}w ${seven_day_pct}%${reset}")
+  [[ -n "$surface_ref" ]] && parts+=("${blue_bold}${surface_ref}${reset}")
   parts+=("${gray}$(build_cursor_link)${reset}")
   join ' | ' "${parts[@]}"
 }
@@ -144,7 +159,7 @@ render_env_line() {
 # project_dir (claude 起動時の固定 cwd) が消えた場合 (git worktree remove 等)
 # は警告のみ表示して env_line は維持。cwd は recover されるためここでは見ない。
 if [[ ! -d "$project_dir" ]]; then
-  printf '%s(stale project_dir: %s)%s\n%s' "$red" "$project_dir" "$reset" "$(render_env_line)"
+  printf '%s(stale project_dir: %s)%s\n%s' "$red_bold" "$project_dir" "$reset" "$(render_env_line)"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- statusline に 5 時間枠 / 週次枠の利用率 (`rate_limits.five_hour.used_percentage` / `rate_limits.seven_day.used_percentage`) を `h XX% | w YY%` 表示として追加
- 色定義を `<color>` (non-bold) / `<color>_bold` (bold) の命名規則に再編。既存の bold 使用箇所は `*_bold` に書き換え
- CLAUDE.md の「ビジュアル設定」節に、worktree 編集を main repo にも反映する必要がある旨を追記 (`~/.claude/statusline.sh` は GNU Stow で main repo に張られているため worktree 側だけ編集しても live session には反映されない)

## Statusline before / after

Before:

```
dotfiles worktree:(precious-singing-sphinx)
Opus 4.7 (1M context) | 25% | surface:26 | [editor]
```

After (rate_limits 取得済み):

```
dotfiles worktree:(precious-singing-sphinx)
Opus 4.7 (1M context) | 25% | h 47% | w 83% | surface:26 | [editor]
```

After (fresh session / 未取得時 — h/w は省略):

```
dotfiles worktree:(precious-singing-sphinx)
Opus 4.7 (1M context) | 25% | surface:26 | [editor]
```

## Notes

- `rate_limits` フィールドは Claude.ai 購読者のみ、かつ最初の API 応答後に出現する。それまでは該当パートを描画しない fallback 付き。
- ctx (`25%`) は bold yellow、h/w (`h 47%` / `w 82%`) は non-bold yellow。同じ hue 内で weight を変えて区別。
- 公式 statusline docs: <https://code.claude.com/docs/en/statusline.md> (Rate limit usage 節)

## Test plan

- [x] `bash -n` 構文チェック
- [x] rate_limits 有りの JSON で h/w が描画されることをローカル確認
- [x] rate_limits 欠損 JSON で h/w が省略されることをローカル確認
- [ ] Claude Code セッションで実値が反映されることを目視確認
