### PR TITLE
fix: write Raycast backup PR body under noclobber and rename alias to rbk

### DIFF
--- a/home/.config/raycast/scripts/raycast_backup.sh
+++ b/home/.config/raycast/scripts/raycast_backup.sh
@@ -112,7 +112,8 @@ git -C "$wt" push -u origin "$branch"
 pushed=1
 
 body_file="$(mktemp)"
-cat > "$body_file" <<'EOF'
+# set -C 下では mktemp 済みファイルへの > が弾かれるので >| で上書きする。
+cat >| "$body_file" <<'EOF'
 ## 概要
 
 Raycast 設定の定期バックアップ。`home/.config/raycast/backup/Raycast.rayconfig` を更新。

--- a/home/.config/raycast/scripts/raycast_backup.sh
+++ b/home/.config/raycast/scripts/raycast_backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Raycast 設定を export し、origin/main 基点の専用ブランチで PR を作ってブラウザで開く。
-# ターミナルから実行する（alias: rcb）。
+# ターミナルから実行する（alias: rbk）。
 #
 # 前提（初回のみ）:
 #   - Raycast でこのコマンドの外部起動確認を「Always Run Command」で抑制済み。

--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -87,4 +87,4 @@ alias tg="terragrunt"
 # Raycast
 # ----------------------------------------------------------------
 # Raycast 設定を export して専用ブランチで PR を作る
-alias rcb="$HOME/.config/raycast/scripts/raycast_backup.sh"
+alias rbk="$HOME/.config/raycast/scripts/raycast_backup.sh"


### PR DESCRIPTION
## 概要

`rbk`（旧 `rcb`）実機テストで PR 作成直前に失敗していた不具合を修正。あわせて alias 名を打ちやすい `rbk` に変更。

## 原因

`set -Ceuo pipefail` の `-C`（noclobber）下で、`body_file="$(mktemp)"`（ファイルを作成）の直後に `cat > "$body_file"` で上書きしようとして `cannot overwrite existing file` で停止していた。export・commit・push は成功しており、PR 本文ファイルの書き込みだけが落ちて `gh pr create` に到達していなかった。

## 修正

- `cat >| "$body_file"` に変更（noclobber を明示的に上書き）。
- alias `rcb` → `rbk` にリネーム（スクリプトのヘッダコメントも追従）。

## 補足

実機テストで export → commit → push の本番動作、および失敗時の cleanup（push 済みリモートブランチの自動削除＝先の M1 修正）が正しく機能することも確認できた。

refs #751
