### PR TITLE
feat: add /broadcast skill for cross-repo changes

### DIFF
--- a/home/.claude/skills/broadcast/SKILL.md
+++ b/home/.claude/skills/broadcast/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: broadcast
+description: >-
+  projects.json で管理されている複数の独立 repo に、同じ変更を横断適用（broadcast）する。
+  ユーザーが /broadcast と入力したとき、または「workspaces のプロジェクト全部に〜したい」「横断で〜入れたい」と言ったときに使用する。
+  第 1 引数が既存ディレクトリならその配下の projects.json を、それ以外は ~/Code/nozomiishii/workspaces/projects.json を対象にする。
+  公式 bundled の /batch（1 つの repo を 5-30 ユニットに分解して worktree 並列実行）とは別物。こちらは N 個の repo への同一変更 broadcast。
+---
+
+# /broadcast
+
+projects.json に列挙された `enabled: true` の全プロジェクト（それぞれ独立した repo）に対し、同じ変更（CODEOWNERS 追加、workflow 更新、設定ファイルの一括同期、依存パッケージのバージョン揃え、など）を横断で broadcast する。
+
+> **公式 `/batch` との違い**: bundled の `/batch` は **1 つの codebase** を 5-30 の独立ユニットに分解して各々を git worktree で並列実装する。`/broadcast` は **複数の別 repo** に **同一の変更**を撒く。対象も粒度も別物。
+
+ユーザーが `/broadcast` を実行した時点で、横断変更の依頼とみなす。
+
+## 引数
+
+```
+/broadcast [<projects-json-dir>] <変更内容の指示...>
+```
+
+- 第 1 引数が既存ディレクトリ → そこを `<projects-json-dir>` として `<dir>/projects.json` を読む
+- 第 1 引数がディレクトリでない → 全引数を指示として扱い、`<projects-json-dir>` は `~/Code/nozomiishii/workspaces` をデフォルトにする
+- 指示部分が空のとき → ユーザーに「何を適用するか」を聞いて止まる（projects.json の一覧だけ読み込んで提示してよい）
+
+## 0. projects.json を読む
+
+```bash
+PROJECTS_JSON="${PROJECTS_JSON_DIR:-$HOME/Code/nozomiishii/workspaces}/projects.json"
+jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSON"
+```
+
+- `enabled: false` は対象外
+- `rootPath` の `~` は `$HOME` に展開する（`jq` 後に shell or 自前で展開）
+- **パスを見ての事前絞り込みは絶対にしない**。「Obsidian の iCloud パスっぽいから git じゃないだろう」などの推測で対象から外さない（実例として `🪴 brain` = `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` は git リポジトリで、CODEOWNERS など共通設定の対象になる）
+
+## 1. 対象リストを提示する
+
+実行前に、対象候補と適用予定の変更内容をユーザーに見せる。形式は表でよい:
+
+```
+| name          | rootPath                              | 対象ファイル有無 |
+|---------------|---------------------------------------|------------------|
+| 🧙🏿‍♂️ dotfiles | ~/dotfiles                            | あり             |
+| 🪴 brain      | ~/Library/.../Documents               | なし             |
+| 🛰️ infra      | ~/Code/nozomiishii/infra              | あり             |
+| ...           | ...                                   | ...              |
+```
+
+- 「対象ファイル有無」は変更内容に応じて事前 check した結果（例: CODEOWNERS 更新なら `.github/CODEOWNERS` の存在、workflow なら `.github/workflows/<name>.yaml` など）
+- 対象ファイルが無いプロジェクトは「新規作成するか / スキップするか」をユーザーに判断してもらう
+- ユーザーが OK を出したら次に進む
+
+## 2. 各プロジェクトで変更を適用する
+
+プロジェクト数と変更の複雑さに応じて選ぶ:
+
+- **数件 or 変更が単純**（1 ファイル sed 相当）: foreground で順に処理。`git -C <rootPath>` で操作する
+- **多数 or 変更にコンテキスト判断が要る**（コミットメッセージ自動生成、conflict 解消、新規ファイル雛形作成など）: `superpowers:dispatching-parallel-agents` を使って各プロジェクトを別 Agent に dispatch する
+
+各プロジェクトで実行する典型ステップ:
+
+1. `git -C <rootPath> status --short` で clean か確認（dirty なら本人に判断を委ねる）
+2. ブランチを切る: `git -C <rootPath> fetch origin main && git -C <rootPath> checkout -b <branch> origin/main`
+3. 変更を適用する
+4. commit & push（コミットメッセージは各 repo の commitlint ルールに従う）
+5. 必要なら `/ta` 相当で PR まで作成する（ユーザーが PR まで欲しいと言った場合のみ）
+
+## 3. 結果を報告する
+
+完了時に以下を 1 表で出す:
+
+```
+| name          | 結果        | 詳細                       |
+|---------------|-------------|----------------------------|
+| 🧙🏿‍♂️ dotfiles | ✅ commit済 | branch: chore/add-foo      |
+| 🪴 brain      | ⏭ skip      | 対象ファイル無し           |
+| 🛰️ infra      | ⚠ 要判断    | git dirty, 本人確認        |
+| ...           | ...         | ...                        |
+```
+
+「変更したプロジェクト」「スキップしたプロジェクト」「ユーザー判断が必要なプロジェクト」を明確に分けて報告する。
+
+## 制約
+
+- **`projects.json` を編集しないこと**。skill の責務は projects.json を「読む」ことだけで、プロジェクト一覧の追加/削除はユーザーが手で `~/Code/nozomiishii/workspaces` を編集する
+- **PR のマージは絶対に実行しない**（`/ta`・`/pr` skill の制約と同じ）
+- **git 操作は `cd <path> && git` でなく `git -C <path>` を使う**（bare repository attack 防止の sandbox 制約）
+- worktree でも動くよう `git checkout main` は使わず `git fetch origin main && git checkout -b <branch> origin/main` を使う
+- 変更内容が repo によって意味的に違う場合（例: 各 repo の独自命名規則が絡む）は、ユーザーに「同じ変更でいいか / repo ごとに差分があるか」を確認してから進める


### PR DESCRIPTION
## 概要

複数の独立 repo に同じ変更を横断適用（broadcast）する personal skill `/broadcast` を追加。

`~/Code/nozomiishii/workspaces/projects.json` の `enabled: true` な全プロジェクトを起点に、CODEOWNERS 追加・workflow 更新・設定ファイル同期などの同一変更を各 repo へ撒くワークフローを skill 化した。

## 公式 `/batch` との衝突回避

当初 `/batch` という名前で作ったが、Claude Code の bundled skill に同名の `/batch` が存在することが判明したため `/broadcast` にリネーム。personal skill は bundled skill を shadow するため、衝突すると公式 `/batch` が使えなくなる。

| 軸 | 公式 `/batch`（bundled） | `/broadcast`（本 PR） |
|---|---|---|
| 対象 | 1 つの repo を 5-30 ユニットに分解 | N 個の別 repo |
| 起点 | 自然言語の指示 | projects.json |
| 実行 | git worktree + background subagent | foreground or 並列 Agent |
| PR | 各 unit ごとに 1 本 | 各 repo ごとに 1 本（任意） |

## 設計のポイント

- パスを見ての事前絞り込み禁止（`🪴 brain` の iCloud パスも git repo なので対象に含める）
- `projects.json` 自体は編集しない（一覧の増減はユーザーが手で行う）
- 多数・複雑な変更は `superpowers:dispatching-parallel-agents` 経由で並列 dispatch
- worktree でも動くよう `git -C <path>` と `git fetch origin main && git checkout -b ... origin/main` を強制
- マージは絶対にしない（`/ta`・`/pr` と同じ制約）

## 補足

`home/.claude/skills/` 配下に置くことで GNU Stow 経由で `~/.claude/skills/broadcast` にシンボリックリンクされ、全 session で利用可能になる。
