### PR TITLE
feat: add claude --bg aliases and disable bg worktree isolation

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -214,5 +214,8 @@
   "tui": "fullscreen",
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "worktree": {
+    "bgIsolation": "none"
+  }
 }

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -1,6 +1,6 @@
 # ~/.claude/settings.json リファレンス
 
-最終更新: 2026-04-22
+最終更新: 2026-05-22
 
 ## 背景
 
@@ -344,6 +344,20 @@ Claude Code 2.1.110 で追加された「Push when Claude decides」機能。Rem
 `defaultMode: "auto"` でセッションを開始したときに表示される「Auto mode を有効にしますか？」の確認プロンプトをスキップする。sandbox を常時有効にしている前提で、auto mode を毎回無言で起動したいための設定。
 
 `permissions.skipDangerousModePermissionPrompt`（bypass permissions 用）と対になる auto mode 版。公式ドキュメントでは明示的に記載されていないが Claude Code 本体が読み取る設定キーとして実装されている。将来挙動が変わる可能性があるため、新しいセッションで確認プロンプトが戻ったらこの記述を見直す。
+
+### worktree
+
+```jsonc
+"worktree": {
+  "bgIsolation": "none"  // background セッション（claude --bg / /bg）を worktree 隔離せず本体で動かす
+}
+```
+
+`worktree.bgIsolation` は background セッションのファイル隔離モード（このリポジトリ単位）。Claude Code 本体のスキーマでは `"worktree"` がデフォルトで、background セッションがメイン checkout に Edit/Write しようとすると `EnterWorktree` を呼ぶまでブロックし、初回編集時に `.claude/worktrees/<id>` へ自動隔離する。`"none"` にすると background ジョブがワーキングコピーを直接編集できる。foreground セッションや `claude --worktree` 起動には影響しない（あれは起動時点で worktree を作る別経路）。
+
+`"none"` を選んだ理由は、worktree のセットアップ hook (`.claude/hooks/startup.sh`) が `SessionStart`（matcher: `startup`）に紐づいているため。`SessionStart` の source は `startup` / `resume` / `clear` / `compact` の 4 つだけで `worktree` は存在せず、background セッションが稼働中に `EnterWorktree` で遅延的に worktree へ移っても `SessionStart` は再発火しない。つまりデフォルトの `"worktree"` だと、新規 worktree に `node_modules` が無いまま `startup.sh` が走らず、依存未インストールでつまずく。`"none"` にすれば background は常に本体（起動時に `startup.sh` が `ff-only` + `pnpm install` で整えた状態）で動くため、この問題が起きない。
+
+トレードオフは、複数の background セッションを同じファイルに並列で走らせると衝突すること。並列編集を多用する運用に変える場合はデフォルトの `"worktree"` に戻し、代わりに `WorktreeCreate` hook 等で全 worktree 作成経路に deps install を配線する必要がある。
 
 ## 使い方
 

--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -46,11 +46,13 @@ z!() {
 # ----------------------------------------------------------------
 alias c="claude"
 alias ca="claude agents"
+alias cb="claude --bg"
 alias cc="claude --continue"
 alias cr="claude --resume"
 alias crs="claude respawn --all"
 alias ct="claude --teleport"
 alias cw="claude --worktree"
+alias cwb="claude --worktree --bg"
 alias cwr="claude --worktree --resume"
 alias cwt="claude --worktree --teleport"
 


### PR DESCRIPTION
## 概要

`claude --bg`（background セッション）まわりの alias 追加と、worktree 隔離挙動の調整。

## 変更内容

### alias 追加（`home/.zsh/alias/alias.zsh`）

- `cb` = `claude --bg` — 新規セッションを background 起動（`claude agents` の agent view に並ぶ）
- `cwb` = `claude --worktree --bg` — 起動時から worktree + background

### `worktree.bgIsolation: "none"` を設定（`home/.claude/settings.json`）

background セッションを worktree 隔離せず、本体（ワーキングコピー）で直接動かす。

## なぜ `none` か

worktree のセットアップ hook である `.claude/hooks/startup.sh`（`git fetch` + `ff-only` + 必要なら `pnpm install`）は **`SessionStart`（matcher: `startup`）** に紐づいている。

Claude Code 本体（v2.1.146）を確認したところ:

- `SessionStart` の source は `["startup","resume","clear","compact"]` の 4 つのみで、`worktree` は存在しない。
- `bgIsolation` のデフォルトは `"worktree"` で、background セッションが稼働中に `EnterWorktree` で**遅延的に** worktree を作る。
- このとき `SessionStart` は再発火しないため、`node_modules` の無い新規 worktree で `startup.sh` が走らず、依存未インストールのまま作業に入ってつまずく。

`"none"` にすれば background は常に本体で動き、本体は起動時の `startup.sh` で整っているのでこの問題が起きない。foreground や `claude --worktree`（= 起動時に worktree を作る別経路）には影響しない。

## トレードオフ

複数の background セッションを同じファイルに並列で走らせると衝突する。並列編集を多用する運用に変える場合は、デフォルトの `"worktree"` に戻したうえで `WorktreeCreate` hook 等で全 worktree 作成経路に deps install を配線する必要がある（`home/.claude/settings.md` に追記済み）。

## 反映タイミング

- `bgIsolation`: `~/.claude/settings.json` は本リポジトリの `home/.claude/settings.json` への symlink なので、merge 後に反映される。
- alias: merge 後、shell の再読み込み（`exec zsh` 等）で有効化される。



---

refs #981