### PR TITLE
chore: change ghostty macos-icon to holographic

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -9,7 +9,7 @@
 
 # macOS
 # https://zenn.dev/kawarimidoll/articles/5f219b4409424b
-macos-icon = xray
+macos-icon = holographic
 macos-option-as-alt = true
 
 # Theme


### PR DESCRIPTION
## Summary

- Ghostty の Dock アイコンを `xray` → `holographic` に変更
- 参考: [Ghostty の macos-icon スタイル一覧](https://zenn.dev/kawarimidoll/articles/5f219b4409424b)

## Test plan

- [ ] Ghostty を再起動して Dock アイコンが holographic スタイルになることを確認
