### PR TITLE
chore: clarify routines vs loop in global CLAUDE.md

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -4,6 +4,16 @@
 
 - 日本語で応答する。コード・コマンド・技術用語はそのまま使用してよい。
 
+## 用語
+
+- 「ルーティン」「Routines」は **Claude Code の Routines 機能**を指す。Anthropic-managed cloud 上で動く saved Claude Code session で、scheduled / API / GitHub event の trigger で実行される。管理 UI は <https://claude.ai/code/routines>。CLI からは `/schedule` で作成（`/schedule` は Routines を作る一 surface であり、別機能ではない。将来 `/schedule` が無くなって `/routines` 系に統一される可能性もある）。
+- 公式ドキュメント: <https://code.claude.com/docs/en/routines> (旧 docs.anthropic.com 配下は 301 で同 URL に redirect)
+- 以下は **Routines とは別物**。混同しないこと:
+  - `/loop` skill / in-session scheduling: 開いている CLI session 内で prompt を interval / 自律ペースで繰り返す機能。cloud では動かない。<https://code.claude.com/docs/en/scheduled-tasks>
+  - Desktop scheduled tasks: ローカル Mac 上で動く scheduled task。<https://code.claude.com/docs/en/desktop-scheduled-tasks>
+  - OS の cron / launchd: dotfiles 側のローカルスケジューラ。
+- ユーザーが「ルーティン」「Routines」と言ったらまず **cloud Routines（claude.ai/code/routines）** を前提に動くこと。loop / Desktop scheduled tasks / OS cron として解釈するのは、文脈上明らかにそれを指している場合に限る。仕様確認は上記公式ドキュメントを起点にする。
+
 ## パーミッション・sandbox
 
 - コマンド実行の許可を確認する時は、Bash ツールの `description` に「何をするコマンドか」と「なぜこの実行が必要か」を日本語で簡潔に記述すること。例: 「PR を作成（GitHub API へのネットワークアクセスのため sandbox 外）」


### PR DESCRIPTION
## Summary

グローバル CLAUDE.md の「言語」直下に「用語」セクションを新設し、「ルーティン / Routines」が **Claude Code の Routines 機能** ([claude.ai/code/routines](https://claude.ai/code/routines)) を指すことを明示。混同しやすい以下と区別する:

- `/loop` skill / in-session scheduling — 開いている CLI session 内で prompt を繰り返す。cloud では動かない
- Desktop scheduled tasks — ローカル Mac 上で動く scheduled task
- OS の cron / launchd — dotfiles 側のローカルスケジューラ

## なぜ

Routines を調整するたびに Claude Code 側で `/loop` や cron job と取り違えられ、毎回最新ドキュメントを読み直す手戻りが発生していた。グローバル指示に **デフォルト解釈と公式リンク集**を持たせることで、取り違えを抑え情報を追える状態にする。

## 公式ドキュメント (本文にも記載)

- <https://code.claude.com/docs/en/routines> (canonical, 旧 `docs.anthropic.com/en/docs/claude-code/routines` は 301 redirect)
- <https://code.claude.com/docs/en/scheduled-tasks> (`/loop` / in-session)
- <https://code.claude.com/docs/en/desktop-scheduled-tasks> (Desktop 用)

## Test plan

- [ ] worktree 側の `home/.claude/CLAUDE.md` に「用語」セクションが追加されていること
- [ ] merge 後は `make link` 不要（既存シンボリックリンク経由で `~/.claude/CLAUDE.md` に自動反映）
- [ ] 新規 session で「ルーティン」と発話したとき、cloud Routines として解釈される (`/loop` や cron job と取り違えない) こと
