### PR TITLE
fix: install codex via cask instead of formula

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -212,8 +212,8 @@ if OS.mac?
   # Anthropic's official Claude AI desktop app https://www.anthropic.com/
   cask "claude"
 
-  # OpenAI's coding agent that runs locally on your computer https://github.com/openai/codex
-  brew "codex"
+  # OpenAI's coding agent that runs in your terminal https://github.com/openai/codex
+  cask "codex"
 
   # Replacement for Docker Desktop https://orbstack.dev/
   cask "orbstack"


### PR DESCRIPTION
## Summary

[#922](https://github.com/nozomiishii/dotfiles/pull/922) で `brew "codex"` として追加した Codex CLI を `cask "codex"` に修正します。

## 背景

`codex` formula は homebrew/core から homebrew/cask に移行済みで、`brew install codex` は失敗します。実際に `brew bundle` で次のエラーになりました:

```
Warning: 'codex' formula is unreadable: No available formula with the name "codex".
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew install --cask codex
```

`brew info --cask codex` で確認したところ cask 側でメンテされているので、Brewfile も `cask "codex"` に揃えます。あわせて説明文を Homebrew の表記に合わせて "runs in your terminal" に修正しました。
