### PR TITLE
chore: disable core.quotePath for readable non-ascii filenames

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -7,6 +7,7 @@ signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDF31h4ogJY+JRiI+k0+aLoO/OTnEI1
 # dev container内にnvim入れて初回起動遅くなるの懸念
 # editor = nvim
 ignorecase = false
+quotePath = false
 
 [init]
 defaultBranch = main


### PR DESCRIPTION
## Summary

- `git status` / `git diff` で日本語ファイル名が `"\343\202\242..."` のような 8 進エスケープで表示される問題を解消するため、`core.quotePath = false` を追加。

## 背景

- git のデフォルト `core.quotePath = true` は、非 ASCII バイト（0x80 以上）や制御文字を C-style にエスケープして出力する保守的な挙動。1990 年代後半の「UTF-8 非対応端末がまだ現役」だった時代の安全側デフォルト。
- macOS の Terminal / iTerm2 / WezTerm / Ghostty 等はすべて UTF-8 完全対応のため、エスケープせず生のバイト列を出力した方が日本語ファイル名がそのまま読める。
- この設定はリポジトリの index / commit / tree に一切影響せず、純粋に CLI の出力フォーマットだけを変える（つまり共有時に他人を壊さない）。
- motemen, Songmu, b4b4r07, fatih など著名 dotfiles で標準採用されている準定番設定。GitHub Code Search で `.gitconfig` への記述が約 1,400 件ヒット。

## やらないこと

- `core.precomposeUnicode` は今回入れない。macOS Git の default が true で明示不要、かつ問題が顕在化してから対応した方が判断しやすいため。
- 「同じファイル名が deleted + Untracked で同時に出る」「変更してないファイルが変更扱いになる」等の症状が出たら、その時点で再検討する。

## Test plan

- [ ] `git -C <日本語ファイル名のあるリポジトリ> status` で日本語ファイル名がそのまま読める
- [ ] 既存の alias / 他セクションの設定に影響がない
