### PR TITLE
fix: move brew-update launchagent to 10:00 to avoid darkwake download failures

### DIFF
--- a/home/Library/LaunchAgents/local.brew-update.plist
+++ b/home/Library/LaunchAgents/local.brew-update.plist
@@ -13,11 +13,13 @@
     <string>exec "$HOME/dotfiles/scripts/darwin/brew_update.sh"</string>
   </array>
 
-  <!-- 毎日 07:00 に実行（Night Shift が一瞬解除されるタイミングに合わせている） -->
+  <!-- 毎日 10:00 に実行。スリープ中は StartCalendarInterval が発火せず次の wake に持ち越され、
+       45-180 秒の DarkWake (PowerNap) 中に走ると大型 Cask の DL が Back to Sleep で切れて
+       make homebrew が失敗する。フル覚醒している日中に寄せるため 07:00 から移動 -->
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
-    <integer>7</integer>
+    <integer>10</integer>
     <key>Minute</key>
     <integer>0</integer>
   </dict>


### PR DESCRIPTION
## 背景

`local.brew-update` LaunchAgent（毎朝 `make homebrew` を実行）が 2 日連続で失敗し、「make homebrew failed」通知が出ていた。

## 調査で判明した原因

ログと `pmset -g log` を突き合わせた結果、原因は **DarkWake 中実行による大型 Cask のダウンロード切断**だった。

```
05-21 07:14:39  DarkWake from Deep Idle ... 46 secs   ← Mac が46秒だけ起きた
05-21 07:14:39  Running make homebrew...              ← まさにこの瞬間ジョブ開始（時刻一致）
05-21 07:15:25  Entering Sleep state 'Back to Sleep'  ← 46秒後に寝た → DL切断
05-21 07:32:34  make homebrew failed                  ← brewが諦めて失敗
```

- `StartCalendarInterval` はスリープ中の Mac を起こさない。07:00 に寝ていると発火が**次の wake に持ち越される**。
- その「次の wake」には、画面オフのまま 45〜180 秒だけ起きる **DarkWake（PowerNap）** も含まれる。
- ジョブはこの短い DarkWake 中に走り、blender（~335MB）/ brooklyn（~277MB）の DL が終わる前にシステムが Back to Sleep → `curl: (56) Connection reset by peer` / `(18) Transferred a partial file` で失敗。
- formula（小サイズの bottle）は成功し、大型 Cask だけが落ちていたのもこれで説明がつく。

手元でフル覚醒状態から手動実行したところ、3 つとも問題なく upgrade 完了したことも裏付けになっている。

## 変更内容

- 実行時刻を **07:00 → 10:00** に移動（フル覚醒している日中に寄せる）。
- コメントを旧記述（「Night Shift 解除タイミング」）から、今回判明した正しい原因に更新。

## 残課題（このPRには含めない）

- 10:00 も Mac が閉じて寝ていれば同じ DarkWake 発火になり得る。再発するなら `brew_update.sh` を `caffeinate -i` で包んでジョブ完了までスリープを抑止する案に切り替える。
- `mas "Kindle"` / `mas "LINE"` は非対話の LaunchAgent から App Store 認証ができず、更新がある日は別途詰まる可能性がある（今回の失敗の原因ではない）。
