### PR TITLE
feat: add cmux Dock control for lazygit on active worktree

### DIFF
--- a/home/.config/cmux/dock.json
+++ b/home/.config/cmux/dock.json
@@ -1,0 +1,9 @@
+{
+  "controls": [
+    {
+      "id": "lazygit",
+      "title": "lazygit",
+      "command": "$HOME/.config/cmux/lazygit-here.sh"
+    }
+  ]
+}

--- a/home/.config/cmux/lazygit-here.sh
+++ b/home/.config/cmux/lazygit-here.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# cmux Dock control launcher: open lazygit on the active Claude Code worktree.
+#
+# Why this script exists:
+#   The Dock terminal opens at the workspace cwd. For a cmux-launched
+#   `claude --worktree` session that cwd is the MAIN checkout (e.g. ~/dotfiles),
+#   not the worktree. Claude Code does its live edits in
+#   <repo>/.claude/worktrees/<name>, so window-inherit-working-directory alone
+#   never lands here. We hop to the most recently modified worktree before
+#   launching lazygit so the Dock shows the diff the agent is actually editing.
+#
+# Heuristic: newest .claude/worktrees/<name> by mtime. Good for a single active
+# agent; with several parallel agents in one repo it may pick the wrong one
+# (revisit with a CMUX_WORKSPACE_ID-keyed mapping if that becomes a problem).
+#
+# Set LAZYGIT_HERE_DRYRUN=1 to print the resolved directory and exit (tests).
+
+# Resolve the main checkout root (works whether cwd is the main checkout or a
+# linked worktree: --git-common-dir always points at the shared .git).
+if common=$(git rev-parse --git-common-dir 2>/dev/null); then
+  root=$(cd "$(dirname "$common")" && pwd)
+else
+  root=$(pwd)
+fi
+
+target="$root"
+if [ -d "$root/.claude/worktrees" ]; then
+  latest=$(ls -dt "$root"/.claude/worktrees/*/ 2>/dev/null | head -n1)
+  [ -n "$latest" ] && target="${latest%/}"
+fi
+
+if [ -n "${LAZYGIT_HERE_DRYRUN:-}" ]; then
+  printf 'root=%s\ntarget=%s\n' "$root" "$target"
+  exit 0
+fi
+
+cd "$target" || exit 1
+exec lazygit


### PR DESCRIPTION
## 概要

cmux の **Dock コントロール**で、クリック一発で右側に lazygit を「いま agent が編集している worktree」で起動するための設定とランチャースクリプトを追加する。

- `home/.config/cmux/dock.json` — Dock に `lazygit` コントロールを 1 つ定義（グローバル設定 `~/.config/cmux/dock.json` に stow される）
- `home/.config/cmux/lazygit-here.sh` — worktree を解決して lazygit を起動するランチャー

## なぜ draft か

Dock 機能自体は cmux に**実装済み**（[manaflow-ai/cmux#3936](https://github.com/manaflow-ai/cmux/issues/3936) がソース構造 `RightSidebarMode.dock` / `DockControlDefinition` を、[#4109](https://github.com/manaflow-ai/cmux/issues/4109) が CLI `cmux right-sidebar … dock` の shipped を裏付け）。

ただし draft で寝かせる理由が 2 つ:

1. **worktree ターゲティングが未解決**（下記 TODO）。これは upstream の [#4315](https://github.com/manaflow-ai/cmux/issues/4315) と同じ問題。
2. 実装時の手元 cmux 0.64.7 では `cmux right-sidebar dock` が `mode 'dock' is not available` を返した。これは機能欠如ではなく、**起動中インスタンスが新規 `dock.json` を未ロードのため**（`cmux reload-config` は ghostty config + cmux.json のみで dock.json を読まない）。**cmux 再起動で表示される見込み**。

## 仕組み

Dock の端末はワークスペースの cwd（= main checkout、例 `~/dotfiles`）で開くが、`claude --worktree` の実作業は `.claude/worktrees/<name>` で行われる。`window-inherit-working-directory` では worktree に着地しないため、スクリプト側で:

1. `git rev-parse --git-common-dir` で main checkout のルートを解決（worktree 内から呼んでも可）
2. `.claude/worktrees/*` のうち mtime 最新へ hop
3. `exec lazygit`

`LAZYGIT_HERE_DRYRUN=1` で解決先ディレクトリを表示して終了（テスト用）。

## 既知の課題 / 今後の TODO

- **並列 agent 環境で worktree を取り違える**。mtime 最新ヒューリスティックは、複数ワークスペースが同時稼働していると別ワークスペースの worktree を掴むことがある（実機で再現済み）。
- **これは upstream でも認識されている**: [manaflow-ai/cmux#4315](https://github.com/manaflow-ai/cmux/issues/4315) 「lazygit in Dock would be more useful with "current workspace directory"」が、グローバル dock の lazygit が `$HOME` 起点になる問題と「ワークスペースのディレクトリ追従」を要望中。cmux 側で解決されればスクリプトの hop ロジックは不要になる可能性がある。
- 当面の対応案: dock 端末にも入る `CMUX_WORKSPACE_ID` を鍵に「このワークスペースの worktree」を確定する。
  - A. dock スクリプトが同一 `CMUX_WORKSPACE_ID` を持つ `claude` プロセスを `ps eww` の env で特定し、その cwd を `lsof` で取得
  - B. Claude Code の SessionStart hook が worktree を `~/.cache/cmux-worktree/$CMUX_WORKSPACE_ID` に記録 → dock スクリプトが読む

## 関連 upstream issue（manaflow-ai/cmux）

- [#4315](https://github.com/manaflow-ai/cmux/issues/4315) lazygit in Dock would be more useful with "current workspace directory"（OPEN, 最終更新 2026-05-18）— **本 PR の worktree/cwd 問題そのもの**
- [#4109](https://github.com/manaflow-ai/cmux/issues/4109) Expose right-sidebar actions as built-in action IDs for surface tab bar / title bar（OPEN, 2026-05-13, 👍1）— 右サイドバーをクリック可能 UI 要素にピン留めする話。`cmux.json` の `actions` registry / `type: command` アクションに言及があり、将来「クリックできるボタン化」を詰める際の参考
- [#3936](https://github.com/manaflow-ai/cmux/issues/3936) Make the cmux Dock composable（OPEN, 2026-05-12）— Dock を terminal 以外（browser 等）も載せられるようにする提案。`DockControlDefinition` スキーマの一次情報
- [#4375](https://github.com/manaflow-ai/cmux/issues/4375) Allow configurable max width for the Dock（OPEN, 2026-05-19）— Dock 幅が ~360pt で頭打ち。lazygit 用に広げたい場合に関連

## 動作確認

- `python3 -m json.tool` で dock.json の JSON 検証 OK
- `LAZYGIT_HERE_DRYRUN=1` でドライラン → worktree 解決を確認（並列取り違えの課題もこれで判明）
- `stow --restow` で `~/.config/cmux/{dock.json,lazygit-here.sh}` の symlink 作成を確認
- `cmux reload-config` → `OK`（ただし reload-config は dock.json を読まないことも確認）

## 参考

- cmux Dock 仕様: https://cmux.com/docs/dock
