### PR TITLE
chore: ignore macOS resource fork files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # System Files
 .DS_Store
+# ネットワーク/USB ボリュームで macOS が生成する resource fork
+._*
 
 # Node
 node_modules


### PR DESCRIPTION
macOS がネットワーク/USB ボリュームで生成する `._*` を gitignore に追加する。