### PR TITLE
chore: tokenize delta intra-line diff per-char for CJK

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -65,6 +65,8 @@ navigate = true
 side-by-side = true
 # hunk 見出し(@@行)を非表示
 hunk-header-style = omit
+# 行内強調の単位。既定 \w+ だと空白の無い日本語は行全体が光るので、英数字は単語・他は1文字で区切る
+word-diff-regex = "[a-zA-Z0-9_]+|."
 
 [gpg]
 # commit 署名形式


### PR DESCRIPTION
## 概要
delta の既定 `word-diff-regex` は `\w+`。Unicode 対応なので日本語も単語とみなすが、日本語は文字間に区切りが無く句読点以外が丸ごと 1 トークン化する。結果、一部変更でも行全体が強調され変更箇所が分からない。

## 変更
`word-diff-regex = "[a-zA-Z0-9_]+|."` を設定。英数字は単語単位、それ以外(CJK 含む)は 1 文字単位に分割。

## 検証
- 日本語「公式」→「最新の公式」: `最新の` だけ強調
- 英語は単語単位で強調
- `.` 単独だと別単語置換で飛び石強調(`banana`→`andorra` が `dorr` だけ)になるため不採用