### PR TITLE
chore: add prettier --cache flag to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "pnpm markdownlint:fix",
     "markdownlint": "npx -y markdownlint-cli2@latest '**/*.md' '#node_modules'",
     "markdownlint:fix": "npx -y markdownlint-cli2-fix@latest '**/*.md' '#node_modules'",
-    "prettier": "prettier --ignore-unknown",
+    "prettier": "prettier --ignore-unknown --cache",
     "test": "node --version",
     "test:perf": "bash scripts/test_shell_startup_time.sh"
   },


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の最新 init template に合わせて、`prettier` script に `--cache` flag を追加する。

## 背景

configs リポジトリの nozomiishii/configs#2285 で `nozo-prettier-init` の生成 scripts が更新され、`--cache` を `prettier` script に集約する形になった (`format` / `format:fix` script は action のみを持つ)。既存 repo は古い init template の名残で `--cache` が無いため、手動で揃える。

## 変更

- root `package.json` の `scripts.prettier` に `--cache` を追加: `prettier --ignore-unknown` → `prettier --ignore-unknown --cache`

## 影響範囲

`pnpm prettier` / `pnpm format` / `pnpm format:fix` 実行時に `node_modules/.cache/prettier/.prettier-cache` がキャッシュとして使われ高速化される。出力結果に変化なし。

## 注記

検証中に `pnpm format` 実行で既存の format 違反が 22 ファイル検出された (本 PR の変更とは無関係で、main 時点から存在)。指示により本 PR では fix せず、別途対応とする。
