### PR TITLE
chore: drop tflint after homebrew-core removal

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -62,9 +62,6 @@ if OS.mac?
   # OpenTofu / Terraform / Terragrunt / Terramate / Atmos version manager https://tofuutils.github.io/tenv/
   brew "tenv"
 
-  # Linter for Terraform files https://github.com/terraform-linters/tflint
-  brew "tflint"
-
   # Tool to generate documentation from Terraform modules https://terraform-docs.io/
   brew "terraform-docs"
 


### PR DESCRIPTION
## Summary

`tflint` を Brewfile から削除します（一旦の暫定対応）。

## 背景

tflint は 2026-05-13 に [homebrew-core から削除](https://github.com/Homebrew/homebrew-core/pull/282587) されました。tflint のコード一部が Terraform 本体由来で **BUSL-1.1** ライセンスを含むようになり、Homebrew の [License Guidelines](https://docs.brew.sh/License-Guidelines)（OSI 承認 license のみ許可）に違反するため即時 remove 対象になったというのが理由です。

これにより [Run #25911329158](https://github.com/nozomiishii/dotfiles/actions/runs/25911329158) のように `brew bundle` が `No available formula with the name "tflint"` で失敗するようになっています。

## 経緯

- Homebrew 側で BUSL コード除去 PR ([terraform-linters/tflint#2509](https://github.com/terraform-linters/tflint/pull/2509)) が出されたが、tflint maintainer の wata727 が拒否
  - 「TFLint は "Terraform" linter なので BUSL 由来コードへの依存は外せない」
  - 「OpenTofu 移行も [discussions/2465](https://github.com/terraform-linters/tflint/discussions/2465) で議論済みだが受け入れない」
- 代替策として `terraform-linters` org に homebrew-tap を作る方向で合意（未着手）
- canonical な議論スレッド: [terraform-linters/tflint discussions/2528](https://github.com/terraform-linters/tflint/discussions/2528)

## 今後の方針

このPRは「CI を一旦通す」ための暫定削除です。次のいずれかへの置き換えを別 PR で検討:

1. `terraform-linters/homebrew-tap` の登場待ち（既に合意あり、まだ未作成）
2. **aqua / mise** 経由で GitHub Releases から取る
3. **Docker image** (`ghcr.io/terraform-linters/tflint`) 利用
4. OpenTofu 側で代替 linter が出てくるのを待つ

## Test plan

- [ ] CI で `brew bundle` の install ジョブが成功すること
