### PR TITLE
chore: set ghostty macos-titlebar-style to tabs

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -11,6 +11,7 @@
 # https://zenn.dev/kawarimidoll/articles/5f219b4409424b
 macos-icon = holographic
 macos-option-as-alt = true
+macos-titlebar-style = tabs
 
 # Theme
 # Run `ghostty +list-themes` to view a list of themes


### PR DESCRIPTION
## 概要

Ghostty のタイトルバースタイルを `tabs` に設定し、タブをタイトルバー領域に統合する。

## 変更

`home/.config/ghostty/config` に `macos-titlebar-style = tabs` を追加。

## 適用方法

stow リンク済みのため反映は Ghostty の再起動が必要。