### PR TITLE
feat: pin Codex TUI input to bottom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ lefthook-local.yaml
 **/CLAUDE.local.md
 **/.claude/worktrees/
 
-# Codex
-home/.codex/tmp/
-
 # Logs
 *.log
 *.log.*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ lefthook-local.yaml
 **/CLAUDE.local.md
 **/.claude/worktrees/
 
+# Codex
+home/.codex/tmp/
+
 # Logs
 *.log
 *.log.*

--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -1,0 +1,2 @@
+[tui]
+alternate_screen = "always"


### PR DESCRIPTION
## What changed
- Add a Codex TUI config that forces alternate-screen mode.
- Ignore Codex runtime temp files under `home/.codex/tmp/`.

## Why
Keeping Codex in alternate-screen mode preserves the TUI layout where the composer stays in the bottom pane, avoiding runtime temp artifacts in the dotfiles package.

## Validation
- Commit hooks passed via lefthook: pre-commit, commit-msg, post-commit.
- Push hook passed via lefthook: pre-push `check-pr-not-merged`.