### PR TITLE
fix: pass cwb prompt via stdin to avoid worktree name length error

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -52,7 +52,14 @@ alias cr="claude --resume"
 alias crs="claude respawn --all"
 alias ct="claude --teleport"
 alias cw="claude --worktree"
-alias cwb="claude --worktree --bg"
+# プロンプトは stdin で渡す。引数で渡すと worktree 名に流用され 64 字制限で死ぬため
+cwb() {
+  if [ $# -gt 0 ]; then
+    printf '%s' "$*" | claude --worktree --bg
+  else
+    claude --worktree --bg
+  fi
+}
 alias cwr="claude --worktree --resume"
 alias cwt="claude --worktree --teleport"
 


### PR DESCRIPTION
## 概要

`cwb`（`claude --worktree --bg`）に長いプロンプトを渡すとセッション作成が失敗する問題を修正する。

## 原因

`claude --worktree --bg '<prompt>'` は、`--worktree` に明示名が無いとき**最初のプロンプト（intent）をそのまま git worktree 名に流用**する。この名前は 64 文字制限のバリデーションにかかり、超えるとバックグラウンド子プロセスが `exit 1 before init` で死ぬ。

```
Error creating worktree: Invalid worktree name: must be 64 characters or fewer (got 82)
```

- `cwb 'test'`（短い）は通り、長い日本語プロンプトで死ぬ（"got N" = プロンプトの文字数と一致）
- `--print` 一発実行や stdin 経由ではプロンプトが名前にならず自動生成名になる（経路依存）
- Claude Code 2.1.150 で確認。dotfiles 側の問題ではなく CLI の挙動

## 修正

`cwb` を alias から関数に変更し、プロンプトを **stdin** で渡す。これにより worktree 名は自動生成され、プロンプト長に関係なく成功する。引数なしの `cwb` は従来どおり対話起動。

## 検証

- `printf '%s' '<82 字の日本語>' | claude --worktree --bg` が `working` に到達する（worktree 名は自動生成）ことを再現確認
- 新しい interactive zsh で `cwb` が shell function として認識されることを確認
- `cwb '長文'` / 複数語 / 引数なし の各経路をモックで検証

## 補足

- 同型のバグは `cw`（`claude --worktree`）にもある（`--worktree` 直後の位置引数が明示名として消費される）。本 PR のスコープ外。
- 上流（anthropics/claude-code）に同一の既存 issue は見当たらず、新規報告の価値あり。
