### PR TITLE
chore: repoint brain vault paths off icloud

### DIFF
--- a/home/.claude/skills/backlog/SKILL.md
+++ b/home/.claude/skills/backlog/SKILL.md
@@ -21,7 +21,7 @@ argument-hint: バックログのタイトル / 補足（任意）
 
 - ネタ元は **直前までの会話の要約**。会話が薄いときだけ、最小限の対話で概要・タイトルを補う。
 - brain vault の canonical パス（Obsidian が見ている実体 / git の main checkout）:
-  `BRAIN="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"`
+  `BRAIN="$HOME/Code/nozomiishii/brain"`
   （ユーザー名はハードコードせず `$HOME` を使う）
 - backlog ノートのスキーマ（frontmatter / 見出し構成）は本 skill のステップ 7 で定義する。brain repo `CLAUDE.md` のディレクトリ表にも `backlog/` 行があるが、運用詳細はこの skill に集約する。
 
@@ -133,5 +133,5 @@ gh pr create -R <brain owner/repo> --base main --head "chore/backlog-<slug>" --t
 ## 注意
 
 - **session URL は GitHub の issue / PR 本文には絶対に貼らない（public / private を問わず）**。session URL を載せてよいのは brain vault のノート（`## Session`）だけ。これは「URL の置き場を vault 1 箇所に限定して事故を防ぐ」ための意図的な運用境界なので、private repo だから OK といった例外も作らない。GitHub 側（issue / PR 本文）には URL でなく要約・タスク内容を書く。
-- なぜ vault は OK で GitHub は NG か: session URL（`https://claude.ai/code/session_xxx`）は visibility がデフォルト **Private**（owner 本人のみ閲覧可）。brain vault はローカル + iCloud 同期で本人のみアクセスするため Private session URL を置いても安全。一方 GitHub に貼ると、その issue / PR が public（または将来 public 化）した瞬間に会話全文が全 claude.ai ユーザーへ露出しうる。だから vault に一元化する。
+- なぜ vault は OK で GitHub は NG か: session URL（`https://claude.ai/code/session_xxx`）は visibility がデフォルト **Private**（owner 本人のみ閲覧可）。brain vault は本人のみがアクセスするローカル環境のため Private session URL を置いても安全。一方 GitHub に貼ると、その issue / PR が public（または将来 public 化）した瞬間に会話全文が全 claude.ai ユーザーへ露出しうる。だから vault に一元化する。
 - ノートを worktree に書いた段階では Obsidian（canonical を見ている）にはまだ出ない。PR が main に merge されてから反映される。

--- a/home/.claude/skills/broadcast/SKILL.md
+++ b/home/.claude/skills/broadcast/SKILL.md
@@ -34,7 +34,6 @@ jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSO
 
 - `enabled: false` は対象外
 - `rootPath` の `~` は `$HOME` に展開する（`jq` 後に shell or 自前で展開）
-- **パスを見ての事前絞り込みは絶対にしない**。「Obsidian の iCloud パスっぽいから git じゃないだろう」などの推測で対象から外さない（実例として `🪴 brain` = `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` は git リポジトリで、CODEOWNERS など共通設定の対象になる）
 
 ## 1. 対象リストを提示する
 
@@ -44,7 +43,7 @@ jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSO
 | name          | rootPath                              | 対象ファイル有無 |
 |---------------|---------------------------------------|------------------|
 | 🧙🏿‍♂️ dotfiles | ~/dotfiles                            | あり             |
-| 🪴 brain      | ~/Library/.../Documents               | なし             |
+| 🪴 brain      | ~/Code/nozomiishii/brain              | なし             |
 | 🛰️ infra      | ~/Code/nozomiishii/infra              | あり             |
 | ...           | ...                                   | ...              |
 ```

--- a/home/.config/zellij/layouts/code.kdl
+++ b/home/.config/zellij/layouts/code.kdl
@@ -32,8 +32,8 @@ layout {
             plugin location="zellij:tab-bar"
         }
         pane split_direction="vertical" {
-            pane cwd="Library/Mobile Documents/iCloud~md~obsidian/Documents" size="50%"
-            pane cwd="Library/Mobile Documents/iCloud~md~obsidian/Documents" size="50%"
+            pane cwd="Code/nozomiishii/brain" size="50%"
+            pane cwd="Code/nozomiishii/brain" size="50%"
         }
         pane size=1 borderless=true {
             plugin location="zellij:status-bar"


### PR DESCRIPTION
## 概要

brain vault の保存先が iCloud（`~/Library/Mobile Documents/iCloud~md~obsidian/Documents`）から `~/Code/nozomiishii/brain` へ移行したのに伴い、dotfiles 内のパス参照を更新する。

## 変更

- `home/.config/zellij/layouts/code.kdl`: brain タブの 2 ペイン cwd を `Code/nozomiishii/brain` に更新
- `home/.claude/skills/backlog/SKILL.md`: `BRAIN` パスを更新。session URL 安全性の根拠から iCloud 依存の記述を除去
- `home/.claude/skills/broadcast/SKILL.md`: 例表のパスを更新。brain が iCloud パスで紛らわしいことを前提にした「事前絞り込み禁止」の注意を削除（普通の `~/Code` パスになり存在理由が消えたため）

## 据え置き

- `home/.claude/statusline.sh:71`: `~` を %7E エスケープする技術的理由の例示コメント。挙動は現役なので残す。

関連: Obsidian vault の iCloud → Self-hosted LiveSync 移行作業の一部。
