### PR TITLE
feat: add spec management policy to global CLAUDE.md

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -44,6 +44,16 @@ gh pr create --title "..." --body-file "$BODY_FILE"
 
 - Closed as duplicate の Issue は結果に含めない。duplicate chain を辿って、現在 Open の canonical issue を返すこと。
 
+## 設計・spec の管理
+
+- 設計ドキュメント・spec・brainstorming の成果は **GitHub issue にまとめる**。`docs/superpowers/specs/` や `docs/` 配下のファイルとして残さない。
+- 理由: 変更行 → `git blame` → PR → linked issue で「なぜこの変更が入ったか」を**逆検索**できる導線を作るため。ファイルで残すとコードの変更行から逆引きする経路が存在しない。
+- skill（superpowers/brainstorming, writing-plans, executing-plans 等）が「`docs/superpowers/specs/YYYY-MM-DD-*-design.md` に保存しろ」と指示してきても、それを上書きで **GitHub issue 作成 or 既存 issue 更新**に置き換えること。skill のデフォルトファイルパスは採用しない。
+- 既存の関連 issue があれば update（コメント追加 or 本文編集）。なければ新規作成。
+- issue タイトルは PR と同じ Conventional Commits 形式（英語）で `<type>: <subject>`。本文は日本語。
+- 大型 spec は issue 1 本にまとめ、Phase 分割や検討経緯は section（`## Phase 1` 等）やコメントで構造化する。
+- 関連 PR は必ず `closes #N` / `refs #N` で対応 issue を紐付け、逆検索チェーンを成立させる。
+
 ## コミュニケーション
 
 - すぐに結論や解決策を出さず、ユーザーと議論しながら段階的に進めること。質問を投げかけたり仮説を共有しながら、一緒に考える姿勢で。


### PR DESCRIPTION
## Summary

- global `CLAUDE.md` に `## 設計・spec の管理` セクションを追加
- 設計 doc / spec / brainstorming 成果は GitHub issue にまとめる方針を明文化
- `docs/` 配下のファイル（`docs/superpowers/specs/` 含む）には残さない

## 背景

`superpowers/brainstorming` や `writing-plans` 等の skill は spec を `docs/superpowers/specs/YYYY-MM-DD-*-design.md` として保存する仕様。これだと:

- skill を別系統に移行する時にコストになる
- コード変更行から「なぜこの変更が入ったか」を逆検索するチェーンが切れる（ファイルに残ると `git blame` → PR → linked issue の経路が成立しない）

issue で管理すれば PR から `closes #N` / `refs #N` で紐付き、逆検索チェーンが成立する。

## 変更内容

`## GitHub Issue 検索` の直後に新セクション `## 設計・spec の管理` を挿入。

- skill のデフォルト保存先（`docs/superpowers/specs/...`）を上書きで issue 化するルール
- issue タイトルは PR と同じ Conventional Commits 形式（英語）、本文は日本語
- 大型 spec は issue 1 本にまとめ、Phase 分割は section / コメントで構造化
- 関連 PR は `closes #N` / `refs #N` で紐付け

## Test plan

- [ ] 次回 brainstorming / writing-plans を実行する際、ファイルじゃなく issue を作るよう動作するか確認
- [ ] 既存 [nozomiishii/brain#137](https://github.com/nozomiishii/brain/issues/137) と同じ Phase 別 issue 構造で運用できるか
