### PR TITLE
feat: add jf function to copy cwd as cd command

### DIFF
--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -2,3 +2,10 @@
 mkcd() {
   mkdir -p "$@" && cd "$_"
 }
+
+# Copy current directory as `cd <path>` to clipboard
+jf() {
+  local payload="cd $(printf '%q' "$PWD")"
+  printf '%s' "$payload" | pbcopy
+  printf '\033[32m✓\033[0m Copied to clipboard\n  \033[2m%s\033[0m\n' "$payload"
+}


### PR DESCRIPTION
## Summary

- 現在の cwd を `cd <path>` 形式でクリップボードへコピーする zsh 関数 `jf` を追加
- `home/.zsh/functions.zsh` に同居（`mkcd` の次）

## なぜ追加するか

Claude Code セッションを抜けずに、隣のペインで同じ worktree に素早く移動したい、というユースケースのため。`pwd | pbcopy` だと貼り付けてから手で `cd ` を打つ必要があり、地味に面倒だった。`jf` を打てば `cd <quoted-path>` がそのままクリップボードに乗るので、別ペインで貼って Enter するだけで同じディレクトリに入れる。

最初は Claude Code のスラッシュコマンド (`/cd`) として実装したが、Bash tool 経由だと `pbcopy` が sandbox 外実行となり毎回承認ダイアログが出て遅かった。`!jf` で zsh に直接行く方が体感ほぼゼロレイテンシなのでこちらを採用。

## 使い方

```sh
$ cd /Users/nozomiishii/dotfiles
$ jf
✓ Copied to clipboard
  cd /Users/nozomiishii/dotfiles
```

- 1 行目: 緑チェック + ステータス
- 2 行目: インデント + dim 色で実際にコピーされた payload
- パスは `printf '%q'` で shell-safe にエスケープされるので、スペースや特殊文字を含むパスでも安全

## Test plan

- [ ] 新しい zsh セッションで `jf` を実行し、`cd <path>` がクリップボードへ入ることを確認
- [ ] スペースを含むディレクトリ（例: `mkdir '/tmp/with space' && cd /tmp/with\ space && jf`）でクオート付きの安全な payload が出ることを確認
- [ ] 別ペイン / 別ターミナルでペースト→ Enter で同じディレクトリに移動できることを確認
