### PR TITLE
chore: tighten GitHub Issue watch-recommendation rule

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -43,6 +43,17 @@ gh pr create --title "..." --body-file "$BODY_FILE"
 ## GitHub Issue 検索
 
 - Closed as duplicate の Issue は結果に含めない。duplicate chain を辿って、現在 Open の canonical issue を返すこと。
+- 「subscribe / watch する価値があるか」を user に提案する場合、以下を必ず**実物で確認**してから引用すること:
+  - `state: OPEN` (CLOSED は提案しない)
+  - `stateReason` が `DUPLICATE` でない (canonical issue を辿る、`gh issue view <n> --json comments -q '.comments[].body'` で "duplicate of #..." を探す)
+  - 直近 3 ヶ月以内に update / コメントがある (= 活発に議論中)
+  - thumbsup や comment 数で community traction を示す
+- 推測や sub-agent / WebSearch の output を鵜呑みにせず、**必ず `gh issue view <number>` で state / updatedAt / stateReason / comments を実物確認する**。一度ダメ出しされた経験あり (2026-05-14: closed 済みや duplicate 済みの issue を「open で active」と紹介してしまった)。
+- 引用 / リストアップ時は state と直近 update 日付を併記すると user の検証コストが下がる。リンク化ルール (下記コミュニケーション section 参照) も守る:
+
+```markdown
+- [#32018](https://github.com/anthropics/claude-code/issues/32018) [BUG] Archived Code session cannot be unarchived (OPEN, 7👍, last update 2026-05-08)
+```
 
 ## コミュニケーション
 


### PR DESCRIPTION
## Summary

GitHub Issue を「subscribe / watch する価値あり」として user に提案する際の検証ルールをグローバル CLAUDE.md に明文化。`gh issue view <number>` での実物確認を必須化する。

## 経緯

2026-05-14、git-harvest の path-regime 設計と連動する形で Anthropic Claude Code の Remote Control session 関連 issue を 5 件紹介したが、後から再検証したら 4 件は実は CLOSED (うち 2 件は COMPLETED で機能実装済み、2 件は DUPLICATE) で、user に余計な検索コストをかけてしまった。

サブエージェントや WebSearch の output を鵜呑みにせず、`gh issue view <number>` で state / stateReason / updatedAt / comments を必ず確認するフローを CLAUDE.md に固定化する。

## 追加した運用ルール

`## GitHub Issue 検索` セクションに以下を追加:

- `state: OPEN` 確認 (CLOSED は提案しない)
- `stateReason` が `DUPLICATE` でないこと (duplicate chain を辿る)
- 直近 3 ヶ月以内に活動 (= 活発な議論)
- thumbsup / comment 数で community traction を表示
- 提案フォーマット: `[#32018](url) [BUG] ... (OPEN, 7👍, last update 2026-05-08)`
- 過去のミスを脚注として残し、ルールの背景が分かるように

## Test plan

- [ ] 次に Issue 紹介を求められた時、`gh issue view <n>` 実行を経由するかセルフチェック
- [ ] bare `#N` 参照ではなく必ず markdown link で出力するか確認
