### PR TITLE
feat: add biweekly Claude Code insights report

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -58,6 +58,9 @@ if OS.mac?
   # GitHub command-line tool. https://github.com/cli/cli
   brew "gh"
 
+  # Send macOS notifications from the command line https://github.com/julienXX/terminal-notifier
+  brew "terminal-notifier"
+
   # ----------------------------------------------------------------
   # OpenTofu / Terraform / Terragrunt / Terramate / Atmos version manager https://tofuutils.github.io/tenv/
   brew "tenv"

--- a/home/Library/LaunchAgents/local.claude-insights.plist
+++ b/home/Library/LaunchAgents/local.claude-insights.plist
@@ -10,11 +10,13 @@
     <string>/bin/bash</string>
     <string>-l</string>
     <string>-c</string>
-    <!-- claude バイナリを Homebrew PATH で解決し、$HOME を bash 展開で解決するためログインシェルで起動 -->
+    <!-- $HOME を bash 展開で解決するためログインシェルで起動。claude(~/.local/bin) の
+         PATH 追加はスクリプト側で行う（login bash の PATH には入らないため） -->
     <string>exec "$HOME/dotfiles/scripts/darwin/claude_insights.sh"</string>
   </array>
 
-  <!-- 毎月 1 日・15 日の 10:00 に実行（月 2 回）。スリープ中なら起床時に 1 回拾う -->
+  <!-- 毎月 1 日・15 日の 10:00 に実行（月 2 回）。発火時刻にスリープなら起床時に取りこぼし分を
+       1 回実行する。電源オフのまま跨いだ回はスキップされる -->
   <key>StartCalendarInterval</key>
   <array>
     <dict>

--- a/home/Library/LaunchAgents/local.claude-insights.plist
+++ b/home/Library/LaunchAgents/local.claude-insights.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>local.claude-insights</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-l</string>
+    <string>-c</string>
+    <!-- claude バイナリを Homebrew PATH で解決し、$HOME を bash 展開で解決するためログインシェルで起動 -->
+    <string>exec "$HOME/dotfiles/scripts/darwin/claude_insights.sh"</string>
+  </array>
+
+  <!-- 毎月 1 日・15 日の 10:00 に実行（月 2 回）。スリープ中なら起床時に 1 回拾う -->
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict>
+      <key>Day</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>10</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Day</key>
+      <integer>15</integer>
+      <key>Hour</key>
+      <integer>10</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+  </array>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/claude-insights.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/claude-insights.log</string>
+</dict>
+</plist>

--- a/scripts/darwin/claude_insights.sh
+++ b/scripts/darwin/claude_insights.sh
@@ -1,122 +1,36 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# -C          : Prevent overwriting files with output redirection
-# -e          : Exit the script if any command returns a non-zero status
-# -u          : Exit the script if an undefined variable is used
-# -o pipefail : Change pipeline exit status to the last non-zero exit
-#               code in the pipeline, or zero if all commands succeed
-set -Ceuo pipefail
+# /insights のレポートを生成 → 日本語訳 → クリックで開く通知。
+# launchd (local.claude-insights.plist) から毎月 1・15 日に起動される。
 
-# Claude Code の利用状況レポート (/insights) を生成し、日本語に翻訳して
-# クリックで開く通知で知らせる。
-# launchd (local.claude-insights.plist) から毎月 1 日・15 日に起動される。
-#
-# 配信方法は今のところ「クリックで開く通知」。後でメール送信に
-# 差し替える場合は、末尾の「配信」ブロックだけ入れ替えればよい。
-
-# claude は公式 install.sh により ~/.local/bin に入る（Homebrew ではない）。
-# launchd は /bin/bash -l で起動するが、~/.local/bin を PATH に通すのは zsh 専用の
-# .zshrc だけなので、login bash の PATH には入らない（claude が command not found に
-# なる）。よってここで明示的に補う。terminal-notifier は /opt/homebrew/bin で解決可。
+# claude は ~/.local/bin にあり、PATH へ追加するのは zsh の .zshrc だけ。
+# launchd の login bash には入らないので明示的に補う。
 export PATH="$HOME/.local/bin:$PATH"
 
-USAGE_DIR="$HOME/.claude/usage-data"
-REPORT_EN="$USAGE_DIR/report.html"
-REPORT_JA="$USAGE_DIR/report.ja.html"
+REPORT="$HOME/.claude/usage-data/report.html"
+REPORT_JA="$HOME/.claude/usage-data/report.ja.html"
 
-# 翻訳に使うモデル。68KB の HTML を「忠実コピー＋翻訳」させるタスクは出力トークン量が
-# 支配的。sonnet は実測でドキュメント前半（head/CSS 含む）を脱落させ完走できず、しかも
-# opus(~9 分)より遅かった(~12 分)。よって忠実に再現できる opus を既定にする。
-TRANSLATE_MODEL="opus"
+notify() { terminal-notifier -title "Claude Code Insights" -message "$1" "${@:2}"; }
+fail() { echo "$1" >&2; notify "Failed: $1" -sound Basso || true; exit 1; }
 
-notify() {
-  # $1: メッセージ, $2: サウンド名 (省略可)
-  # メッセージ・サウンド名は argv 経由で AppleScript に渡す。-e 文字列に直接埋め込むと
-  # " やバックスラッシュで構文が壊れる/インジェクションになるため。
-  osascript - "$1" "${2:-}" <<'APPLESCRIPT'
-on run argv
-  set msg to item 1 of argv
-  set snd to item 2 of argv
-  if snd is "" then
-    display notification msg with title "Claude Code Insights"
-  else
-    display notification msg with title "Claude Code Insights" sound name snd
-  end if
-end run
-APPLESCRIPT
-}
-
-fail() {
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >&2
-  notify "Failed: $1 (see /tmp/claude-insights.log)" "Basso"
-  exit 1
-}
-
-# ----------------------------------------------------------------
-# 1. 英語レポートを生成
-# ----------------------------------------------------------------
-echo "$(date '+%Y-%m-%d %H:%M:%S') - Generating insights report..."
-command -v claude >/dev/null 2>&1 || fail "claude not found in PATH"
-# 生成前の mtime を記録。/insights が（exit 0 でも）レポートを更新できなかった場合、
-# 古い report.html が残っていると stale なレポートを「新着」として通知してしまう。
-# 生成後に mtime が進んだことを確認して stale データを弾く。
-PREV_MTIME=$(stat -f %m "$REPORT_EN" 2>/dev/null || echo 0)
+# 1. 英語レポート生成。古い report を消してから生成し、/insights が no-op でも
+#    stale なレポートを掴まないようにする。
+rm -f "$REPORT"
 claude -p "/insights" >/dev/null || fail "/insights generation failed"
-[[ -f "$REPORT_EN" ]] || fail "report.html was not generated"
-NEW_MTIME=$(stat -f %m "$REPORT_EN")
-(( NEW_MTIME > PREV_MTIME )) || fail "report.html was not refreshed (stale data; /insights may be a no-op)"
+[[ -f "$REPORT" ]] || fail "report.html was not generated"
 
-# ----------------------------------------------------------------
-# 2. 日本語に翻訳
-# ----------------------------------------------------------------
-echo "$(date '+%Y-%m-%d %H:%M:%S') - Translating to Japanese..."
-TRANSLATE_PROMPT='あなたは HTML 翻訳器です。入力 HTML の人間が読む表示テキスト（title, 見出し, 段落, ラベル, リスト項目など）だけを自然な日本語に翻訳し、それ以外（DOCTYPE, タグ, 属性, class名, <style> 内の CSS, リンクURL）は1文字も変えずに維持してください。数値・日付・コスト・統計の値は1文字も変えないこと。出力は HTML 全体のみ。マークダウンのコードフェンス(```)や説明文は絶対に付けないこと。'
+# 2. 日本語訳。68KB を忠実コピー＋翻訳するタスクは sonnet だと前半脱落するので opus 固定。
+PROMPT='HTML の表示テキスト（見出し・本文・ラベル等）だけを自然な日本語に訳し、タグ/CSS/属性/URL/数値は1文字も変えないこと。HTML 全体のみ出力し、コードフェンスや説明文は付けない。'
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+claude -p --model opus "$PROMPT" >"$TMP" <"$REPORT" || fail "translation failed"
 
-# 翻訳結果を一時ファイルへ。途中失敗で report.ja.html を壊さないため。
-TMP_JA="$(mktemp)"
-trap 'rm -f "$TMP_JA"' EXIT
-# mktemp が作る既存ファイルへ書くため、noclobber (set -C) を >| で明示上書き。
-# stdin リダイレクトで渡し、claude の exit code を || fail で直接拾う。
-claude -p --model "$TRANSLATE_MODEL" "$TRANSLATE_PROMPT" >| "$TMP_JA" < "$REPORT_EN" || fail "translation failed"
-
-# 安全網: 万一コードフェンスが付いた場合は剥がす
-if [[ "$(head -1 "$TMP_JA")" == '```'* ]]; then
-  sed -i '' -e '1d' -e '/^```$/d' "$TMP_JA"
-fi
-
-# 妥当性チェック: 翻訳結果が原文の構造を保っているか。
-# モデルが途中脱落・要約すると head/CSS/サイズが欠ける（sonnet で実測）ので、
-# 先頭がHTML宣言で始まること・必須要素・サイズ下限（原文の70%）を確認し、
-# 壊れていれば原文を捨てずに通知して止める。
-EN_SIZE=$(wc -c < "$REPORT_EN")
-JA_SIZE=$(wc -c < "$TMP_JA")
-# 先頭がフェンス/前置き文でなく <!DOCTYPE か <html で始まること（sonnet は先頭脱落で </div> 始まりだった）
-head -1 "$TMP_JA" | grep -qiE '^[[:space:]]*<(!doctype|html)' || fail "translation broken (leading junk; not <!DOCTYPE/<html)"
-grep -qi '</html>' "$TMP_JA" || fail "translation broken (no </html>)"
-# <style> は属性付き(<style type="...">)もあり得るので [ >] で受ける
-grep -qiE '<style[ >]' "$TMP_JA" || fail "translation broken (missing <style>, CSS dropped)"
-if (( JA_SIZE * 100 < EN_SIZE * 70 )); then
-  fail "translation too small (${JA_SIZE}B < 70% of source ${EN_SIZE}B), likely truncated"
-fi
-
-mv "$TMP_JA" "$REPORT_JA"
+# 翻訳の破損チェック（前半脱落・要約を弾く）: HTML で始まり、原文の 70% 以上のサイズ。
+head -1 "$TMP" | grep -qiE '^[[:space:]]*<(!doctype|html)' || fail "translation looks broken (not HTML)"
+(( $(wc -c <"$TMP") * 10 >= $(wc -c <"$REPORT") * 7 )) || fail "translation too small (truncated?)"
+mv "$TMP" "$REPORT_JA"
 trap - EXIT
 
-# ----------------------------------------------------------------
-# 3. 配信（クリックで開く通知）
-# ----------------------------------------------------------------
-# terminal-notifier の通知をクリックすると既定ブラウザでレポートを開く。
-# 勝手にタブを開かず、見たいときだけ開ける。
-echo "$(date '+%Y-%m-%d %H:%M:%S') - Notifying..."
-if command -v terminal-notifier >/dev/null 2>&1; then
-  terminal-notifier \
-    -title "Claude Code Insights" \
-    -message "Your usage report is ready (click to open)" \
-    -open "file://$REPORT_JA" \
-    -sound Glass
-else
-  # フォールバック: terminal-notifier 未導入ならブラウザを直接開いて通知
-  open "$REPORT_JA"
-  notify "Report opened (terminal-notifier not installed)" "Glass"
-fi
-echo "$(date '+%Y-%m-%d %H:%M:%S') - Done."
+# 3. 通知。クリックで既定ブラウザにレポートを開く。
+notify "Your usage report is ready (click to open)" -open "file://$REPORT_JA" -sound Glass

--- a/scripts/darwin/claude_insights.sh
+++ b/scripts/darwin/claude_insights.sh
@@ -8,11 +8,17 @@
 set -Ceuo pipefail
 
 # Claude Code の利用状況レポート (/insights) を生成し、日本語に翻訳して
-# ブラウザで開き、macOS 通知で知らせる。
+# クリックで開く通知で知らせる。
 # launchd (local.claude-insights.plist) から毎月 1 日・15 日に起動される。
 #
-# 配信方法は今のところ「通知 + ブラウザ自動オープン」。後でメール送信に
+# 配信方法は今のところ「クリックで開く通知」。後でメール送信に
 # 差し替える場合は、末尾の「配信」ブロックだけ入れ替えればよい。
+
+# claude は公式 install.sh により ~/.local/bin に入る（Homebrew ではない）。
+# launchd は /bin/bash -l で起動するが、~/.local/bin を PATH に通すのは zsh 専用の
+# .zshrc だけなので、login bash の PATH には入らない（claude が command not found に
+# なる）。よってここで明示的に補う。terminal-notifier は /opt/homebrew/bin で解決可。
+export PATH="$HOME/.local/bin:$PATH"
 
 USAGE_DIR="$HOME/.claude/usage-data"
 REPORT_EN="$USAGE_DIR/report.html"
@@ -25,12 +31,19 @@ TRANSLATE_MODEL="opus"
 
 notify() {
   # $1: メッセージ, $2: サウンド名 (省略可)
-  local sound="${2:-}"
-  if [[ -n "$sound" ]]; then
-    osascript -e "display notification \"$1\" with title \"Claude Code Insights\" sound name \"$sound\""
+  # メッセージ・サウンド名は argv 経由で AppleScript に渡す。-e 文字列に直接埋め込むと
+  # " やバックスラッシュで構文が壊れる/インジェクションになるため。
+  osascript - "$1" "${2:-}" <<'APPLESCRIPT'
+on run argv
+  set msg to item 1 of argv
+  set snd to item 2 of argv
+  if snd is "" then
+    display notification msg with title "Claude Code Insights"
   else
-    osascript -e "display notification \"$1\" with title \"Claude Code Insights\""
-  fi
+    display notification msg with title "Claude Code Insights" sound name snd
+  end if
+end run
+APPLESCRIPT
 }
 
 fail() {
@@ -43,20 +56,28 @@ fail() {
 # 1. 英語レポートを生成
 # ----------------------------------------------------------------
 echo "$(date '+%Y-%m-%d %H:%M:%S') - Generating insights report..."
+command -v claude >/dev/null 2>&1 || fail "claude not found in PATH"
+# 生成前の mtime を記録。/insights が（exit 0 でも）レポートを更新できなかった場合、
+# 古い report.html が残っていると stale なレポートを「新着」として通知してしまう。
+# 生成後に mtime が進んだことを確認して stale データを弾く。
+PREV_MTIME=$(stat -f %m "$REPORT_EN" 2>/dev/null || echo 0)
 claude -p "/insights" >/dev/null || fail "/insights generation failed"
 [[ -f "$REPORT_EN" ]] || fail "report.html was not generated"
+NEW_MTIME=$(stat -f %m "$REPORT_EN")
+(( NEW_MTIME > PREV_MTIME )) || fail "report.html was not refreshed (stale data; /insights may be a no-op)"
 
 # ----------------------------------------------------------------
 # 2. 日本語に翻訳
 # ----------------------------------------------------------------
 echo "$(date '+%Y-%m-%d %H:%M:%S') - Translating to Japanese..."
-TRANSLATE_PROMPT='あなたは HTML 翻訳器です。入力 HTML の人間が読む表示テキスト（title, 見出し, 段落, ラベル, リスト項目など）だけを自然な日本語に翻訳し、それ以外（DOCTYPE, タグ, 属性, class名, <style> 内の CSS, リンクURL）は1文字も変えずに維持してください。出力は HTML 全体のみ。マークダウンのコードフェンス(```)や説明文は絶対に付けないこと。'
+TRANSLATE_PROMPT='あなたは HTML 翻訳器です。入力 HTML の人間が読む表示テキスト（title, 見出し, 段落, ラベル, リスト項目など）だけを自然な日本語に翻訳し、それ以外（DOCTYPE, タグ, 属性, class名, <style> 内の CSS, リンクURL）は1文字も変えずに維持してください。数値・日付・コスト・統計の値は1文字も変えないこと。出力は HTML 全体のみ。マークダウンのコードフェンス(```)や説明文は絶対に付けないこと。'
 
 # 翻訳結果を一時ファイルへ。途中失敗で report.ja.html を壊さないため。
 TMP_JA="$(mktemp)"
 trap 'rm -f "$TMP_JA"' EXIT
-# mktemp が作る既存ファイルへ書くため、noclobber (set -C) を >| で明示上書き
-cat "$REPORT_EN" | claude -p --model "$TRANSLATE_MODEL" "$TRANSLATE_PROMPT" >| "$TMP_JA" || fail "translation failed"
+# mktemp が作る既存ファイルへ書くため、noclobber (set -C) を >| で明示上書き。
+# stdin リダイレクトで渡し、claude の exit code を || fail で直接拾う。
+claude -p --model "$TRANSLATE_MODEL" "$TRANSLATE_PROMPT" >| "$TMP_JA" < "$REPORT_EN" || fail "translation failed"
 
 # 安全網: 万一コードフェンスが付いた場合は剥がす
 if [[ "$(head -1 "$TMP_JA")" == '```'* ]]; then
@@ -65,11 +86,15 @@ fi
 
 # 妥当性チェック: 翻訳結果が原文の構造を保っているか。
 # モデルが途中脱落・要約すると head/CSS/サイズが欠ける（sonnet で実測）ので、
-# 必須要素とサイズ下限（原文の 70%）の両方を確認し、壊れていれば原文を捨てない。
+# 先頭がHTML宣言で始まること・必須要素・サイズ下限（原文の70%）を確認し、
+# 壊れていれば原文を捨てずに通知して止める。
 EN_SIZE=$(wc -c < "$REPORT_EN")
 JA_SIZE=$(wc -c < "$TMP_JA")
+# 先頭がフェンス/前置き文でなく <!DOCTYPE か <html で始まること（sonnet は先頭脱落で </div> 始まりだった）
+head -1 "$TMP_JA" | grep -qiE '^[[:space:]]*<(!doctype|html)' || fail "translation broken (leading junk; not <!DOCTYPE/<html)"
 grep -qi '</html>' "$TMP_JA" || fail "translation broken (no </html>)"
-grep -qi '<style>' "$TMP_JA" || fail "translation broken (missing <style>, CSS dropped)"
+# <style> は属性付き(<style type="...">)もあり得るので [ >] で受ける
+grep -qiE '<style[ >]' "$TMP_JA" || fail "translation broken (missing <style>, CSS dropped)"
 if (( JA_SIZE * 100 < EN_SIZE * 70 )); then
   fail "translation too small (${JA_SIZE}B < 70% of source ${EN_SIZE}B), likely truncated"
 fi

--- a/scripts/darwin/claude_insights.sh
+++ b/scripts/darwin/claude_insights.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# -C          : Prevent overwriting files with output redirection
+# -e          : Exit the script if any command returns a non-zero status
+# -u          : Exit the script if an undefined variable is used
+# -o pipefail : Change pipeline exit status to the last non-zero exit
+#               code in the pipeline, or zero if all commands succeed
+set -Ceuo pipefail
+
+# Claude Code の利用状況レポート (/insights) を生成し、日本語に翻訳して
+# ブラウザで開き、macOS 通知で知らせる。
+# launchd (local.claude-insights.plist) から毎月 1 日・15 日に起動される。
+#
+# 配信方法は今のところ「通知 + ブラウザ自動オープン」。後でメール送信に
+# 差し替える場合は、末尾の「配信」ブロックだけ入れ替えればよい。
+
+USAGE_DIR="$HOME/.claude/usage-data"
+REPORT_EN="$USAGE_DIR/report.html"
+REPORT_JA="$USAGE_DIR/report.ja.html"
+
+# 翻訳に使うモデル。68KB の HTML を「忠実コピー＋翻訳」させるタスクは出力トークン量が
+# 支配的。sonnet は実測でドキュメント前半（head/CSS 含む）を脱落させ完走できず、しかも
+# opus(~9 分)より遅かった(~12 分)。よって忠実に再現できる opus を既定にする。
+TRANSLATE_MODEL="opus"
+
+notify() {
+  # $1: メッセージ, $2: サウンド名 (省略可)
+  local sound="${2:-}"
+  if [[ -n "$sound" ]]; then
+    osascript -e "display notification \"$1\" with title \"Claude Code Insights\" sound name \"$sound\""
+  else
+    osascript -e "display notification \"$1\" with title \"Claude Code Insights\""
+  fi
+}
+
+fail() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >&2
+  notify "Failed: $1 (see /tmp/claude-insights.log)" "Basso"
+  exit 1
+}
+
+# ----------------------------------------------------------------
+# 1. 英語レポートを生成
+# ----------------------------------------------------------------
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Generating insights report..."
+claude -p "/insights" >/dev/null || fail "/insights generation failed"
+[[ -f "$REPORT_EN" ]] || fail "report.html was not generated"
+
+# ----------------------------------------------------------------
+# 2. 日本語に翻訳
+# ----------------------------------------------------------------
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Translating to Japanese..."
+TRANSLATE_PROMPT='あなたは HTML 翻訳器です。入力 HTML の人間が読む表示テキスト（title, 見出し, 段落, ラベル, リスト項目など）だけを自然な日本語に翻訳し、それ以外（DOCTYPE, タグ, 属性, class名, <style> 内の CSS, リンクURL）は1文字も変えずに維持してください。出力は HTML 全体のみ。マークダウンのコードフェンス(```)や説明文は絶対に付けないこと。'
+
+# 翻訳結果を一時ファイルへ。途中失敗で report.ja.html を壊さないため。
+TMP_JA="$(mktemp)"
+trap 'rm -f "$TMP_JA"' EXIT
+# mktemp が作る既存ファイルへ書くため、noclobber (set -C) を >| で明示上書き
+cat "$REPORT_EN" | claude -p --model "$TRANSLATE_MODEL" "$TRANSLATE_PROMPT" >| "$TMP_JA" || fail "translation failed"
+
+# 安全網: 万一コードフェンスが付いた場合は剥がす
+if [[ "$(head -1 "$TMP_JA")" == '```'* ]]; then
+  sed -i '' -e '1d' -e '/^```$/d' "$TMP_JA"
+fi
+
+# 妥当性チェック: 翻訳結果が原文の構造を保っているか。
+# モデルが途中脱落・要約すると head/CSS/サイズが欠ける（sonnet で実測）ので、
+# 必須要素とサイズ下限（原文の 70%）の両方を確認し、壊れていれば原文を捨てない。
+EN_SIZE=$(wc -c < "$REPORT_EN")
+JA_SIZE=$(wc -c < "$TMP_JA")
+grep -qi '</html>' "$TMP_JA" || fail "translation broken (no </html>)"
+grep -qi '<style>' "$TMP_JA" || fail "translation broken (missing <style>, CSS dropped)"
+if (( JA_SIZE * 100 < EN_SIZE * 70 )); then
+  fail "translation too small (${JA_SIZE}B < 70% of source ${EN_SIZE}B), likely truncated"
+fi
+
+mv "$TMP_JA" "$REPORT_JA"
+trap - EXIT
+
+# ----------------------------------------------------------------
+# 3. 配信（クリックで開く通知）
+# ----------------------------------------------------------------
+# terminal-notifier の通知をクリックすると既定ブラウザでレポートを開く。
+# 勝手にタブを開かず、見たいときだけ開ける。
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Notifying..."
+if command -v terminal-notifier >/dev/null 2>&1; then
+  terminal-notifier \
+    -title "Claude Code Insights" \
+    -message "Your usage report is ready (click to open)" \
+    -open "file://$REPORT_JA" \
+    -sound Glass
+else
+  # フォールバック: terminal-notifier 未導入ならブラウザを直接開いて通知
+  open "$REPORT_JA"
+  notify "Report opened (terminal-notifier not installed)" "Glass"
+fi
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Done."

--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -286,6 +286,17 @@ launchctl bootout "gui/$UID" "$local_d2d_plist" 2>/dev/null || true
 launchctl bootstrap "gui/$UID" "$local_d2d_plist"
 
 # ----------------------------------------------------------------
+# Claude Code Insights
+# ----------------------------------------------------------------
+# /insights の利用状況レポートを毎月 1 日・15 日に生成・日本語翻訳し、
+# ブラウザで開いて macOS 通知で知らせる LaunchAgent を登録する
+echo "- 📊 Claude Code Insights"
+
+local_insights_plist="$HOME/Library/LaunchAgents/local.claude-insights.plist"
+launchctl bootout "gui/$UID" "$local_insights_plist" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" "$local_insights_plist"
+
+# ----------------------------------------------------------------
 # Network
 # ----------------------------------------------------------------
 echo "- 📡 Network"


### PR DESCRIPTION
## 概要

`/insights` の利用状況レポートを**毎月 1 日・15 日**に自動生成し、**日本語に翻訳**して、**クリックでブラウザが開く通知**で知らせる仕組みを追加します。

当初は GitHub issue に貼る案でしたが、issue は HTML の `<style>` を sanitizer で落とすため配色つきダッシュボードが崩れます。ローカルでブラウザレンダリングすればそのまま見えるので、launchd + terminal-notifier 構成にしました。

## 構成

| ファイル | 役割 |
|---|---|
| `scripts/darwin/claude_insights.sh` | 生成 → 翻訳(opus) → 妥当性チェック → 通知 |
| `home/Library/LaunchAgents/local.claude-insights.plist` | `StartCalendarInterval` 配列で 1 日・15 日 10:00 起動 |
| `scripts/darwin/macos.sh` | LaunchAgent を bootstrap 登録 |
| `Brewfile` | `terminal-notifier` を追加 |

## 設計上の判断

- **スケジュール**: launchd 単体では「隔週の特定曜日」は表現できないが、`StartCalendarInterval` 配列で「毎月 1 日・15 日」は素直に書ける。skip 判定スクリプト不要。
- **翻訳モデルは opus**: 速度・コスト目当てで sonnet を試したが、実測で 68KB の HTML を完走できず**前半(head/CSS 含む)を脱落**させ、しかも opus(~9分)より遅かった(~12分)。よって忠実再現できる opus を採用。
- **配信**: `terminal-notifier -open` で通知クリック → 既定ブラウザでレポートを開く。勝手にタブを開かない。未導入時は `open` + `osascript` 通知にフォールバック。

## マルチエージェントレビューで入れた堅牢化

複数角度のサブエージェントレビューで見つかった問題を修正:

- **PATH**: `claude` は `~/.local/bin` にあり、その PATH 追加は zsh 専用の `.zshrc` だけ。LaunchAgent は `/bin/bash -l` 起動でこれを読まないため、補正しないと**毎回 command not found で失敗**する（clean 環境で実証）。スクリプト先頭で `export PATH` して解決。
- **stale データ検証**: `/insights` が no-op でも古い `report.html` を「新着」として通知しないよう、生成前後の mtime を比較して弾く。
- **翻訳の妥当性チェック強化**: 先頭が `<!DOCTYPE`/`<html` で始まること・`</html>`/`<style ...>` の存在・サイズが原文の70%以上、を確認。途中脱落・要約を捕捉して原文を捨てない（sonnet の壊れ出力を弾けることを実証）。
- **osascript 注入対策**: 通知文言を argv 経由で AppleScript に渡し、引用符・バックスラッシュで壊れないように。

## 検証済み

- `/insights` が `~/.claude/usage-data/report.html` を生成
- opus 翻訳がフェンス無し・行数一致・CSS 無傷のクリーンな日本語 HTML を出力
- 妥当性チェックが sonnet の壊れ出力を弾き、opus の正常出力を通すことを実証
- PATH 補正で clean login bash から `claude` が解決できることを実証
- `set -C`(noclobber)下で `>|` が必要なことを実証
- terminal-notifier の通知クリックでブラウザが開く / バナー表示を実機確認

## 有効化手順(マージ後)

1. `make link`(stow で `~/Library/LaunchAgents/` に symlink)
2. `make brew` で `terminal-notifier` を導入
3. `scripts/darwin/macos.sh` の bootstrap を実行（LaunchAgent 登録）
4. 通知を消えにくくするなら **System Settings → 通知 → terminal-notifier → Alert Style を Persistent** に（macOS の per-app 設定で、CLI からの自動化は ncprefs のバイナリ構造上ふさわしくないため手動）
