### PR TITLE
chore: require short, simple comments in code and config

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -92,6 +92,11 @@ gh pr create --title "..." --body-file "$BODY_FILE"
 - sandbox の allowedDomains にドメインを追加する際は、可能な限りワイルドカード（`*.example.com`）で正規化すること。個別サブドメインが1つだけの場合はそのままでよい。
 - パーミッションの追加・変更は必ず `~/.claude/settings.json`（グローバル設定）に行うこと。プロジェクトの `settings.local.json` には追加しない。`settings.local.json` にルールが溜まっていた場合は、ユーザーにグローバルへの移行を提案すること。
 
+## コメント
+
+- コード・設定ファイルに書くコメントは、できるだけ短くシンプルに、わかりやすい日本語で書く。短くてわかりやすいのが最善。
+- 最初から長く詳細に書き込まない。説明が足りずわかりにくいと指摘されたら、その都度必要な分だけ伸ばす。
+
 ## pnpm allowBuilds コメント
 
 `pnpm-workspace.yaml` の `allowBuilds` 各エントリには、build を許可/拒否する判断根拠が分かるコメントを必ず付けること。フォーマット:


### PR DESCRIPTION
## 概要

グローバル指示（`home/.claude/CLAUDE.md`）に、コード・設定ファイルに書くコメントの方針を追加する。

## 背景

[nozomiishii/.github#779](https://github.com/nozomiishii/.github/pull/779) の `pnpm-workspace.yaml` で、Claude が書いた説明コメントが毎回長く詳細すぎて困っていた。「もっとシンプルでわかりやすい文にして欲しい」という指摘があったため、方針として明文化する。

## 追加内容

`## 設定管理` と `## pnpm allowBuilds コメント` の間に `## コメント` section を追加:

- コード・設定ファイルに書くコメントは、できるだけ短くシンプルに、わかりやすい日本語で書く。短くてわかりやすいのが最善。
- 最初から長く詳細に書き込まない。説明が足りずわかりにくいと指摘されたら、その都度必要な分だけ伸ばす。

適用範囲はコード・設定ファイルのコメントのみ（PR レビューコメントや PR 本文は対象外）。
