### PR TITLE
feat: add ca alias for claude agents

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -45,6 +45,7 @@ z!() {
 # claude
 # ----------------------------------------------------------------
 alias c="claude"
+alias ca="claude agents"
 alias cc="claude --continue"
 alias cr="claude --resume"
 alias ct="claude --teleport"


### PR DESCRIPTION
## 概要

`ca` を `claude agents` のエイリアスとして登録する。

## 変更点

- `home/.zsh/alias/alias.zsh` の claude セクションに `alias ca="claude agents"` を追加（`c` の直下に配置）

## 動作確認

- [ ] `source ~/.zsh/alias/alias.zsh` または `rr` 後、`ca` が `claude agents` を起動することを確認
