### PR TITLE
chore: allow make in global settings

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -56,6 +56,7 @@
       "Bash(nix:*)",
       "Bash(home-manager:*)",
       "Bash(brew:*)",
+      "Bash(make:*)",
       "Bash(tar:*)",
       "Bash(unzip:*)",
       "Bash(curl:*)",


### PR DESCRIPTION
## Summary

グローバル設定の `permissions.allow` に `Bash(make:*)` を追加します。

## 背景

infra リポジトリの `.claude/settings.local.json` に `Bash(make:*)` のルールが溜まっていたためグローバルに集約します。`sandbox.excludedCommands` には既に `make:*` が入っているため、ここに追加することで auto mode 下で承認なしに make を実行できるようになります。

他に local 側にあった terraform / dotenv-linter / WebFetch(registry.terraform.io) は OpenTofu へ移行したため不要となり、global へは持ち込みません。
