### PR TITLE
chore: drop stale Raycast import step from README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -264,7 +264,6 @@ Finder Sidebar
 - 先に Finder のセットアップを済ませてください
 
 - サインイン
-- "~/dotfiles/src/configs/\_raycast/backup" から設定をインポート
 
 ### 🐟 VSCode
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ Finder Sidebar
 - needs: Finder setup
 
 - Sign in
-- Import Settings from "~/dotfiles/src/configs/\_raycast/backup"
 
 ### 🐟 VSCode
 


### PR DESCRIPTION
## 概要

README の Raycast セクションにある「`~/dotfiles/src/configs/_raycast/backup` から設定をインポート」手順を削除する。

## 背景

- `src/configs/_raycast/backup` は Raycast 設定のバックアップ置き場だったが、#321（chezmoi 移行）で `src/configs/` ごと廃止された
- その後 #676（日本語 README 追加）が、既に存在しないこのパスを README に書いてしまい、英語版にも残っていた
- このパスを参照するコードや設定は無く、Raycast 設定を repo で持つ仕組み自体が現在は存在しない

参照先が無い死んだ手順なので、日本語・英語 README の両方から該当行を削除する。サインイン手順は有効なので残す。
