### PR TITLE
chore: sync git aliases with oh-my-zsh upstream

### DIFF
--- a/home/.zsh/alias/git.zsh
+++ b/home/.zsh/alias/git.zsh
@@ -1,313 +1,81 @@
-# https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh
+# Synced from https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh (MIT)
+# Custom additions live at the bottom under "Custom additions".
+# To sync upstream: diff this file against the URL above and update everything
+# except the "Custom additions" section.
 
 # Git version checking
 autoload -Uz is-at-least
-git_version=$(git --version | cut -d ' ' -f 3)
+git_version="${${(As: :)$(git version 2>/dev/null)}[3]}"
 
 #
-# Functions
+# Compatibility shim: standalone use (not in upstream git.plugin.zsh)
+# Upstream relies on `lib/git.zsh` for these. Kept here so this file works on
+# its own without the rest of oh-my-zsh.
 #
 
-# We wrap in a local function instead of exporting the variable directly in
-# order to avoid interfering with manually-run git commands by the user.
+# Wrap git so prompt-side calls don't fight with manually-run git
 function __git_prompt_git() {
   GIT_OPTIONAL_LOCKS=0 command git "$@"
 }
 
 # Outputs the name of the current branch
-# Usage example: git pull origin $(git_current_branch)
-# Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
-# it's not a symbolic ref, but in a Git repo.
 function git_current_branch() {
   local ref
   ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2>/dev/null)
   local ret=$?
   if [[ $ret != 0 ]]; then
-    [[ $ret == 128 ]] && return # no git repo.
+    [[ $ret == 128 ]] && return
     ref=$(__git_prompt_git rev-parse --short HEAD 2>/dev/null) || return
   fi
   echo ${ref#refs/heads/}
 }
 
-# Pretty log messages
-function _git_log_prettily() {
-  if ! [ -z $1 ]; then
-    git log --pretty=$1
-  fi
-}
-compdef _git _git_log_prettily=git-log
+#
+# Functions Current
+# (sorted alphabetically by function name)
+# (order should follow README)
+#
 
-# Warn if the current branch is a WIP
-function work_in_progress() {
-  if $(git log -n 1 2>/dev/null | grep -q -c "\-\-wip\-\-"); then
-    echo "WIP!!"
-  fi
-}
-
-# Check if main exists and use instead of master
-function git_main_branch() {
+# Check for develop and similarly named branches
+function git_develop_branch() {
   command git rev-parse --git-dir &>/dev/null || return
   local branch
-  for branch in main trunk; do
+  for branch in dev devel develop development; do
     if command git show-ref -q --verify refs/heads/$branch; then
       echo $branch
-      return
+      return 0
     fi
   done
+
+  echo develop
+  return 1
+}
+
+# Get the default branch name from common branch names or fallback to remote HEAD
+function git_main_branch() {
+  command git rev-parse --git-dir &>/dev/null || return
+
+  local remote ref
+
+  for ref in refs/{heads,remotes/{origin,upstream}}/{main,trunk,mainline,default,stable,master}; do
+    if command git show-ref -q --verify $ref; then
+      echo ${ref:t}
+      return 0
+    fi
+  done
+
+  # Fallback: try to get the default branch from remote HEAD symbolic refs
+  for remote in origin upstream; do
+    ref=$(command git rev-parse --abbrev-ref $remote/HEAD 2>/dev/null)
+    if [[ $ref == $remote/* ]]; then
+      echo ${ref#"$remote/"}; return 0
+    fi
+  done
+
+  # If no main branch was found, fall back to master but return error
   echo master
+  return 1
 }
-
-#
-# Aliases
-# (sorted alphabetically)
-#
-
-alias g='git'
-
-alias ga='git add'
-alias gaa='git add --all'
-alias gapa='git add --patch'
-alias gau='git add --update'
-alias gav='git add --verbose'
-alias gap='git apply'
-alias gapt='git apply --3way'
-
-alias gb='git branch'
-alias gba='git branch -a'
-alias gbd='git branch -d'
-alias gbda='git branch --no-color --merged | command grep -vE "^(\+|\*|\s*($(git_main_branch)|development|develop|devel|dev)\s*$)" | command xargs -n 1 git branch -d'
-alias gbD='git branch -D'
-alias gbl='git blame -b -w'
-alias gbnm='git branch --no-merged'
-alias gbr='git branch --remote'
-alias gbs='git bisect'
-alias gbsb='git bisect bad'
-alias gbsg='git bisect good'
-alias gbsr='git bisect reset'
-alias gbss='git bisect start'
-
-alias gc='git commit -v'
-alias gc!='git commit -v --amend'
-alias gcn!='git commit -v --no-edit --amend'
-alias gca='git commit -v -a'
-alias gca!='git commit -v -a --amend'
-alias gcan!='git commit -v -a --no-edit --amend'
-alias gcans!='git commit -v -a -s --no-edit --amend'
-alias gcam='git commit -a -m'
-alias gcsm='git commit -s -m'
-alias gcas='git commit -a -s'
-alias gcasm='git commit -a -s -m'
-alias gcb='git checkout -b'
-alias gcf='git config --list'
-alias gcl='git clone --recurse-submodules'
-alias gclean='git clean -id'
-alias gpristine='git reset --hard && git clean -dffx'
-alias gcm='git checkout $(git_main_branch)'
-alias gcd='git checkout develop'
-alias gcmsg='git commit -m'
-alias gco='git checkout'
-alias gcount='git shortlog -sn'
-alias gcp='git cherry-pick'
-alias gcpa='git cherry-pick --abort'
-alias gcpc='git cherry-pick --continue'
-alias gcs='git commit -S'
-
-alias gd='git diff'
-alias gdca='git diff --cached'
-alias gdcw='git diff --cached --word-diff'
-alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
-alias gds='git diff --staged'
-alias gdt='git diff-tree --no-commit-id --name-only -r'
-alias gdw='git diff --word-diff'
-
-function gdnolock() {
-  git diff "$@" ":(exclude)package-lock.json" ":(exclude)*.lock"
-}
-compdef _git gdnolock=git-diff
-
-function gdv() {
-  git diff -w "$@" | view -
-}
-compdef _git gdv=git-diff
-
-alias gf='git fetch'
-# --jobs=<n> was added in git 2.8
-is-at-least 2.8 "$git_version" &&
-  alias gfa='git fetch --all --prune --jobs=10' ||
-  alias gfa='git fetch --all --prune'
-alias gfo='git fetch origin'
-
-alias gfg='git ls-files | grep'
-
-alias gg='git gui citool'
-alias gga='git gui citool --amend'
-
-function ggf() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git push --force origin "${b:=$1}"
-}
-compdef _git ggf=git-checkout
-function ggfl() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git push --force-with-lease origin "${b:=$1}"
-}
-compdef _git ggfl=git-checkout
-
-function ggl() {
-  if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
-    git pull origin "${*}"
-  else
-    [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git pull origin "${b:=$1}"
-  fi
-}
-compdef _git ggl=git-checkout
-
-function ggp() {
-  if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
-    git push origin "${*}"
-  else
-    [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git push origin "${b:=$1}"
-  fi
-}
-compdef _git ggp=git-checkout
-
-function ggpnp() {
-  if [[ "$#" == 0 ]]; then
-    ggl && ggp
-  else
-    ggl "${*}" && ggp "${*}"
-  fi
-}
-compdef _git ggpnp=git-checkout
-
-function ggu() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git pull --rebase origin "${b:=$1}"
-}
-compdef _git ggu=git-checkout
-
-alias ggpur='ggu'
-alias ggpull='git pull origin "$(git_current_branch)"'
-alias ggpush='git push origin "$(git_current_branch)"'
-
-alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
-alias gpsup='git push --set-upstream origin $(git_current_branch)'
-
-alias ghh='git help'
-
-alias gignore='git update-index --assume-unchanged'
-alias gignored='git ls-files -v | grep "^[[:lower:]]"'
-alias git-svn-dcommit-push='git svn dcommit && git push github $(git_main_branch):svntrunk'
-
-alias gk='\gitk --all --branches'
-alias gke='\gitk --all $(git log -g --pretty=%h)'
-
-alias gl='git pull'
-alias glg='git log --stat'
-alias glgp='git log --stat -p'
-alias glgg='git log --graph'
-alias glgga='git log --graph --decorate --all'
-alias glgm='git log --graph --max-count=10'
-alias glo='git log --oneline --decorate'
-alias glol="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
-alias glols="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --stat"
-alias glod="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset'"
-alias glods="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset' --date=short"
-alias glola="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --all"
-alias glog='git log --oneline --decorate --graph'
-alias gloga='git log --oneline --decorate --graph --all'
-alias glp="_git_log_prettily"
-
-alias gm='git merge'
-alias gmom='git merge origin/$(git_main_branch)'
-alias gmt='git mergetool --no-prompt'
-alias gmtvim='git mergetool --no-prompt --tool=vimdiff'
-alias gmum='git merge upstream/$(git_main_branch)'
-alias gma='git merge --abort'
-
-alias gp='git push'
-alias gpd='git push --dry-run'
-alias gpf='git push --force-with-lease'
-alias gpf!='git push --force'
-alias gpoat='git push origin --all && git push origin --tags'
-alias gpu='git push upstream'
-alias gpv='git push -v'
-
-alias gr='git remote'
-alias gra='git remote add'
-alias grb='git rebase'
-alias grba='git rebase --abort'
-alias grbc='git rebase --continue'
-alias grbd='git rebase develop'
-alias grbi='git rebase -i'
-alias grbm='git rebase $(git_main_branch)'
-alias grbo='git rebase --onto'
-alias grbs='git rebase --skip'
-alias grev='git revert'
-alias grh='git reset'
-alias grhh='git reset --hard'
-alias groh='git reset origin/$(git_current_branch) --hard'
-alias grm='git rm'
-alias grmc='git rm --cached'
-alias grmv='git remote rename'
-alias grrm='git remote remove'
-alias grs='git restore'
-alias grset='git remote set-url'
-alias grss='git restore --source'
-alias grst='git restore --staged'
-alias grt='cd "$(git rev-parse --show-toplevel || echo .)"'
-alias gru='git reset --'
-alias grup='git remote update'
-alias grv='git remote -v'
-
-alias gsb='git status -sb'
-alias gsd='git svn dcommit'
-alias gsh='git show'
-alias gsi='git submodule init'
-alias gsps='git show --pretty=short --show-signature'
-alias gsr='git svn rebase'
-alias gss='git status -s'
-alias gst='git status'
-
-# use the default stash push on git 2.13 and newer
-is-at-least 2.13 "$git_version" &&
-  alias gsta='git stash push' ||
-  alias gsta='git stash save'
-
-alias gstaa='git stash apply'
-alias gstc='git stash clear'
-alias gstd='git stash drop'
-alias gstl='git stash list'
-alias gstp='git stash pop'
-alias gsts='git stash show --text'
-alias gstu='gsta --include-untracked'
-alias gstall='git stash --all'
-alias gsu='git submodule update'
-alias gsw='git switch'
-alias gswc='git switch -c'
-
-alias gts='git tag -s'
-alias gtv='git tag | sort -V'
-alias gtl='gtl(){ git tag --sort=-v:refname -n -l "${1}*" }; noglob gtl'
-
-alias gunignore='git update-index --no-assume-unchanged'
-alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
-alias gup='git pull --rebase'
-alias gupv='git pull --rebase -v'
-alias gupa='git pull --rebase --autostash'
-alias gupav='git pull --rebase --autostash -v'
-alias glum='git pull upstream $(git_main_branch)'
-
-alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
-alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"'
-
-alias gam='git am'
-alias gamc='git am --continue'
-alias gams='git am --skip'
-alias gama='git am --abort'
-alias gamscp='git am --show-current-patch'
 
 function grename() {
   if [[ -z "$1" || -z "$2" ]]; then
@@ -323,9 +91,397 @@ function grename() {
   fi
 }
 
+#
+# Functions Work in Progress (WIP)
+#
+
+# Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one
+function gunwipall() {
+  local _commit=$(git log --grep='--wip--' --invert-grep --max-count=1 --format=format:%H)
+
+  # Check if a commit without "--wip--" was found and it's not the same as HEAD
+  if [[ "$_commit" != "$(git rev-parse HEAD)" ]]; then
+    git reset $_commit || return 1
+  fi
+}
+
+# Warn if the current branch is a WIP
+function work_in_progress() {
+  command git -c log.showSignature=false log -n 1 2>/dev/null | grep -q -- "--wip--" && echo "WIP!!"
+}
+
+#
+# Aliases
+# (sorted alphabetically by command)
+#
+
+alias grt='cd "$(git rev-parse --show-toplevel || echo .)"'
+
+function ggpnp() {
+  if [[ $# == 0 ]]; then
+    ggl && ggp
+  else
+    ggl "${*}" && ggp "${*}"
+  fi
+}
+compdef _git ggpnp=git-checkout
+
+alias ggpur='ggu'
+alias g='git'
+alias ga='git add'
+alias gaa='git add --all'
+alias gapa='git add --patch'
+alias gau='git add --update'
+alias gav='git add --verbose'
+alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign --message "--wip-- [skip ci]"'
+alias gam='git am'
+alias gama='git am --abort'
+alias gamc='git am --continue'
+alias gamscp='git am --show-current-patch'
+alias gams='git am --skip'
+alias gap='git apply'
+alias gapt='git apply --3way'
+alias gbs='git bisect'
+alias gbsb='git bisect bad'
+alias gbsg='git bisect good'
+alias gbsn='git bisect new'
+alias gbso='git bisect old'
+alias gbsr='git bisect reset'
+alias gbss='git bisect start'
+alias gbl='git blame -w'
+alias gb='git branch'
+alias gba='git branch --all'
+alias gbd='git branch --delete'
+alias gbD='git branch --delete --force'
+
+function gbda() {
+  git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null
+}
+
+# Copied and modified from James Roeder (jmaroeder) under MIT License
+# https://github.com/jmaroeder/plugin-git/blob/216723ef4f9e8dde399661c39c80bdf73f4076c4/functions/gbda.fish
+function gbds() {
+  local default_branch=$(git_main_branch)
+  (( ! $? )) || default_branch=$(git_develop_branch)
+
+  git for-each-ref refs/heads/ "--format=%(refname:short)" | \
+    while read branch; do
+      local merge_base=$(git merge-base $default_branch $branch)
+      if [[ $(git cherry $default_branch $(git commit-tree $(git rev-parse $branch\^{tree}) -p $merge_base -m _)) = -* ]]; then
+        git branch -D $branch
+      fi
+    done
+}
+
+alias gbgd='LANG=C git branch --no-color -vv | grep ": gone\]" | cut -c 3- | awk '"'"'{print $1}'"'"' | xargs git branch -d'
+alias gbgD='LANG=C git branch --no-color -vv | grep ": gone\]" | cut -c 3- | awk '"'"'{print $1}'"'"' | xargs git branch -D'
+alias gbm='git branch --move'
+alias gbnm='git branch --no-merged'
+alias gbr='git branch --remote'
+alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
+alias gbg='LANG=C git branch -vv | grep ": gone\]"'
+alias gco='git checkout'
+alias gcor='git checkout --recurse-submodules'
+alias gcb='git checkout -b'
+alias gcB='git checkout -B'
+alias gcd='git checkout $(git_develop_branch)'
+alias gcm='git checkout $(git_main_branch)'
+alias gcp='git cherry-pick'
+alias gcpa='git cherry-pick --abort'
+alias gcpc='git cherry-pick --continue'
+alias gclean='git clean --interactive -d'
+alias gcl='git clone --recurse-submodules'
+alias gclf='git clone --recursive --shallow-submodules --filter=blob:none --also-filter-submodules'
+
+function gccd() {
+  setopt localoptions extendedglob
+
+  # get repo URI from args based on valid formats: https://git-scm.com/docs/git-clone#URLS
+  local repo="${${@[(r)(ssh://*|git://*|ftp(s)#://*|http(s)#://*|*@*)(.git/#)#]}:-$_}"
+
+  # clone repository and exit if it fails
+  command git clone --recurse-submodules "$@" || return
+
+  # if last arg passed was a directory, that's where the repo was cloned
+  # otherwise parse the repo URI and use the last part as the directory
+  [[ -d "$_" ]] && cd "$_" || cd "${${repo:t}%.git/#}"
+}
+compdef _git gccd=git-clone
+
+alias gcam='git commit --all --message'
+alias gcas='git commit --all --signoff'
+alias gcasm='git commit --all --signoff --message'
+alias gcs='git commit --gpg-sign'
+alias gcss='git commit --gpg-sign --signoff'
+alias gcssm='git commit --gpg-sign --signoff --message'
+alias gcmsg='git commit --message'
+alias gcsm='git commit --signoff --message'
+alias gc='git commit --verbose'
+alias gca='git commit --verbose --all'
+alias gca!='git commit --verbose --all --amend'
+alias gcan!='git commit --verbose --all --no-edit --amend'
+alias gcans!='git commit --verbose --all --signoff --no-edit --amend'
+alias gcann!='git commit --verbose --all --date=now --no-edit --amend'
+alias gc!='git commit --verbose --amend'
+alias gcn='git commit --verbose --no-edit'
+alias gcn!='git commit --verbose --no-edit --amend'
+alias gcf='git config --list'
+alias gcfu='git commit --fixup'
+alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
+alias gd='git diff'
+alias gdca='git diff --cached'
+alias gdcw='git diff --cached --word-diff'
+alias gds='git diff --staged'
+alias gdw='git diff --word-diff'
+
+function gdv() { git diff -w "$@" | view - }
+compdef _git gdv=git-diff
+
+alias gdup='git diff @{upstream}'
+
+function gdnolock() {
+  git diff "$@" ":(exclude)package-lock.json" ":(exclude)*.lock"
+}
+compdef _git gdnolock=git-diff
+
+alias gdt='git diff-tree --no-commit-id --name-only -r'
+alias gf='git fetch'
+# --jobs=<n> was added in git 2.8
+is-at-least 2.8 "$git_version" \
+  && alias gfa='git fetch --all --tags --prune --jobs=10' \
+  || alias gfa='git fetch --all --tags --prune'
+alias gfo='git fetch origin'
+alias gg='git gui citool'
+alias gga='git gui citool --amend'
+alias ghh='git help'
+alias glgg='git log --graph'
+alias glgga='git log --graph --decorate --all'
+alias glgm='git log --graph --max-count=10'
+alias glods='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset" --date=short'
+alias glod='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset"'
+alias glola='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ar) %C(bold blue)<%an>%Creset" --all'
+alias glols='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ar) %C(bold blue)<%an>%Creset" --stat'
+alias glol='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%ar) %C(bold blue)<%an>%Creset"'
+alias glo='git log --oneline --decorate'
+alias glog='git log --oneline --decorate --graph'
+alias gloga='git log --oneline --decorate --graph --all'
+
+# Pretty log messages
+function _git_log_prettily(){
+  if ! [ -z $1 ]; then
+    git log --pretty=$1
+  fi
+}
+compdef _git _git_log_prettily=git-log
+
+alias glp='_git_log_prettily'
+alias glg='git log --stat'
+alias glgp='git log --stat --patch'
+alias gignored='git ls-files -v | grep "^[[:lower:]]"'
+alias gfg='git ls-files | grep'
+alias gm='git merge'
+alias gma='git merge --abort'
+alias gmc='git merge --continue'
+alias gms="git merge --squash"
+alias gmff="git merge --ff-only"
+alias gmom='git merge origin/$(git_main_branch)'
+alias gmum='git merge upstream/$(git_main_branch)'
+alias gmtl='git mergetool --no-prompt'
+alias gmtlvim='git mergetool --no-prompt --tool=vimdiff'
+
+alias gl='git pull'
+alias gpr='git pull --rebase'
+alias gprv='git pull --rebase -v'
+alias gpra='git pull --rebase --autostash'
+alias gprav='git pull --rebase --autostash -v'
+
+function ggu() {
+  local b
+  [[ $# != 1 ]] && b="$(git_current_branch)"
+  git pull --rebase origin "${b:-$1}"
+}
+compdef _git ggu=git-pull
+
+alias gprom='git pull --rebase origin $(git_main_branch)'
+alias gpromi='git pull --rebase=interactive origin $(git_main_branch)'
+alias gprum='git pull --rebase upstream $(git_main_branch)'
+alias gprumi='git pull --rebase=interactive upstream $(git_main_branch)'
+alias ggpull='git pull origin "$(git_current_branch)"'
+
+function ggl() {
+  if [[ $# != 0 ]] && [[ $# != 1 ]]; then
+    git pull origin "${*}"
+  else
+    local b
+    [[ $# == 0 ]] && b="$(git_current_branch)"
+    git pull origin "${b:-$1}"
+  fi
+}
+compdef _git ggl=git-pull
+
+alias gluc='git pull upstream $(git_current_branch)'
+alias glum='git pull upstream $(git_main_branch)'
+alias gp='git push'
+alias gpd='git push --dry-run'
+
+function ggf() {
+  local b
+  [[ $# != 1 ]] && b="$(git_current_branch)"
+  git push --force origin "${b:-$1}"
+}
+compdef _git ggf=git-push
+
+alias gpf!='git push --force'
+is-at-least 2.30 "$git_version" \
+  && alias gpf='git push --force-with-lease --force-if-includes' \
+  || alias gpf='git push --force-with-lease'
+
+function ggfl() {
+  local b
+  [[ $# != 1 ]] && b="$(git_current_branch)"
+  git push --force-with-lease origin "${b:-$1}"
+}
+compdef _git ggfl=git-push
+
+alias gpsup='git push --set-upstream origin $(git_current_branch)'
+is-at-least 2.30 "$git_version" \
+  && alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease --force-if-includes' \
+  || alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease'
+alias gpv='git push --verbose'
+alias gpoat='git push origin --all && git push origin --tags'
+alias gpod='git push origin --delete'
+alias ggpush='git push origin "$(git_current_branch)"'
+
+function ggp() {
+  if [[ $# != 0 ]] && [[ $# != 1 ]]; then
+    git push origin "${*}"
+  else
+    local b
+    [[ $# == 0 ]] && b="$(git_current_branch)"
+    git push origin "${b:-$1}"
+  fi
+}
+compdef _git ggp=git-push
+
+alias gpu='git push upstream'
+alias grb='git rebase'
+alias grba='git rebase --abort'
+alias grbc='git rebase --continue'
+alias grbi='git rebase --interactive'
+alias grbo='git rebase --onto'
+alias grbs='git rebase --skip'
+alias grbd='git rebase $(git_develop_branch)'
+alias grbm='git rebase $(git_main_branch)'
+alias grbom='git rebase origin/$(git_main_branch)'
+alias grbum='git rebase upstream/$(git_main_branch)'
+alias grf='git reflog'
+alias gr='git remote'
+alias grv='git remote --verbose'
+alias gra='git remote add'
+alias grrm='git remote remove'
+alias grmv='git remote rename'
+alias grset='git remote set-url'
+alias grup='git remote update'
+alias grh='git reset'
+alias gru='git reset --'
+alias grhh='git reset --hard'
+alias grhk='git reset --keep'
+alias grhs='git reset --soft'
+alias gpristine='git reset --hard && git clean --force -dfx'
+alias gwipe='git reset --hard && git clean --force -df'
+alias groh='git reset origin/$(git_current_branch) --hard'
+alias grs='git restore'
+alias grss='git restore --source'
+alias grst='git restore --staged'
+alias gunwip='git rev-list --max-count=1 --format="%s" HEAD | grep -q "\--wip--" && git reset HEAD~1'
+alias grev='git revert'
+alias greva='git revert --abort'
+alias grevc='git revert --continue'
+alias grm='git rm'
+alias grmc='git rm --cached'
+alias gcount='git shortlog --summary --numbered'
+alias gsh='git show'
+alias gsps='git show --pretty=short --show-signature'
+alias gstall='git stash --all'
+alias gstaa='git stash apply'
+alias gstc='git stash clear'
+alias gstd='git stash drop'
+alias gstl='git stash list'
+alias gstp='git stash pop'
+# use the default stash push on git 2.13 and newer
+is-at-least 2.13 "$git_version" \
+  && alias gsta='git stash push' \
+  || alias gsta='git stash save'
+alias gsts='git stash show --patch'
+alias gst='git status'
+alias gss='git status --short'
+alias gsb='git status --short --branch'
+alias gsi='git submodule init'
+alias gsu='git submodule update'
+alias gsd='git svn dcommit'
+alias git-svn-dcommit-push='git svn dcommit && git push github $(git_main_branch):svntrunk'
+alias gsr='git svn rebase'
+alias gsw='git switch'
+alias gswc='git switch --create'
+alias gswd='git switch $(git_develop_branch)'
+alias gswm='git switch $(git_main_branch)'
+alias gta='git tag --annotate'
+alias gts='git tag --sign'
+alias gtv='git tag | sort -V'
+alias gignore='git update-index --assume-unchanged'
+alias gunignore='git update-index --no-assume-unchanged'
+alias gwch='git log --patch --abbrev-commit --pretty=medium --raw'
+alias gwt='git worktree'
+alias gwta='git worktree add'
+alias gwtls='git worktree list'
+alias gwtmv='git worktree move'
+alias gwtrm='git worktree remove'
+alias gstu='gsta --include-untracked'
+alias gtl='gtl(){ git tag --sort=-v:refname -n --list "${1}*" }; noglob gtl'
+alias gk='\gitk --all --branches &!'
+alias gke='\gitk --all $(git log --walk-reflogs --pretty=%h) &!'
+
 unset git_version
 
-# NOTE: custom workflow
+# Logic for adding warnings on deprecated aliases or functions
+local old_name new_name
+for old_name new_name (
+  current_branch  git_current_branch
+); do
+  aliases[$old_name]="
+    print -Pu2 \"%F{yellow}[oh-my-zsh] '%F{red}${old_name}%F{yellow}' is deprecated, using '%F{green}${new_name}%F{yellow}' instead.%f\"
+    $new_name"
+done
+unset old_name new_name
+
+#
+# Custom additions (not from upstream)
+# Keep upstream sync confined to the section above this line.
+#
+
+# Override upstream gpristine with a more aggressive form: `-ff` makes
+# `git clean` descend into untracked nested git repos (submodules / cloned
+# folders) and `-x` ignores .gitignore. Intentional: I want truly pristine.
+alias gpristine='git reset --hard && git clean -dffx'
+
+# Short aliases I prefer over upstream's gmtl / gmtlvim. Both names coexist.
+alias gmt='git mergetool --no-prompt'
+alias gmtvim='git mergetool --no-prompt --tool=vimdiff'
+
+# Custom pull --rebase shortcuts. Upstream uses gpr / gprv / gpra / gprav;
+# I keep these for muscle memory.
+alias gup='git pull --rebase'
+alias gupv='git pull --rebase -v'
+alias gupa='git pull --rebase --autostash'
+alias gupav='git pull --rebase --autostash -v'
+
+# Worktree shortcut. Upstream's gwt does the same; gw kept for muscle memory.
+alias gw='git worktree'
+
+# Undo last commit but keep changes staged.
+alias greset='git reset --soft HEAD^'
+
+# Sync current branch onto main: stash → checkout main → pull → return → rebase → pop.
 function gmm() {
   git stash push
   git checkout main
@@ -340,13 +496,9 @@ function gmm() {
   fi
 }
 
-alias greset='git reset --soft HEAD^'
-
-# git worktree
-alias gw='git worktree'
-
-# 作ったはいいが遅いし、lefthookでなぜかcommit message落とされる。featとかのとこに色がついてるのが原因な気がする
-# commit message
+# AI-generated conventional commit message via copilot CLI.
+# 作ったはいいが遅いし、lefthook でなぜか commit message が落とされる。
+# feat/fix 等の色付けが原因な気がする。
 gcai() {
   if git diff --staged --quiet; then
     echo "No staged changes to commit"
@@ -369,7 +521,7 @@ gcai() {
 
   local output=$(copilot --prompt "$prompt")
 
-  # conventional commit形式の行を探す
+  # conventional commit 形式の行を探す
   local msg=$(echo "$output" | grep -E '^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\([^)]+\))?:' | head -1)
 
   [ -z "$msg" ] && echo "Failed to generate" && return 1


### PR DESCRIPTION
## 概要

`home/.zsh/alias/git.zsh` を [ohmyzsh/ohmyzsh の git.plugin.zsh](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh) (MIT) と再同期し、自分のカスタム部分をファイル末尾の `Custom additions` 節に隔離した。今後 upstream を取り込む時は、この節より上だけ差分を当てれば済む。

## upstream に揃えた挙動変更（自分の旧版と差があったもの）

- `gcd` / `grbd` / `gswd`: ハードコード `develop` から `$(git_develop_branch)` に。`dev` / `devel` / `development` のリポジトリでも動く
- `git_main_branch()`: `mainline` / `default` / `stable` と remote HEAD の symbolic ref も解決する upstream 版に
- `gk` / `gke`: 末尾 `&!` でバックグラウンド起動 + disown
- `gsts`: `--text` → `--patch`（stash 中身を diff として表示）
- `gunwip`: `git rev-list --format=%s` を使う堅牢版に。`log.showSignature=true` の影響を受けない
- `gwch`: `git whatchanged` → `git log --patch --raw`
- `glol` / `glola` / `glols`: `%cr`（committer relative）→ `%ar`（author relative）
- `gbl`: `-b` を削除（root commit を空白表示する挙動を解除）
- `gpf` / `gpsupf`: git ≥ 2.30 で `--force-if-includes` を付与する分岐に
- `gtl`: `-l` → `--list`
- `work_in_progress()`: `git -c log.showSignature=false log` で gpg 署名表示の影響を排除
- `git_version` 抽出: alias 拡張に強い zsh パラメータ展開方式に
- 短縮 flag を長形式に統一（`-v` → `--verbose` 等、挙動同一）

## 追加された関数 / alias（upstream 由来）

- 関数: `git_develop_branch`, `gunwipall`, `gbds`, `gccd`, `gbda`（関数化）
- alias 46 個: `gbg` / `gbgd` / `gbgD`, `gbsn` / `gbso`, `gcB`, `gcor`, `gcfu`, `gcn`, `gcss` / `gcssm`, `gcann!`, `gclf`, `gdup`, `gluc`, `gmc` / `gms` / `gmff`, `gmtl` / `gmtlvim`, `gpr` 系（`gpr` / `gprv` / `gpra` / `gprav` / `gprom(i)` / `gprum(i)`）, `gpod`, `grbom` / `grbum`, `grf`, `grhk` / `grhs`, `greva` / `grevc`, `gswd` / `gswm`, `gta`, `gwipe`, `gwt` 系（`gwt` / `gwta` / `gwtls` / `gwtmv` / `gwtrm`）
- `current_branch` → `git_current_branch` の deprecation warning

## standalone 動作のために残したもの

upstream は `lib/git.zsh` に分離した `__git_prompt_git` と `git_current_branch` を、`Compatibility shim` 節として冒頭に保持。これが無いと `lib/git.zsh` を別途 source しないと alias が動かない。

## `Custom additions` 節（末尾、自分専用）

- `gpristine='git reset --hard && git clean -dffx'`: upstream を override。`-ff` で untracked nested git repo まで削除する強い版を維持
- `gmt` / `gmtvim`: upstream の `gmtl` / `gmtlvim` と並存
- `gup` / `gupv` / `gupa` / `gupav`: upstream の `gpr` 系と並存（指の筋肉記憶用）
- `gw`: upstream の `gwt` と並存
- `greset`: `git reset --soft HEAD^`
- `gmm()` / `gcai()`: 自分のワークフロー関数

## 動作確認

- [x] `zsh -n home/.zsh/alias/git.zsh` で構文チェック OK
- [ ] 新しいシェルで source して、よく使う alias（`gst` / `gco` / `gcb` / `gp` / `gpf` / `gmm` / `gcai`）が動くこと
- [ ] `gcd` が `develop` / `dev` / `devel` / `development` を順に探すこと
- [ ] `gk` がフォアグラウンドをブロックしないこと
