### PR TITLE
feat: make dotfiles location-independent (#1057)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,11 @@ macOS と Linux で開発環境のセットアップを自動化する dotfiles 
   - dotfiles は複数の Mac で異なるユーザー名で運用されるため、`/Users/<name>/...` と直書きせず `$HOME` または `~` を使うこと。
   - LaunchAgent plist で `$HOME` 展開が必要な場合は `bash -l -c 'exec "$HOME/..."'` を経由する（参考: [home/Library/LaunchAgents/local.brew-update.plist](home/Library/LaunchAgents/local.brew-update.plist)）
 
+- repo の配置場所をハードコードしない。
+  - 別マシンや別 worktree で repo の置き場が変わっても動く必要がある。`$HOME/dotfiles/...` のような repo 実体パスを外から名指ししない。
+  - launchd plist や VS Code 設定など外部ツールからは `$HOME/.local/bin/<name>.sh` 経由で呼ぶ。リンクは [scripts/symlink.sh](scripts/symlink.sh) が張る。
+  - スクリプト内で repo root が要る場合は `readlink -f "${BASH_SOURCE[0]}"` の自己参照で解決する。参考: [scripts/darwin/brew_update.sh](scripts/darwin/brew_update.sh)
+
 
 ## 設定の更新
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -168,7 +168,7 @@ open https://nozomiishii.dev/dotfiles
 ### Clone
 
 ```shell
-cd ~ && git clone https://github.com/nozomiishii/dotfiles.git
+mkdir -p ~/Code/nozomiishii && git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
 ```
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ open https://nozomiishii.dev/dotfiles
 ### Clone
 
 ```shell
-cd ~ && git clone https://github.com/nozomiishii/dotfiles.git
+mkdir -p ~/Code/nozomiishii && git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
 ```
 
 ### Install

--- a/home/.claude/skills/broadcast/SKILL.md
+++ b/home/.claude/skills/broadcast/SKILL.md
@@ -42,7 +42,7 @@ jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSO
 ```
 | name          | rootPath                              | 対象ファイル有無 |
 |---------------|---------------------------------------|------------------|
-| 🧙🏿‍♂️ dotfiles | ~/dotfiles                            | あり             |
+| 🧙🏿‍♂️ dotfiles | ~/Code/nozomiishii/dotfiles           | あり             |
 | 🪴 brain      | ~/Code/nozomiishii/brain              | なし             |
 | 🛰️ infra      | ~/Code/nozomiishii/infra              | あり             |
 | ...           | ...                                   | ...              |

--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -16,7 +16,7 @@
   // dotfiles
   // ----------------------------------------------------------------
   "dotfiles.repository": "nozomiishii/dotfiles",
-  "dotfiles.targetPath": "~/dotfiles",
+  "dotfiles.targetPath": "~/Code/nozomiishii/dotfiles",
   "dotfiles.installCommand": "install.sh",
 
   // ----------------------------------------------------------------

--- a/home/Library/LaunchAgents/local.brew-update.plist
+++ b/home/Library/LaunchAgents/local.brew-update.plist
@@ -10,7 +10,7 @@
     <string>/bin/bash</string>
     <string>-l</string>
     <string>-c</string>
-    <string>exec "$HOME/dotfiles/scripts/darwin/brew_update.sh"</string>
+    <string>exec "$HOME/.local/bin/brew_update.sh"</string>
   </array>
 
   <!-- 毎日 10:00 に実行。スリープ中は StartCalendarInterval が発火せず次の wake に持ち越され、

--- a/home/Library/LaunchAgents/local.claude-insights.plist
+++ b/home/Library/LaunchAgents/local.claude-insights.plist
@@ -12,7 +12,7 @@
     <string>-c</string>
     <!-- $HOME を bash 展開で解決するためログインシェルで起動。claude(~/.local/bin) の
          PATH 追加はスクリプト側で行う（login bash の PATH には入らないため） -->
-    <string>exec "$HOME/dotfiles/scripts/darwin/claude_insights.sh"</string>
+    <string>exec "$HOME/.local/bin/claude_insights.sh"</string>
   </array>
 
   <!-- 毎月 1 日・15 日の 10:00 に実行（月 2 回）。発火時刻にスリープなら起床時に取りこぼし分を

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 DOTFILES_REPO="https://github.com/nozomiishii/dotfiles.git"
-DOTFILES_DIR="$HOME/dotfiles"
+DOTFILES_DIR="$HOME/Code/nozomiishii/dotfiles"
 OS_NAME="$(uname -s)"
 
 # ----------------------------------------------------------------

--- a/scripts/darwin/brew_update.sh
+++ b/scripts/darwin/brew_update.sh
@@ -7,9 +7,7 @@
 #               code in the pipeline, or zero if all commands succeed
 set -Ceuo pipefail
 
-# launchd は ~/.local/bin/brew_update.sh (symlink) からこのスクリプトを起動するため、
-# BASH_SOURCE はその symlink パスになる。readlink -f で実体まで解決してから
-# scripts/darwin/.. の 2 階層上を repo root として取り出す。repo の配置に依存しない。
+# symlink を解決して repo root を得る。
 DOTFILES_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." && pwd)"
 
 if [[ ! -f "$DOTFILES_DIR/Makefile" ]]; then

--- a/scripts/darwin/brew_update.sh
+++ b/scripts/darwin/brew_update.sh
@@ -7,7 +7,10 @@
 #               code in the pipeline, or zero if all commands succeed
 set -Ceuo pipefail
 
-DOTFILES_DIR="$HOME/dotfiles"
+# launchd は ~/.local/bin/brew_update.sh (symlink) からこのスクリプトを起動するため、
+# BASH_SOURCE はその symlink パスになる。readlink -f で実体まで解決してから
+# scripts/darwin/.. の 2 階層上を repo root として取り出す。repo の配置に依存しない。
+DOTFILES_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." && pwd)"
 
 if [[ ! -f "$DOTFILES_DIR/Makefile" ]]; then
   echo "dotfiles directory not found at $DOTFILES_DIR" >&2

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -50,3 +50,12 @@ if [ -d "$SKILLS_DIR" ]; then
     ln -sfn "$SKILLS_DIR/$name/SKILL.md" "$HOME/.claude/commands/$name.md"
   done
 fi
+
+# launchd から起動するスクリプトを ~/.local/bin に symlink する。plist は repo の
+# 実体パスではなく $HOME/.local/bin/<name>.sh を指すので、repo の配置場所が変わって
+# も plist の書き換えなしで追従する（SCRIPT_DIR 経由で常に repo 実体を指す）。
+LOCAL_BIN="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN"
+for script in brew_update.sh claude_insights.sh; do
+  ln -sfn "$SCRIPT_DIR/scripts/darwin/$script" "$LOCAL_BIN/$script"
+done

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -51,9 +51,7 @@ if [ -d "$SKILLS_DIR" ]; then
   done
 fi
 
-# launchd から起動するスクリプトを ~/.local/bin に symlink する。plist は repo の
-# 実体パスではなく $HOME/.local/bin/<name>.sh を指すので、repo の配置場所が変わって
-# も plist の書き換えなしで追従する（SCRIPT_DIR 経由で常に repo 実体を指す）。
+# plist が指すための入口を ~/.local/bin に張る。
 LOCAL_BIN="$HOME/.local/bin"
 mkdir -p "$LOCAL_BIN"
 for script in brew_update.sh claude_insights.sh; do


### PR DESCRIPTION
## 概要

dotfiles repo を `~/dotfiles` 固定から、配置場所に依存しない構成へ変える。実体は `~/Code/nozomiishii/dotfiles` に置き、他 repo と同じ階層に揃える。動機は `/broadcast` の projects 一元化。設計は #1057 にまとまっている。

## 方針

repo 内部の root 解決と、外部からの名指しを 2 レイヤーで分けた。

- 内部スクリプト: `readlink -f "${BASH_SOURCE[0]}"` で実体を辿って root を解決
- 外部の名指し (launchd plist): `$HOME/.local/bin/<name>.sh` 経由。`scripts/symlink.sh` がリンクを張る。dotfiles 専用の固定入口は持たない

対象 OS は macOS 26+ と Linux に固定し、`readlink -f` を使える前提で書いた。

## 変更内容

| commit | 対象 | 変更 |
|---|---|---|
| f4c4c11 | `scripts/symlink.sh` | `~/.local/bin/` への symlink 処理を追加 |
| 9e4c9a3 | `scripts/darwin/brew_update.sh` | `DOTFILES_DIR` を自己参照解決に |
| d97bf30 | launchd plist 2 つ | exec 先を `$HOME/.local/bin/<name>.sh` に |
| c00edb1 | `install.sh` | 初回 clone 先を `$HOME/Code/nozomiishii/dotfiles` に |
| 6d881f3 | VS Code `settings.json` | `dotfiles.targetPath` を新パスに |
| c56122e | `README.ja.md` / `README.md` | 手動 clone 例を新パスに |
| 6dd9ecf | `broadcast/SKILL.md` | サンプル表の dotfiles 行を揃える |
| 6587baf | `CLAUDE.md` | ポータビリティに配置非依存ルールを追加 |

## 動作確認

静的:
- `bash -n` / `shellcheck` / `plutil -lint` 全 pass
- lefthook (commitlint, readme-sync-check) 各 commit で pass

実機 (マージ後の別作業):
- repo 実体を `~/Code/nozomiishii/dotfiles` へ移動 → `make link` → `~/.local/bin/` 配下の symlink 生成を確認
- 旧 launchd を unload して再 load、旧 `~/dotfiles` の残存 symlink を掃除
- 別の場所に動かして `make link` し直し、全部追従するかで配置非依存を検証
- `launchctl kickstart -k gui/$UID/local.brew-update` で plist 経由起動が成功するか

## 関連

Closes #1057
