### PR TITLE
fix: install Claude Code via install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,6 +103,7 @@ if [[ "$OS_NAME" == "Darwin" ]]; then
   bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
   bash "$SCRIPT_DIR/scripts/nvim.sh"
   bash "$SCRIPT_DIR/scripts/default_apps.sh"
   bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
@@ -120,6 +121,7 @@ if [[ "$OS_NAME" == "Linux" ]]; then
   bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
 fi
 
 echo -e "${yellow}"


### PR DESCRIPTION
## Summary

- `install.sh` から `scripts/toolchains/claude-code.sh` が呼ばれておらず、初回セットアップで Claude Code が入らない状態だったのを修正
- Darwin / Linux 両方のブロックに追加

## Test plan

- [ ] 新規マシンで `install.sh` を実行し、`claude --version` が通ることを確認