### PR TITLE
fix: scroll fzf preview with the mouse wheel in csr

### DIFF
--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -27,9 +27,11 @@ csr() {
       cut -f4 <<<"$rows" >&2
       return 1
     fi
+    # ホイール/トラックパッドのスクロールは preview に向ける（既定だとリストが動いて画面が揺れる）。
     line=$(fzf --delimiter=$'\t' --with-nth=4 \
                --preview='csr-resolve.ts --preview {1}' \
-               --preview-window='right:60%:wrap' <<<"$rows") || return 1
+               --preview-window='right:60%:wrap' \
+               --bind='scroll-up:preview-up,scroll-down:preview-down' <<<"$rows") || return 1
   else
     line=$lines[1]
   fi


### PR DESCRIPTION
## 概要

[#1012](https://github.com/nozomiishii/dotfiles/pull/1012) で入れた `csr` の fzf プレビューで、トラックパッド/ホイールのスクロールが候補リスト側に効いてしまい、3 候補の間でカーソルが動いて画面がガタつく問題を修正する。

ホイールの `scroll-up` / `scroll-down` を preview のスクロール（`preview-up` / `preview-down`）に bind し、トラックパッドのスクロールが常に preview を動かすようにした。候補は通常少数なので、ホイールでのリスト移動を犠牲にしても支障はない（リスト移動は矢印キー等で可能）。

## 変更

- `home/.zsh/functions.zsh`: `csr()` の fzf 呼び出しに `--bind='scroll-up:preview-up,scroll-down:preview-down'` を追加。

## 検証

- `zsh -n` clean / `--bind` 構文が fzf 0.72.0 で通ることを確認。
- 体感（スクロールが滑らかか）は手動確認をお願いします。
