### PR TITLE
chore: convert markdownlint config to esm

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,1 +1,0 @@
-module.exports = require('@nozomiishii/markdownlint-cli2-config');

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,0 +1,1 @@
+export { default } from "@nozomiishii/markdownlint-cli2-config";


### PR DESCRIPTION
## 概要

`.markdownlint-cli2.cjs` を `.markdownlint-cli2.mjs` にリネームし、CommonJS の `require` から ESM の `export` 形式に変換した。

共有 config リポジトリ（`~/Code/nozomiishii/configs/.markdownlint-cli2.mjs`）の書き方に揃えるのが目的。

## 変更内容

- 削除: `.markdownlint-cli2.cjs`（`module.exports = require('@nozomiishii/markdownlint-cli2-config')`）
- 追加: `.markdownlint-cli2.mjs`（`export { default } from "@nozomiishii/markdownlint-cli2-config"`）

## 確認

- `pnpm exec markdownlint-cli2 "README.md"` で `.mjs` config が読み込まれ、ルールが従来どおり適用されることを確認
- prettier 適用済み（ダブルクォート）