### PR TITLE
feat: add csr command to recover sessions from deleted worktrees

### DIFF
--- a/home/.local/bin/csr-resolve.ts
+++ b/home/.local/bin/csr-resolve.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+// クラウドセッション URL または branch 名から、消えた worktree のローカルセッションを特定する。
+// 1 件に絞れたら "<repo>\t<worktree_path>\t<uuid>" を stdout に出力。
+// 複数候補・不在は stderr に出して非ゼロ終了。csr 関数 (.zsh/functions.zsh) から呼ばれる。
+// 設計: https://github.com/nozomiishii/dotfiles/issues/1006
+
+import { Glob } from "bun";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename } from "node:path";
+
+const arg = process.argv[2];
+if (!arg) {
+  console.error("usage: csr-resolve.ts <claude-session-url|branch-name>");
+  process.exit(2);
+}
+
+const projects = `${homedir()}/.claude/projects`;
+
+// 入力判定: URL/session id らしき形なら URL モード(url フィールド)、それ以外は branch 名(gitBranch 完全一致)。
+// branch 名が偶然 "session_" を含んでも URL モードに誤入しないよう、URL らしさで判定する。
+// いずれも JSON フィールドの完全一致で照合するため、正規表現メタ文字の混入や本文言及の偽陽性が起きない。
+const urlLike = /^(https?:\/\/|session_)/.test(arg) || arg.includes("claude.ai/code/");
+const sid = urlLike ? (arg.match(/session_[A-Za-z0-9]+/)?.[0] ?? null) : null;
+if (urlLike && !sid) {
+  console.error(`csr: URL に session id が見つかりません: ${arg}`);
+  process.exit(2);
+}
+
+type Sess = {
+  uuid: string;
+  cwd: string;
+  forkedFrom: string | null;
+  lastTs: string;
+  humanTurns: number;
+  snippet: string;
+};
+
+const matched: Sess[] = [];
+
+for (const rel of new Glob("*/*.jsonl").scanSync(projects)) {
+  const file = `${projects}/${rel}`;
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  // 安価な pre-filter（リテラル文字列。正規表現なし）。
+  if (sid ? !text.includes(sid) : !text.includes(`"gitBranch":"${arg}"`)) continue;
+
+  let cwd = "";
+  let forkedFrom: string | null = null;
+  let lastTs = "";
+  let humanTurns = 0;
+  let snippet = "";
+  let hit = false;
+
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    let d: Record<string, any>;
+    try {
+      d = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!d || typeof d !== "object") continue; // 単独 null やプリミティブ行で field 参照が throw するのを防ぐ。
+
+    // 構造化フィールドでの確定マッチ。url は session id を完全一致で照合
+    // （末尾スラッシュ/クエリがあっても拾え、かつ id の前方一致誤マッチも防ぐ）。
+    if (sid) {
+      if (typeof d.url === "string" && d.url.match(/session_[A-Za-z0-9]+/)?.[0] === sid) hit = true;
+    } else if (d.gitBranch === arg) {
+      hit = true;
+    }
+
+    if (typeof d.cwd === "string" && !cwd) cwd = d.cwd;
+    if (d.forkedFrom?.sessionId && !forkedFrom) forkedFrom = d.forkedFrom.sessionId;
+    // 行順に依存せず真の最大 timestamp を取る（末尾が summary 等で非時系列でも正しい）。
+    if (typeof d.timestamp === "string" && d.timestamp > lastTs) lastTs = d.timestamp;
+
+    // 人間ターンのみ数える（Claude は tool_result も type:"user" で保存するため content で判定）。
+    if (d.type === "user") {
+      const c: unknown = d.message?.content;
+      const human =
+        typeof c === "string"
+          ? c.trim().length > 0
+          : Array.isArray(c)
+            ? c.some((x) => x?.type === "text")
+            : false;
+      if (human) {
+        humanTurns++;
+        if (!snippet) {
+          const t =
+            typeof c === "string"
+              ? c
+              : (c as { type?: string; text?: string }[])
+                  .filter((x) => x?.type === "text")
+                  .map((x) => x.text ?? "")
+                  .join(" ");
+          const s = t.replace(/\s+/g, " ").trim();
+          if (s) snippet = s.slice(0, 60);
+        }
+      }
+    }
+  }
+
+  if (!hit || !cwd) continue;
+  matched.push({ uuid: basename(file, ".jsonl"), cwd, forkedFrom, lastTs, humanTurns, snippet });
+}
+
+if (matched.length === 0) {
+  console.error(`csr: no session found for: ${arg}`);
+  process.exit(1);
+}
+
+// cwd 内を fork lineage でまとめ、各 lineage の代表(最新 last_ts)を返す。
+// 親が matched 集合に無くても forkedFrom の uuid を lineage key にして兄弟 fork を畳む。
+function lineageReps(sessions: Sess[]): Sess[] {
+  const byUuid = new Map(sessions.map((s) => [s.uuid, s]));
+  const rootOf = (s: Sess): string => {
+    let cur = s;
+    const seen = new Set<string>();
+    while (cur.forkedFrom && !seen.has(cur.uuid)) {
+      seen.add(cur.uuid);
+      const parent = byUuid.get(cur.forkedFrom);
+      if (!parent) return cur.forkedFrom; // 親が未ロード → 共通の親 uuid を lineage key にする。
+      cur = parent;
+    }
+    return cur.uuid;
+  };
+  const groups = new Map<string, Sess[]>();
+  for (const s of sessions) {
+    const r = rootOf(s);
+    const g = groups.get(r);
+    if (g) g.push(s);
+    else groups.set(r, [s]);
+  }
+  // 代表 = 最新 last_ts（同点は human turns が多い方 = よりフルな履歴）。
+  return [...groups.values()].map((members) =>
+    members.reduce((a, b) =>
+      b.lastTs > a.lastTs || (b.lastTs === a.lastTs && b.humanTurns > a.humanTurns) ? b : a,
+    ),
+  );
+}
+
+const byCwd = new Map<string, Sess[]>();
+for (const s of matched) {
+  const g = byCwd.get(s.cwd);
+  if (g) g.push(s);
+  else byCwd.set(s.cwd, [s]);
+}
+
+const reps: Sess[] = [];
+for (const sessions of byCwd.values()) reps.push(...lineageReps(sessions));
+
+// 人間ターン 0 の lineage（teleport stub 等）は、本物の候補が他にあればノイズとして落とす。
+// 実際の会話を持つ（humanTurns>0）lineage は決して隠さない。
+const withHuman = reps.filter((s) => s.humanTurns > 0);
+const cands = withHuman.length ? withHuman : reps;
+
+const repoOf = (cwd: string) => cwd.replace(/\/\.claude\/worktrees\/[^/]+$/, "");
+
+if (cands.length === 1) {
+  const s = cands[0]!;
+  process.stdout.write(`${repoOf(s.cwd)}\t${s.cwd}\t${s.uuid}\n`);
+} else {
+  // 別物のセッションが複数 → 自動で選ばず、人間ターン数・日付・抜粋つきで候補を提示。
+  console.error("csr: 複数候補があります。branch 名で絞って再実行してください:");
+  cands.sort((a, b) => b.lastTs.localeCompare(a.lastTs));
+  for (const s of cands) {
+    const slug = basename(s.cwd);
+    const repo = basename(repoOf(s.cwd));
+    const date = s.lastTs.slice(0, 10);
+    console.error(
+      `  ${slug.padEnd(26)} ${repo.padEnd(12)} ${date}  ${String(s.humanTurns).padStart(3)}turns  ${s.snippet}`,
+    );
+  }
+  process.exit(1);
+}

--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -9,3 +9,26 @@ jf() {
   printf '%s' "$payload" | pbcopy
   printf '\033[32m✓\033[0m Copied to clipboard\n  \033[2m%s\033[0m\n' "$payload"
 }
+
+# csr (Claude Session Recover): 消えた worktree のローカルセッションを
+# クラウドセッション URL または branch 名から復元して resume する。
+# git hooks で worktree が自動削除された後の最終手段。設計: nozomiishii/dotfiles#1006
+csr() {
+  local res
+  res=$(csr-resolve.ts "$1") || return 1 # "<repo>\t<worktree_path>\t<uuid>"
+  # zsh の `path` は $PATH に tie された配列なので変数名に使わない（git/claude が見つからなくなる）。
+  local repo wt uuid
+  IFS=$'\t' read -r repo wt uuid <<<"$res"
+  # worktree が無ければ detached HEAD で再構築する（元 branch は復元不可なので repo の主ブランチを使う）。
+  if [[ ! -d $wt ]]; then
+    if [[ $repo == "$wt" ]]; then
+      # cwd が worktree 配下でない（repo==wt）→ 再構築する worktree が無く、ディレクトリも消えている。
+      echo "csr: 非 worktree セッションのディレクトリが見つかりません: $wt" >&2
+      return 1
+    fi
+    local mb
+    mb=$(cd "$repo" && git_main_branch) || return 1
+    git -C "$repo" worktree add --detach "$wt" "$mb" || return 1
+  fi
+  cd "$wt" && claude --resume "$uuid"
+}


### PR DESCRIPTION
closes #1006

## 概要

git hooks が disconnect 時に worktree を自動削除する運用のため、worktree が消えるとそのローカルセッションは通常の resume（`cwr` 等）では拾えなくなる（resume は cwd のパスにスコープされるため）。

クラウドセッション URL または branch 名から、消えた worktree を再構築してセッションを resume する最終手段コマンド `csr`（**C**laude **S**ession **R**ecover）を追加する。

設計の詳細・検証経緯は #1006 を参照。

## 変更

- **`home/.local/bin/csr-resolve.ts`**（新規, bun）: 決定論的な核。`~/.claude/projects/*/*.jsonl` を `JSON.parse` し、`url`（session id 完全一致）/ `gitBranch`（完全一致）でセッションを特定。`cwd` × **fork lineage（`forkedFrom` チェーン）** でまとめ、候補が真に1つなら `<repo>\t<worktree_path>\t<uuid>` を出力、複数なら人間ターン数・日付・抜粋つきで候補一覧を提示して非ゼロ終了。
- **`home/.zsh/functions.zsh`**: `csr` 関数を追加。resolver の結果を受け、worktree を `--detach` で再構築 → `cd` → `claude --resume`。関数なので `cd` が現在のシェルに残り対話 claude に突入できる。

## 設計上のポイント

- **bun(TS) + JSON.parse**: JSON を grep/sed で捌く脆さを排除。フィールド完全一致なので正規表現メタ文字の混入（`renovate/pnpm-11.x` の `.` 等）や本文言及の偽陽性が起きない。
- **選択ロジック（複数なら必ず候補提示、自動 resume は1つの時だけ）**: `forkedFrom` を root まで辿って系統をまとめ（親が未取得でも親 uuid を key に兄弟 fork を畳む）、系統内は最新 `timestamp` の末端を代表に。**該当系統が複数あれば自動で賭けず候補一覧を出す**。重み付けでセッションを黙って除外しない（人間ターン 0 の系統だけ、本物が他にあればノイズとして落とす）。
- **重みは人間ターンのみ**: `type:"user"` には tool_result も含まれるため、テキスト発言のみを数える。
- **zsh の `path` 回避**: 関数内で worktree パスを `path` に入れると zsh の `$PATH`（tie された配列）を破壊し `git`/`claude` が command not found になる。`wt` を使用。
- **`git_main_branch`**: 主ブランチをハードコードせず既存ヘルパで解決（master/trunk 等の repo にも対応）。

## 動作確認・レビュー対応

2 回の多角レビュー（max effort）の指摘を反映:

- **null/プリミティブ行ガード**: JSONL の単独 `null` 行で field 参照が throw しスクリプト全体が落ちるのを防止。
- **短い/新しいセッションを隠さない**: 旧 size/weight ベースの自動除外をやめ、複数該当時は必ず候補提示（silently 別セッションに入らない）。
- **fork 畳み**: 親が matched 外（branch 作成が fork より後）でも兄弟 fork を 1 系統に畳む。
- **timestamp**: 行順非依存で真の最大を採用。
- **完全一致**: `renovate/pnpm-11.x` が `renovate/pnpm-11Xx` に誤マッチしないこと、session id の前方一致誤マッチを防ぐことを確認。
- **session id 無し URL**: 明示エラーで終了。
- **非 worktree セッションのディレクトリ消失**: クリーンなエラー。
- bun build OK / zsh 構文 OK / `csr` 関数の resolve→cd→`claude --resume` 連結と `$PATH` 非破壊を確認。

## マージ後に必要な作業

`csr-resolve.ts` は新規ファイルのため、`~/.local/bin/` への symlink を張る stow の再実行が必要。実行には bun が必要だが `scripts/toolchains/node.sh` が native install するため全マシンで保証される。
