### PR TITLE
chore: warn against gh pr checks --watch in /pr skill

### DIFF
--- a/home/.claude/skills/pr/SKILL.md
+++ b/home/.claude/skills/pr/SKILL.md
@@ -123,7 +123,23 @@ worktree でも動くよう `git checkout main` は使わない。
 
 push の後は CI が走り直すので、step 1 に戻って status を再取得する。
 
-抜ける条件（いずれかを満たしたら終了）:
+### CI 完了の待ち方
+
+push 直後は workflow がまだ queue されていない。`gh pr checks <PR>` を 15–30 秒間隔で polling して完了を待つ。
+
+**`gh pr checks --watch` は使わない**: workflow 全体が path-filter / `if:` 条件で skip された場合に `skipping` ステータスで残り、gh CLI が terminal と認識せず無限ループする（README 変更のみの PR で `actionlint` / `zizmor` などが path-filter で skip されるケース等）。
+
+polling 例:
+
+```bash
+while gh pr checks <PR> 2>/dev/null | awk '{print $2}' | grep -qE '^(pending|queued|in_progress)$'; do
+  sleep 20
+done
+```
+
+### 抜ける条件
+
+いずれかを満たしたら終了:
 
 - `mergeable: MERGEABLE` かつ `mergeStateStatus` が `CLEAN` / `HAS_HOOKS` / `UNSTABLE`（CI 全 pass）
 - 残った課題が「ユーザーの判断が必要なレビュー指摘」のみ


### PR DESCRIPTION
## Summary

- `/pr` skill の section 3 に `### CI 完了の待ち方` を新設
- `gh pr checks --watch` を禁止し、理由を明記（path-filter / `if:` で skip された workflow が `skipping` ステータスで残り、gh CLI が terminal と認識せず無限ループする）
- 代替の polling パターン（`pending|queued|in_progress` を含まなくなるまで sleep 20）を提示
- 既存の「抜ける条件」を `### 抜ける条件` 見出しに昇格して整理

## Motivation

git-harvest の README 変更 PR ([#148](https://github.com/nozomiishii/git-harvest/pull/148)) で `/pr` フォロー中、`gh pr checks --watch` が `actionlint` / `zizmor` の `skipping` ステータスを terminal と扱わずに無限待ちした。再現パスは「README のみ変更 → path-filter で workflow が skip → gh CLI が skipping を pending として扱う」。同じことを毎回踏まないよう skill 側で明示的に禁止しておく。

## Test plan

- [ ] 次に `/pr` を流す PR で `gh pr checks --watch` を使わず polling で完了判定できているか確認
