### PR TITLE
feat: add codex cli to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -212,6 +212,9 @@ if OS.mac?
   # Anthropic's official Claude AI desktop app https://www.anthropic.com/
   cask "claude"
 
+  # OpenAI's coding agent that runs locally on your computer https://github.com/openai/codex
+  brew "codex"
+
   # Replacement for Docker Desktop https://orbstack.dev/
   cask "orbstack"
 


### PR DESCRIPTION
## Summary

OpenAI の Codex CLI（`codex`）を Brewfile に追加します。

## 配置

AI ツール（`cask "claude"`）の直後に brew formula として置きました。GUI（cask）と CLI（brew）が混在していますが、AI 関連でひとまとめにしておく方が見つけやすいという判断です。

## 参考

- [openai/codex](https://github.com/openai/codex)
