### PR TITLE
feat: pick csr candidate via fzf with last-conversation preview

### DIFF
--- a/home/.local/bin/csr-resolve.test.ts
+++ b/home/.local/bin/csr-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatRow, messageText, lineageReps, repoOf, type Sess } from "./csr-resolve.ts";
+import { collectMessages, formatPreview, formatRow, messageText, lineageReps, repoOf, type Msg, type Sess } from "./csr-resolve.ts";
 
 describe("messageText", () => {
   test("string content はそのまま trim", () => {
@@ -99,5 +99,51 @@ describe("formatRow", () => {
         "/Users/x/dotfiles/.claude/worktrees/gentle-swinging-quasar\t" +
         "gentle-swinging-quasar  2026-05-22  62t  5664bcf4",
     );
+  });
+});
+
+describe("collectMessages", () => {
+  const jsonl = [
+    JSON.stringify({ type: "user", cwd: "/r/.claude/worktrees/s", timestamp: "2026-05-22T01:00:00Z", message: { content: "first" } }),
+    JSON.stringify({ type: "assistant", timestamp: "2026-05-22T02:00:00Z", message: { content: [{ type: "text", text: "reply" }] } }),
+    JSON.stringify({ type: "user", timestamp: "2026-05-22T03:00:00Z", message: { content: [{ type: "tool_result", content: "ignored" }] } }),
+    "null",
+    JSON.stringify({ type: "summary", summary: "x" }),
+  ].join("\n");
+
+  test("text の human/assistant のみ順番に集める", () => {
+    const { messages } = collectMessages(jsonl);
+    expect(messages).toEqual([
+      { role: "user", text: "first" },
+      { role: "assistant", text: "reply" },
+    ] satisfies Msg[]);
+  });
+  test("cwd と最大 timestamp を拾う", () => {
+    const { cwd, lastTs } = collectMessages(jsonl);
+    expect(cwd).toBe("/r/.claude/worktrees/s");
+    expect(lastTs).toBe("2026-05-22T03:00:00Z");
+  });
+});
+
+describe("formatPreview", () => {
+  const msgs: Msg[] = Array.from({ length: 20 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    text: `m${i}`,
+  }));
+  test("末尾 tail 件だけ・新しい末尾を含む", () => {
+    const out = formatPreview("HEAD", msgs, 3);
+    expect(out).toContain("HEAD");
+    expect(out).toContain("m19");
+    expect(out).not.toContain("m0\n");
+  });
+  test("role ラベルが付く", () => {
+    const out = formatPreview("HEAD", [{ role: "user", text: "hi" }, { role: "assistant", text: "yo" }]);
+    expect(out).toContain("👤 hi");
+    expect(out).toContain("🤖 yo");
+  });
+  test("cap を超える本文は切り詰める", () => {
+    const out = formatPreview("HEAD", [{ role: "user", text: "x".repeat(50) }], 5, 10);
+    expect(out).toContain("…(略)");
+    expect(out).not.toContain("x".repeat(50));
   });
 });

--- a/home/.local/bin/csr-resolve.test.ts
+++ b/home/.local/bin/csr-resolve.test.ts
@@ -57,7 +57,6 @@ describe("lineageReps", () => {
     forkedFrom: null,
     lastTs: "",
     humanTurns: 1,
-    snippet: "",
     ...o,
   });
   test("fork チェーンは最新 lastTs の1代表に畳む", () => {
@@ -91,7 +90,6 @@ describe("formatRow", () => {
       forkedFrom: null,
       lastTs: "2026-05-22T09:00:00Z",
       humanTurns: 62,
-      snippet: "...",
     };
     expect(formatRow(s)).toBe(
       "5664bcf4-273f-4474-8f1e-799eb72c9088\t" +

--- a/home/.local/bin/csr-resolve.test.ts
+++ b/home/.local/bin/csr-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { messageText, lineageReps, repoOf, type Sess } from "./csr-resolve.ts";
+import { formatRow, messageText, lineageReps, repoOf, type Sess } from "./csr-resolve.ts";
 
 describe("messageText", () => {
   test("string content はそのまま trim", () => {
@@ -80,5 +80,24 @@ describe("lineageReps", () => {
       base({ uuid: "q", lastTs: "2026-05-22T00:00:00Z" }),
     ]);
     expect(reps.map((s) => s.uuid).sort()).toEqual(["p", "q"]);
+  });
+});
+
+describe("formatRow", () => {
+  test("uuid\\trepo\\twt\\tdisplay を返す", () => {
+    const s: Sess = {
+      uuid: "5664bcf4-273f-4474-8f1e-799eb72c9088",
+      cwd: "/Users/x/dotfiles/.claude/worktrees/gentle-swinging-quasar",
+      forkedFrom: null,
+      lastTs: "2026-05-22T09:00:00Z",
+      humanTurns: 62,
+      snippet: "...",
+    };
+    expect(formatRow(s)).toBe(
+      "5664bcf4-273f-4474-8f1e-799eb72c9088\t" +
+        "/Users/x/dotfiles\t" +
+        "/Users/x/dotfiles/.claude/worktrees/gentle-swinging-quasar\t" +
+        "gentle-swinging-quasar  2026-05-22  62t  5664bcf4",
+    );
   });
 });

--- a/home/.local/bin/csr-resolve.test.ts
+++ b/home/.local/bin/csr-resolve.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { messageText, lineageReps, repoOf, type Sess } from "./csr-resolve.ts";
+
+describe("messageText", () => {
+  test("string content はそのまま trim", () => {
+    expect(messageText({ message: { content: "  hello  " } })).toBe("hello");
+  });
+  test("text ブロックを連結", () => {
+    expect(
+      messageText({ message: { content: [{ type: "text", text: "a" }, { type: "text", text: "b" }] } }),
+    ).toBe("a\nb");
+  });
+  test("tool_result は除外して空", () => {
+    expect(
+      messageText({ message: { content: [{ type: "tool_result", content: "x" }] } }),
+    ).toBe("");
+  });
+  test("thinking / tool_use は除外し text だけ残す", () => {
+    expect(
+      messageText({
+        message: {
+          content: [
+            { type: "thinking", thinking: "secret" },
+            { type: "tool_use", name: "Bash" },
+            { type: "text", text: "answer" },
+          ],
+        },
+      }),
+    ).toBe("answer");
+  });
+  test("content 無しは空", () => {
+    expect(messageText({})).toBe("");
+  });
+  test("空配列は空", () => {
+    expect(messageText({ message: { content: [] } })).toBe("");
+  });
+  test("content が null は空", () => {
+    expect(messageText({ message: { content: null } })).toBe("");
+  });
+});
+
+describe("repoOf", () => {
+  test("worktree サフィックスを除去", () => {
+    expect(repoOf("/Users/x/dotfiles/.claude/worktrees/gentle-swinging-quasar")).toBe(
+      "/Users/x/dotfiles",
+    );
+  });
+  test("worktree でない cwd はそのまま", () => {
+    expect(repoOf("/Users/x/dotfiles")).toBe("/Users/x/dotfiles");
+  });
+});
+
+describe("lineageReps", () => {
+  const base = (o: Partial<Sess>): Sess => ({
+    uuid: "",
+    cwd: "/r/.claude/worktrees/s",
+    forkedFrom: null,
+    lastTs: "",
+    humanTurns: 1,
+    snippet: "",
+    ...o,
+  });
+  test("fork チェーンは最新 lastTs の1代表に畳む", () => {
+    const reps = lineageReps([
+      base({ uuid: "a", lastTs: "2026-05-21T00:00:00Z" }),
+      base({ uuid: "b", forkedFrom: "a", lastTs: "2026-05-22T00:00:00Z" }),
+    ]);
+    expect(reps.map((s) => s.uuid)).toEqual(["b"]);
+  });
+  test("親が未ロードでも兄弟 fork を1系統に畳む", () => {
+    const reps = lineageReps([
+      base({ uuid: "x", forkedFrom: "ghost", lastTs: "2026-05-21T00:00:00Z" }),
+      base({ uuid: "y", forkedFrom: "ghost", lastTs: "2026-05-22T00:00:00Z" }),
+    ]);
+    expect(reps.map((s) => s.uuid)).toEqual(["y"]);
+  });
+  test("独立した2系統は2代表のまま", () => {
+    const reps = lineageReps([
+      base({ uuid: "p", lastTs: "2026-05-21T00:00:00Z" }),
+      base({ uuid: "q", lastTs: "2026-05-22T00:00:00Z" }),
+    ]);
+    expect(reps.map((s) => s.uuid).sort()).toEqual(["p", "q"]);
+  });
+});

--- a/home/.local/bin/csr-resolve.ts
+++ b/home/.local/bin/csr-resolve.ts
@@ -33,6 +33,48 @@ export function messageText(d: Record<string, any>): string {
   return "";
 }
 
+export type Msg = { role: "user" | "assistant"; text: string };
+
+const PREVIEW_TAIL = 16; // preview に出す末尾メッセージ数（"末尾多め"。残りは fzf スクロールで追う）
+const MSG_CAP = 1500; // 1 メッセージの上限（貼り付けログ等で preview が崩れるのを防ぐ）
+
+// jsonl 全体から text の human/assistant メッセージを時系列で集め、cwd と最大 timestamp も返す。
+export function collectMessages(text: string): { cwd: string; lastTs: string; messages: Msg[] } {
+  let cwd = "";
+  let lastTs = "";
+  const messages: Msg[] = [];
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    let d: Record<string, any>;
+    try {
+      d = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!d || typeof d !== "object") continue;
+    if (typeof d.cwd === "string" && !cwd) cwd = d.cwd;
+    if (typeof d.timestamp === "string" && d.timestamp > lastTs) lastTs = d.timestamp;
+    if (d.type === "user" || d.type === "assistant") {
+      const t = messageText(d);
+      if (t) messages.push({ role: d.type, text: t });
+    }
+  }
+  return { cwd, lastTs, messages };
+}
+
+// 末尾 tail 件を 👤/🤖 ラベル付きで整形。長い本文は cap で切り詰める。
+export function formatPreview(header: string, messages: Msg[], tail = PREVIEW_TAIL, cap = MSG_CAP): string {
+  const body = messages
+    .slice(-tail)
+    .map((m) => {
+      const label = m.role === "user" ? "👤" : "🤖";
+      const text = m.text.length > cap ? `${m.text.slice(0, cap)} …(略)` : m.text;
+      return `${label} ${text}`;
+    })
+    .join("\n\n");
+  return `${header}\n\n${body}\n`;
+}
+
 export const repoOf = (cwd: string) => cwd.replace(/\/\.claude\/worktrees\/[^/]+$/, "");
 
 export function formatRow(s: Sess): string {
@@ -162,11 +204,41 @@ function resolveMode(arg: string): number {
   return 0;
 }
 
+function previewMode(uuid: string): number {
+  let file = "";
+  for (const rel of new Glob(`*/${uuid}.jsonl`).scanSync(PROJECTS)) {
+    file = `${PROJECTS}/${rel}`;
+    break;
+  }
+  if (!file) {
+    console.error(`csr: session not found: ${uuid}`);
+    return 1;
+  }
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    console.error(`csr: cannot read: ${file}`);
+    return 1;
+  }
+  const { cwd, lastTs, messages } = collectMessages(text);
+  const header = `${uuid.slice(0, 8)} · ${basename(cwd) || "?"} · ${lastTs.slice(0, 10) || "?"}`;
+  process.stdout.write(formatPreview(header, messages));
+  return 0;
+}
+
 if (import.meta.main) {
-  const arg = process.argv[2];
-  if (!arg) {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "--preview") {
+    if (!argv[1]) {
+      console.error("usage: csr-resolve.ts --preview <uuid>");
+      process.exit(2);
+    }
+    process.exit(previewMode(argv[1]));
+  }
+  if (!argv[0]) {
     console.error("usage: csr-resolve.ts <claude-session-url|branch-name>");
     process.exit(2);
   }
-  process.exit(resolveMode(arg));
+  process.exit(resolveMode(argv[0]));
 }

--- a/home/.local/bin/csr-resolve.ts
+++ b/home/.local/bin/csr-resolve.ts
@@ -16,7 +16,6 @@ export type Sess = {
   forkedFrom: string | null;
   lastTs: string;
   humanTurns: number;
-  snippet: string;
 };
 
 // d.message.content からテキストブロックを抽出する（tool_result/thinking/tool_use は除外）。
@@ -136,7 +135,6 @@ function findCandidates(arg: string): { cands: Sess[]; error?: { msg: string; co
     let forkedFrom: string | null = null;
     let lastTs = "";
     let humanTurns = 0;
-    let snippet = "";
     let hit = false;
 
     for (const line of text.split("\n")) {
@@ -162,15 +160,12 @@ function findCandidates(arg: string): { cands: Sess[]; error?: { msg: string; co
 
       if (d.type === "user") {
         const t = messageText(d); // tool_result は除外されるので人間ターンのみ数える。
-        if (t) {
-          humanTurns++;
-          if (!snippet) snippet = t.replace(/\s+/g, " ").trim().slice(0, 60);
-        }
+        if (t) humanTurns++;
       }
     }
 
     if (!hit || !cwd) continue;
-    matched.push({ uuid: basename(file, ".jsonl"), cwd, forkedFrom, lastTs, humanTurns, snippet });
+    matched.push({ uuid: basename(file, ".jsonl"), cwd, forkedFrom, lastTs, humanTurns });
   }
 
   if (matched.length === 0) {

--- a/home/.local/bin/csr-resolve.ts
+++ b/home/.local/bin/csr-resolve.ts
@@ -1,33 +1,16 @@
 #!/usr/bin/env bun
 // クラウドセッション URL または branch 名から、消えた worktree のローカルセッションを特定する。
-// 1 件に絞れたら "<repo>\t<worktree_path>\t<uuid>" を stdout に出力。
-// 複数候補・不在は stderr に出して非ゼロ終了。csr 関数 (.zsh/functions.zsh) から呼ばれる。
-// 設計: https://github.com/nozomiishii/dotfiles/issues/1006
+// 候補を機械可読な TSV 行で列挙し、--preview <uuid> で末尾会話を整形出力する。
+// 判定と副作用は csr 関数 (.zsh/functions.zsh) 側。設計: https://github.com/nozomiishii/dotfiles/issues/1006
 
 import { Glob } from "bun";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename } from "node:path";
 
-const arg = process.argv[2];
-if (!arg) {
-  console.error("usage: csr-resolve.ts <claude-session-url|branch-name>");
-  process.exit(2);
-}
+const PROJECTS = `${homedir()}/.claude/projects`;
 
-const projects = `${homedir()}/.claude/projects`;
-
-// 入力判定: URL/session id らしき形なら URL モード(url フィールド)、それ以外は branch 名(gitBranch 完全一致)。
-// branch 名が偶然 "session_" を含んでも URL モードに誤入しないよう、URL らしさで判定する。
-// いずれも JSON フィールドの完全一致で照合するため、正規表現メタ文字の混入や本文言及の偽陽性が起きない。
-const urlLike = /^(https?:\/\/|session_)/.test(arg) || arg.includes("claude.ai/code/");
-const sid = urlLike ? (arg.match(/session_[A-Za-z0-9]+/)?.[0] ?? null) : null;
-if (urlLike && !sid) {
-  console.error(`csr: URL に session id が見つかりません: ${arg}`);
-  process.exit(2);
-}
-
-type Sess = {
+export type Sess = {
   uuid: string;
   cwd: string;
   forkedFrom: string | null;
@@ -36,87 +19,25 @@ type Sess = {
   snippet: string;
 };
 
-const matched: Sess[] = [];
-
-for (const rel of new Glob("*/*.jsonl").scanSync(projects)) {
-  const file = `${projects}/${rel}`;
-  let text: string;
-  try {
-    text = readFileSync(file, "utf8");
-  } catch {
-    continue;
+// d.message.content からテキストブロックを抽出する（tool_result/thinking/tool_use は除外）。
+export function messageText(d: Record<string, any>): string {
+  const c: unknown = d?.message?.content;
+  if (typeof c === "string") return c.trim();
+  if (Array.isArray(c)) {
+    return c
+      .filter((x) => x?.type === "text" && typeof x.text === "string")
+      .map((x) => x.text as string)
+      .join("\n")
+      .trim();
   }
-  // 安価な pre-filter（リテラル文字列。正規表現なし）。
-  if (sid ? !text.includes(sid) : !text.includes(`"gitBranch":"${arg}"`)) continue;
-
-  let cwd = "";
-  let forkedFrom: string | null = null;
-  let lastTs = "";
-  let humanTurns = 0;
-  let snippet = "";
-  let hit = false;
-
-  for (const line of text.split("\n")) {
-    if (!line) continue;
-    let d: Record<string, any>;
-    try {
-      d = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!d || typeof d !== "object") continue; // 単独 null やプリミティブ行で field 参照が throw するのを防ぐ。
-
-    // 構造化フィールドでの確定マッチ。url は session id を完全一致で照合
-    // （末尾スラッシュ/クエリがあっても拾え、かつ id の前方一致誤マッチも防ぐ）。
-    if (sid) {
-      if (typeof d.url === "string" && d.url.match(/session_[A-Za-z0-9]+/)?.[0] === sid) hit = true;
-    } else if (d.gitBranch === arg) {
-      hit = true;
-    }
-
-    if (typeof d.cwd === "string" && !cwd) cwd = d.cwd;
-    if (d.forkedFrom?.sessionId && !forkedFrom) forkedFrom = d.forkedFrom.sessionId;
-    // 行順に依存せず真の最大 timestamp を取る（末尾が summary 等で非時系列でも正しい）。
-    if (typeof d.timestamp === "string" && d.timestamp > lastTs) lastTs = d.timestamp;
-
-    // 人間ターンのみ数える（Claude は tool_result も type:"user" で保存するため content で判定）。
-    if (d.type === "user") {
-      const c: unknown = d.message?.content;
-      const human =
-        typeof c === "string"
-          ? c.trim().length > 0
-          : Array.isArray(c)
-            ? c.some((x) => x?.type === "text")
-            : false;
-      if (human) {
-        humanTurns++;
-        if (!snippet) {
-          const t =
-            typeof c === "string"
-              ? c
-              : (c as { type?: string; text?: string }[])
-                  .filter((x) => x?.type === "text")
-                  .map((x) => x.text ?? "")
-                  .join(" ");
-          const s = t.replace(/\s+/g, " ").trim();
-          if (s) snippet = s.slice(0, 60);
-        }
-      }
-    }
-  }
-
-  if (!hit || !cwd) continue;
-  matched.push({ uuid: basename(file, ".jsonl"), cwd, forkedFrom, lastTs, humanTurns, snippet });
+  return "";
 }
 
-if (matched.length === 0) {
-  console.error(`csr: no session found for: ${arg}`);
-  process.exit(1);
-}
+export const repoOf = (cwd: string) => cwd.replace(/\/\.claude\/worktrees\/[^/]+$/, "");
 
-// cwd 内を fork lineage でまとめ、各 lineage の代表(最新 last_ts)を返す。
+// cwd 内を fork lineage でまとめ、各 lineage の代表(最新 lastTs)を返す。
 // 親が matched 集合に無くても forkedFrom の uuid を lineage key にして兄弟 fork を畳む。
-function lineageReps(sessions: Sess[]): Sess[] {
+export function lineageReps(sessions: Sess[]): Sess[] {
   const byUuid = new Map(sessions.map((s) => [s.uuid, s]));
   const rootOf = (s: Sess): string => {
     let cur = s;
@@ -136,7 +57,7 @@ function lineageReps(sessions: Sess[]): Sess[] {
     if (g) g.push(s);
     else groups.set(r, [s]);
   }
-  // 代表 = 最新 last_ts（同点は human turns が多い方 = よりフルな履歴）。
+  // 代表 = 最新 lastTs（同点は human turns が多い方 = よりフルな履歴）。
   return [...groups.values()].map((members) =>
     members.reduce((a, b) =>
       b.lastTs > a.lastTs || (b.lastTs === a.lastTs && b.humanTurns > a.humanTurns) ? b : a,
@@ -144,37 +65,115 @@ function lineageReps(sessions: Sess[]): Sess[] {
   );
 }
 
-const byCwd = new Map<string, Sess[]>();
-for (const s of matched) {
-  const g = byCwd.get(s.cwd);
-  if (g) g.push(s);
-  else byCwd.set(s.cwd, [s]);
+// url|branch にマッチするセッションを ~/.claude/projects から収集して候補を返す。
+function findCandidates(arg: string): { cands: Sess[]; error?: { msg: string; code: number } } {
+  const urlLike = /^(https?:\/\/|session_)/.test(arg) || arg.includes("claude.ai/code/");
+  const sid = urlLike ? (arg.match(/session_[A-Za-z0-9]+/)?.[0] ?? null) : null;
+  if (urlLike && !sid) {
+    return { cands: [], error: { msg: `csr: URL に session id が見つかりません: ${arg}`, code: 2 } };
+  }
+
+  const matched: Sess[] = [];
+  for (const rel of new Glob("*/*.jsonl").scanSync(PROJECTS)) {
+    const file = `${PROJECTS}/${rel}`;
+    let text: string;
+    try {
+      text = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    // 安価な pre-filter（リテラル文字列。正規表現なし）。
+    if (sid ? !text.includes(sid) : !text.includes(`"gitBranch":"${arg}"`)) continue;
+
+    let cwd = "";
+    let forkedFrom: string | null = null;
+    let lastTs = "";
+    let humanTurns = 0;
+    let snippet = "";
+    let hit = false;
+
+    for (const line of text.split("\n")) {
+      if (!line) continue;
+      let d: Record<string, any>;
+      try {
+        d = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!d || typeof d !== "object") continue; // 単独 null やプリミティブ行で field 参照が throw するのを防ぐ。
+
+      // 構造化フィールドでの確定マッチ。url は session id を完全一致で照合。
+      if (sid) {
+        if (typeof d.url === "string" && d.url.match(/session_[A-Za-z0-9]+/)?.[0] === sid) hit = true;
+      } else if (d.gitBranch === arg) {
+        hit = true;
+      }
+
+      if (typeof d.cwd === "string" && !cwd) cwd = d.cwd;
+      if (d.forkedFrom?.sessionId && !forkedFrom) forkedFrom = d.forkedFrom.sessionId;
+      if (typeof d.timestamp === "string" && d.timestamp > lastTs) lastTs = d.timestamp;
+
+      if (d.type === "user") {
+        const t = messageText(d); // tool_result は除外されるので人間ターンのみ数える。
+        if (t) {
+          humanTurns++;
+          if (!snippet) snippet = t.replace(/\s+/g, " ").trim().slice(0, 60);
+        }
+      }
+    }
+
+    if (!hit || !cwd) continue;
+    matched.push({ uuid: basename(file, ".jsonl"), cwd, forkedFrom, lastTs, humanTurns, snippet });
+  }
+
+  if (matched.length === 0) {
+    return { cands: [], error: { msg: `csr: no session found for: ${arg}`, code: 1 } };
+  }
+
+  const byCwd = new Map<string, Sess[]>();
+  for (const s of matched) {
+    const g = byCwd.get(s.cwd);
+    if (g) g.push(s);
+    else byCwd.set(s.cwd, [s]);
+  }
+  const reps: Sess[] = [];
+  for (const sessions of byCwd.values()) reps.push(...lineageReps(sessions));
+
+  // 人間ターン 0 の lineage（teleport stub 等）は本物が他にあれば落とす。実会話は決して隠さない。
+  const withHuman = reps.filter((s) => s.humanTurns > 0);
+  const cands = withHuman.length ? withHuman : reps;
+  cands.sort((a, b) => b.lastTs.localeCompare(a.lastTs)); // 新しい順
+  return { cands };
 }
 
-const reps: Sess[] = [];
-for (const sessions of byCwd.values()) reps.push(...lineageReps(sessions));
-
-// 人間ターン 0 の lineage（teleport stub 等）は、本物の候補が他にあればノイズとして落とす。
-// 実際の会話を持つ（humanTurns>0）lineage は決して隠さない。
-const withHuman = reps.filter((s) => s.humanTurns > 0);
-const cands = withHuman.length ? withHuman : reps;
-
-const repoOf = (cwd: string) => cwd.replace(/\/\.claude\/worktrees\/[^/]+$/, "");
-
-if (cands.length === 1) {
-  const s = cands[0]!;
-  process.stdout.write(`${repoOf(s.cwd)}\t${s.cwd}\t${s.uuid}\n`);
-} else {
-  // 別物のセッションが複数 → 自動で選ばず、人間ターン数・日付・抜粋つきで候補を提示。
-  console.error("csr: 複数候補があります。branch 名で絞って再実行してください:");
-  cands.sort((a, b) => b.lastTs.localeCompare(a.lastTs));
-  for (const s of cands) {
-    const slug = basename(s.cwd);
-    const repo = basename(repoOf(s.cwd));
-    const date = s.lastTs.slice(0, 10);
-    console.error(
-      `  ${slug.padEnd(26)} ${repo.padEnd(12)} ${date}  ${String(s.humanTurns).padStart(3)}turns  ${s.snippet}`,
-    );
+function resolveMode(arg: string): number {
+  const { cands, error } = findCandidates(arg);
+  if (error) {
+    console.error(error.msg);
+    return error.code;
   }
-  process.exit(1);
+  if (cands.length === 1) {
+    const s = cands[0]!;
+    process.stdout.write(`${repoOf(s.cwd)}\t${s.cwd}\t${s.uuid}\n`);
+  } else {
+    console.error("csr: 複数候補があります。branch 名で絞って再実行してください:");
+    for (const s of cands) {
+      const slug = basename(s.cwd);
+      const repo = basename(repoOf(s.cwd));
+      console.error(
+        `  ${slug.padEnd(26)} ${repo.padEnd(12)} ${s.lastTs.slice(0, 10)}  ${String(s.humanTurns).padStart(3)}turns  ${s.snippet}`,
+      );
+    }
+    return 1;
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("usage: csr-resolve.ts <claude-session-url|branch-name>");
+    process.exit(2);
+  }
+  process.exit(resolveMode(arg));
 }

--- a/home/.local/bin/csr-resolve.ts
+++ b/home/.local/bin/csr-resolve.ts
@@ -35,6 +35,11 @@ export function messageText(d: Record<string, any>): string {
 
 export const repoOf = (cwd: string) => cwd.replace(/\/\.claude\/worktrees\/[^/]+$/, "");
 
+export function formatRow(s: Sess): string {
+  const display = `${basename(s.cwd)}  ${s.lastTs.slice(0, 10)}  ${s.humanTurns}t  ${s.uuid.slice(0, 8)}`;
+  return `${s.uuid}\t${repoOf(s.cwd)}\t${s.cwd}\t${display}`;
+}
+
 // cwd 内を fork lineage でまとめ、各 lineage の代表(最新 lastTs)を返す。
 // 親が matched 集合に無くても forkedFrom の uuid を lineage key にして兄弟 fork を畳む。
 export function lineageReps(sessions: Sess[]): Sess[] {
@@ -152,20 +157,8 @@ function resolveMode(arg: string): number {
     console.error(error.msg);
     return error.code;
   }
-  if (cands.length === 1) {
-    const s = cands[0]!;
-    process.stdout.write(`${repoOf(s.cwd)}\t${s.cwd}\t${s.uuid}\n`);
-  } else {
-    console.error("csr: 複数候補があります。branch 名で絞って再実行してください:");
-    for (const s of cands) {
-      const slug = basename(s.cwd);
-      const repo = basename(repoOf(s.cwd));
-      console.error(
-        `  ${slug.padEnd(26)} ${repo.padEnd(12)} ${s.lastTs.slice(0, 10)}  ${String(s.humanTurns).padStart(3)}turns  ${s.snippet}`,
-      );
-    }
-    return 1;
-  }
+  // 1 件でも複数でも同じ行フォーマットで stdout に出す。判定は csr() 側。
+  for (const s of cands) process.stdout.write(`${formatRow(s)}\n`);
   return 0;
 }
 

--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -14,11 +14,30 @@ jf() {
 # クラウドセッション URL または branch 名から復元して resume する。
 # git hooks で worktree が自動削除された後の最終手段。設計: nozomiishii/dotfiles#1006
 csr() {
-  local res
-  res=$(csr-resolve.ts "$1") || return 1 # "<repo>\t<worktree_path>\t<uuid>"
+  local rows
+  rows=$(csr-resolve.ts "$1") || return 1 # 各行: <uuid>\t<repo>\t<wt>\t<display>
+  local -a lines
+  lines=("${(@f)rows}")
+
+  local line
+  if (( ${#lines} > 1 )); then
+    # 複数候補 → 各セッションの「最後の会話」を preview しながら fzf で選ぶ。
+    if (( ! $+commands[fzf] )); then
+      echo "csr: 複数候補があります（fzf 未導入のため一覧表示）:" >&2
+      cut -f4 <<<"$rows" >&2
+      return 1
+    fi
+    line=$(fzf --delimiter=$'\t' --with-nth=4 \
+               --preview='csr-resolve.ts --preview {1}' \
+               --preview-window='right:60%:wrap' <<<"$rows") || return 1
+  else
+    line=$lines[1]
+  fi
+
   # zsh の `path` は $PATH に tie された配列なので変数名に使わない（git/claude が見つからなくなる）。
-  local repo wt uuid
-  IFS=$'\t' read -r repo wt uuid <<<"$res"
+  local uuid repo wt
+  IFS=$'\t' read -r uuid repo wt _ <<<"$line"
+
   # worktree が無ければ detached HEAD で再構築する（元 branch は復元不可なので repo の主ブランチを使う）。
   if [[ ! -d $wt ]]; then
     if [[ $repo == "$wt" ]]; then


### PR DESCRIPTION
refs #1006

## 概要

`csr` で候補が複数のとき、各セッションの「最後の会話の終わり方」を fzf の preview で見せて選択し、選んだものを worktree 再構築して resume できるようにする。判断基準は「最後の会話がどう終わっているか」。候補が1つなら従来通り即 resume（高速パス維持）。

## 変更

- **`csr-resolve.ts`**: 純粋関数（`messageText` / `repoOf` / `lineageReps` / `formatRow` / `collectMessages` / `formatPreview`）を export し、`import.meta.main` ガードで CLI を分離。候補を統一 TSV 行 `<uuid>\t<repo>\t<wt>\t<display>` で stdout に列挙（1件でも複数でも同形式）。`--preview <uuid>` モードで末尾会話を 👤/🤖 付き・末尾16件・1メッセージ1500字 cap で整形出力。判定（1なら即/多なら fzf）は resolver でなく csr() 側に集約。
- **`csr-resolve.test.ts`（新規）**: bun test。実装ファイルと並列配置。合成 jsonl で fork 畳み・human ターン数え（tool_result 除外）・行整形・preview 抽出を回帰テスト（18 tests）。
- **`csr()`（zsh）**: 1件は即 resume、複数は fzf（`--with-nth=4` で display 表示、`{1}`=uuid を preview キー、`right:60%:wrap`）。fzf 未導入はフォールバック一覧、Esc は静かに return。worktree 再構築（`--detach`）・`repo==wt` エラー・`path` 変数回避などの既存挙動は保持。

## 検証

- bun test 18 pass / 0 fail（`bun test ./home/.local/bin/csr-resolve.test.ts`）
- `zsh -n home/.zsh/functions.zsh` clean
- resolver が実データで候補行を出力・`--preview <uuid>` が末尾会話を出力することを確認
- resolver 行と csr() の `read -r uuid repo wt _` のフィールド整合、fzf `{1}`=uuid / `--with-nth=4`=display の対応を最終レビューで確認

## Test Plan（対話部分は手動確認）

fzf の TUI は TTY 必須で自動テストできないため、新しいシェルで以下を確認:

- [ ] 複数候補（例: `csr https://claude.ai/code/session_013LqaVjPdF1t1YJ6M7tkxA6`）で fzf が display 列で開き、右ペインに選択中セッションの最後の会話が出る（Shift+↑↓ でスクロール）
- [ ] 候補を選んで Enter → worktree が無ければ再構築 → その worktree に cd して `claude --resume` に突入
- [ ] Esc キャンセルで静かに戻り、`$PATH` が壊れず `git`/`claude` が使える
- [ ] 単一候補に絞れる branch 名では fzf を出さず即 resume

## マージ後

`csr-resolve.test.ts` は新規ファイル。`~/.local/bin/` への symlink は stow が再実行で張る（テスト自体は repo から `bun test` するため PATH 不要）。
