### PR TITLE
chore: add git-delta as syntax-highlighting git pager

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -149,6 +149,9 @@ if OS.mac?
   # Distributed revision control system. https://git-scm.com
   brew "git"
 
+  # Syntax-highlighting pager for git, diff, grep output https://github.com/dandavison/delta
+  brew "git-delta"
+
   # GNU grep, egrep and fgrep https://www.gnu.org/software/grep/
   brew "grep"
 

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -10,6 +10,8 @@ signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDF31h4ogJY+JRiI+k0+aLoO/OTnEI1
 ignorecase = false
 # 日本語ファイル表示 (非 ASCII ファイル名をエスケープせず生表示)
 quotePath = false
+# diff/show/log を delta で syntax highlight 表示 https://github.com/dandavison/delta
+pager = delta
 
 [init]
 # git init のデフォルトブランチ名
@@ -51,6 +53,18 @@ useForceIfIncludes = true
 [merge]
 # fast-forward 可能な merge のみ許可 (手動 merge で commit を作らない安全弁)
 ff = only
+
+[interactive]
+# git add -p などの対話 diff も delta で色付け
+diffFilter = delta --color-only
+
+[delta]
+# n で次・p で前の差分へジャンプ
+navigate = true
+# 差分を左右で表示
+side-by-side = true
+# hunk 見出し(@@行)を非表示
+hunk-header-style = omit
 
 [gpg]
 # commit 署名形式


### PR DESCRIPTION
## 概要

[git-delta](https://github.com/dandavison/delta) を導入し、git の diff/show/log をシンタックスハイライト表示にする。

## 変更

- `Brewfile`: `git-delta` を追加
- `home/.gitconfig` `[core]`: `pager = delta`
- `home/.gitconfig` `[interactive]`: `diffFilter = delta --color-only`（`git add -p` 等の対話 diff も色付け）
- `home/.gitconfig` `[delta]`:
  - `navigate = true`（pager 表示中に `n`=次 / `p`=前 の差分へジャンプ）
  - `side-by-side = true`（差分を左右2カラム表示）
  - `hunk-header-style = omit`（`@@` 見出しを非表示。セクション見出しが誤解を招くため）

## 補足

行番号表示（`line-numbers`）と hunk 見出しのセクション名表示は検討の末いずれも不採用。後者は git の hunk header の見出し行が必ずしも意味的なセクションを指さないため、`omit` で消す方針にした。