### PR TITLE
chore: make stow setup conflict-proof with --adopt

### DIFF
--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -17,8 +17,19 @@ cd "$SCRIPT_DIR"
 # stow would happily link them into $HOME on every restow.
 find home -name '.DS_Store' -delete
 
-# repo を常に正とする。衝突する実体ファイルは --adopt で stow が吸収し
-# （削除しない）、直後に git restore で repo 版へ戻してローカル内容は破棄する。
+# --adopt は衝突した実体ファイルを repo の working tree に吸収するため、home/ に
+# 未コミットの変更があると、後段の git restore を待たず adopt 自身が上書きして消す。
+# 破棄を防ぐため、adopt する前に home/ の未コミット変更を検出して中断する。
+if ! git diff --quiet -- home || ! git diff --quiet --cached -- home; then
+  echo "ERROR: home/ に未コミットの変更があります。stow --adopt で破棄されるため中断します。" >&2
+  echo "       commit か stash してから再実行してください。" >&2
+  git status --short -- home >&2
+  exit 1
+fi
+
+# repo を常に正とする。衝突する実体ファイルは --adopt で stow が吸収し（削除しない）、
+# 直後に git restore で repo 版へ戻す。home/ は上のチェックでクリーンなので、
+# restore が戻すのは adopt が吸収した分だけ。
 stow --adopt --verbose --restow --target="$HOME" home
 git restore home
 

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -10,12 +10,6 @@ set -Ceuo pipefail
 
 echo -e "🐂 stow"
 
-echo "Pre-removing known conflicting files..."
-rm -f "$HOME/.gitconfig"
-rm -f "$HOME/.zprofile"
-rm -f "$HOME/.zshrc"
-rm -f "$HOME/.bashrc"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -23,7 +17,10 @@ cd "$SCRIPT_DIR"
 # stow would happily link them into $HOME on every restow.
 find home -name '.DS_Store' -delete
 
-stow --verbose --restow --target="$HOME" home
+# repo を常に正とする。衝突する実体ファイルは --adopt で stow が吸収し
+# （削除しない）、直後に git restore で repo 版へ戻してローカル内容は破棄する。
+stow --adopt --verbose --restow --target="$HOME" home
+git restore home
 
 SKILLS_DIR="$HOME/.config/skills"
 if [ -d "$SKILLS_DIR" ]; then


### PR DESCRIPTION
## 背景

新品 Mac で `install.sh` を流すと、ツールが先に作った実体ファイル（`~/.zprofile` 等）と stow が衝突して失敗する。その対策として `scripts/symlink.sh` は stow 前に `~/.gitconfig` `~/.zprofile` `~/.zshrc` `~/.bashrc` を `rm -f` で消していた。

## 問題

stow は package 内の **どれか1つでも**衝突を見つけると**全体を atomic に中止**する。`set -Ceuo pipefail` 下では:

1. `rm -f` で 4 ファイルを削除
2. stow が**別のファイル**で衝突 → 全体 abort
3. 削除した 4 ファイルは貼り直されず、**消えたまま復活しない**

実際にこれを踏み、`~/.gitconfig`（`core.quotePath = false` 等を含む）が消えて git の日本語ファイル名が `\343\202...` とエスケープ表示される状態になっていた。`rm` のハードコードリストは新規 dotfile が増えるたびにメンテも必要だった。

## 変更

repo を常に正とする方針のもと、ハードコードの `rm -f` を撤廃し `stow --adopt` 方式へ:

- `--adopt` … 衝突した実体ファイルを stow が**消さずに** package へ吸収（symlink がそれを指す）
- `git restore home` … 吸収した中身を捨てて repo 版へ戻す（ローカル内容は破棄）

結果、どのファイルが衝突しても削除ゼロで symlink 化でき、新規ファイルも自動で飲み込む。ローカルの内容は常に repo 版で上書きされる（意図通り）。

## 検証

隔離環境で E2E 確認済み:

- before: target = 実体ファイル（ローカル内容）
- after: target = repo ファイルへの symlink、内容は repo 版
- repo working tree はクリーン（吸収したローカル内容は破棄）
