### PR TITLE
chore: drop unused color variables from statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -7,17 +7,12 @@ set -uo pipefail
 esc=$'\033'
 st=$'\033\\'
 reset="${esc}[0m"
-red="${esc}[31m"
 red_bold="${esc}[1;31m"
-green="${esc}[32m"
 green_bold="${esc}[1;32m"
 yellow="${esc}[33m"
 yellow_bold="${esc}[1;33m"
-blue="${esc}[34m"
 blue_bold="${esc}[1;34m"
 white="${esc}[37m"
-white_bold="${esc}[1;37m"
-cyan="${esc}[36m"
 cyan_bold="${esc}[1;36m"
 gray="${esc}[38;5;250m"
 


### PR DESCRIPTION
## 概要

`home/.claude/statusline.sh` で定義していたカラー変数のうち、現状どこからも参照されていない `red` / `green` / `blue` / `white_bold` / `cyan` の 5 つを削除する。

## 背景

`# --- colors ---` セクションでは bold / non-bold を網羅的に定義していたが、実際に使われているのは下記のみだった（`grep \${...}` で確認）:

- `reset`
- `red_bold`
- `green_bold`
- `yellow`, `yellow_bold`
- `blue_bold`
- `white`
- `cyan_bold`
- `gray`

未使用の定義はノイズになるため削除する。命名規則コメント (`<color> は non-bold、<color>_bold は bold 版`) は将来の追加指針として残している。

## 動作確認

色を使う出力箇所（worktree 行 / env line / stale project_dir 警告）はいずれも残っている変数のみを参照しており、見た目に変化はない。
