### PR TITLE
fix: percent-encode tilde in statusline editor link

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -67,6 +67,9 @@ join() {
 
 # RFC 3986 unreserved + / 以外を percent-encode する。
 # LC_ALL=C で UTF-8 マルチバイト文字を byte 単位で正しくエンコード。
+# `~` は技術的には unreserved だが、Cursor の URL handler がパス内の `~` を
+# ホーム展開等で誤解釈し ~/Library/Mobile Documents/iCloud~md~obsidian/...
+# 配下を開けないため、明示的に %7E にエスケープする。
 urlencode() {
   local s="$1"
   local out="" i char
@@ -74,7 +77,7 @@ urlencode() {
   for ((i = 0; i < ${#s}; i++)); do
     char="${s:$i:1}"
     case "$char" in
-      [a-zA-Z0-9._~/-]) out+="$char" ;;
+      [a-zA-Z0-9._/-]) out+="$char" ;;
       *)
         printf -v char '%%%02X' "'$char"
         out+="$char"


### PR DESCRIPTION
## Summary

Status line の `[editor]` リンクが `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` 配下で動かなかったため修正。`urlencode` の unreserved 集合から `~` を外し、`%7E` にエンコードするようにした。

Cursor の URL handler はパス内の `~` をホーム展開などで誤解釈するため、技術的には RFC 3986 unreserved でもエスケープ必須。

## Statusline before / after

可視テキストは同じだが、OSC 8 hyperlink の URL が変わる。

Before:

```
cursor://file/Users/nozomiishii/Library/Mobile%20Documents/iCloud~md~obsidian/Documents
```

→ Cursor が開けず `[editor]` クリックが no-op になる。

After:

```
cursor://file/Users/nozomiishii/Library/Mobile%20Documents/iCloud%7Emd%7Eobsidian/Documents
```

→ Cursor が正しく該当ディレクトリを開く。

## Test plan

- [ ] `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` 配下で Claude Code を起動し、`[editor]` クリックで Cursor が開くことを確認
- [ ] 既存の通常パス（`~/dotfiles` 等）でもリグレッションなく `[editor]` が動くことを確認
