### PR TITLE
chore: disable ghostty osc 9;4 progress bar

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -51,3 +51,7 @@ keybind = super+z=text:\x1f
 
 # pm
 keybind = super+alt+j=text:pm\n
+
+# Disable OSC 9;4 progress bar (the blue bar at the top during long-running commands)
+# https://ghostty.org/docs/config/reference#progress-style
+progress-style = false


### PR DESCRIPTION
## Summary

Ghostty で長時間実行コマンド中に上部に表示される青いプログレスバー（OSC 9;4 / ConEmu progress sequence による不定インジケータ）を無効化する。

`home/.config/ghostty/config` に `progress-style = false` を追加。Ghostty はこの値が `false` のとき OSC 9;4 シーケンスを silently ignore する。

参考: [Ghostty config reference: progress-style](https://ghostty.org/docs/config/reference#progress-style)

## 反映方法

`~/.config/ghostty/config` は GNU Stow で `home/.config/ghostty/config` を指すシンボリックリンクなので、マージすれば即反映。Ghostty 再起動、または `Cmd+Shift+,` で設定リロード。
