### PR TITLE
fix: force IPv4 for github.com ssh to dodge IPv6 blackhole

### DIFF
--- a/home/.ssh/config
+++ b/home/.ssh/config
@@ -3,5 +3,10 @@
 # This won't be added again if you remove it.
 Include ~/.orbstack/ssh/config
 
+# GitHub を IPv4 に固定。Tailscale(MagicDNS)が AAAA を返すと IPv6 経路が
+# ブラックホール化して接続がタイムアウトするため、IPv4 で接続する
+Host github.com
+  AddressFamily inet
+
 Host *
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"


### PR DESCRIPTION
## 概要
Tailscale 稼働中に `git push`/`ssh` が port 22 でタイムアウトする問題の修正。

## 原因
GitHub が AAAA(IPv6) を持つようになり Tailscale MagicDNS(`100.100.100.100`) 経由で返る。OS が IPv6 を優先するがこの環境の IPv6 経路はブラックホールでタイムアウトする。

実測: `ssh -4 git@github.com` は成功、`ssh git@github.com`(v6 優先) は port 22 タイムアウト。

## 変更
`Host github.com` に `AddressFamily inet` を追加し IPv4 固定。port 22 は IPv4 なら通るため 443 化は不要。