### PR TITLE
fix: post-merge follow-ups for #1067 (location independence)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -168,7 +168,7 @@ open https://nozomiishii.dev/dotfiles
 ### Clone
 
 ```shell
-mkdir -p ~/Code/nozomiishii && git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
+git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
 ```
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ open https://nozomiishii.dev/dotfiles
 ### Clone
 
 ```shell
-mkdir -p ~/Code/nozomiishii && git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
+git clone https://github.com/nozomiishii/dotfiles.git ~/Code/nozomiishii/dotfiles
 ```
 
 ### Install

--- a/home/.config/zellij/layouts/code.kdl
+++ b/home/.config/zellij/layouts/code.kdl
@@ -20,8 +20,8 @@ layout {
             plugin location="zellij:tab-bar"
         }
         pane split_direction="vertical" {
-            pane cwd="dotfiles" size="50%"
-            pane cwd="dotfiles" size="50%"
+            pane cwd="Code/nozomiishii/dotfiles" size="50%"
+            pane cwd="Code/nozomiishii/dotfiles" size="50%"
         }
         pane size=1 borderless=true {
             plugin location="zellij:status-bar"

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 DOTFILES_REPO="https://github.com/nozomiishii/dotfiles.git"
-DOTFILES_DIR="$HOME/Code/nozomiishii/dotfiles"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Code/nozomiishii/dotfiles}"
 OS_NAME="$(uname -s)"
 
 # ----------------------------------------------------------------

--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -297,6 +297,16 @@ launchctl bootout "gui/$UID" "$local_insights_plist" 2>/dev/null || true
 launchctl bootstrap "gui/$UID" "$local_insights_plist"
 
 # ----------------------------------------------------------------
+# Homebrew Update
+# ----------------------------------------------------------------
+# brew_update.sh を毎日 10:00 に走らせる LaunchAgent を登録する。
+echo "- 🍺 Homebrew Update"
+
+local_brew_update_plist="$HOME/Library/LaunchAgents/local.brew-update.plist"
+launchctl bootout "gui/$UID" "$local_brew_update_plist" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" "$local_brew_update_plist"
+
+# ----------------------------------------------------------------
 # Network
 # ----------------------------------------------------------------
 echo "- 📡 Network"

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -27,6 +27,11 @@ if ! git diff --quiet -- home || ! git diff --quiet --cached -- home; then
   exit 1
 fi
 
+# ~/.local/bin を実 dir として先に用意してから stow を走らせる。tree folding で
+# ~/.local/bin が repo 配下への folder-symlink に畳まれると、あとで張る ln -sfn の
+# 書き込み先が repo working tree に入って次回 make link が止まる。
+mkdir -p "$HOME/.local/bin"
+
 # repo を常に正とする。衝突する実体ファイルは --adopt で stow が吸収し（削除しない）、
 # 直後に git restore で repo 版へ戻す。home/ は上のチェックでクリーンなので、
 # restore が戻すのは adopt が吸収した分だけ。
@@ -51,9 +56,11 @@ if [ -d "$SKILLS_DIR" ]; then
   done
 fi
 
-# plist が指すための入口を ~/.local/bin に張る。
-LOCAL_BIN="$HOME/.local/bin"
-mkdir -p "$LOCAL_BIN"
-for script in brew_update.sh claude_insights.sh; do
-  ln -sfn "$SCRIPT_DIR/scripts/darwin/$script" "$LOCAL_BIN/$script"
-done
+# plist が指すための入口を ~/.local/bin に張る (Darwin のみ)。新しい launchd 入口を
+# 増やす場合はこの配列に追加する。
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  LOCAL_BIN_SCRIPTS=(brew_update.sh claude_insights.sh)
+  for script in "${LOCAL_BIN_SCRIPTS[@]}"; do
+    ln -sfn "$SCRIPT_DIR/scripts/darwin/$script" "$HOME/.local/bin/$script"
+  done
+fi


### PR DESCRIPTION
## 概要

#1067 マージ後に `/code-review` を回して見つかった指摘の修正。実害が確実な 5 件にしぼった。

## 修正内容

| commit | 対象 | 直したこと |
|---|---|---|
| 5d038eb | `scripts/symlink.sh` | (a) `mkdir -p ~/.local/bin` を stow より前に出して tree folding で repo working tree に書き込みが流れ込むのを防ぐ。(b) 末尾の launchd 入口ループを `[[ "$(uname -s)" == "Darwin" ]]` ガードで Linux 除外。(c) スクリプト一覧を `LOCAL_BIN_SCRIPTS` 配列に出して、増えたときの追加先を明確化 |
| 7c6cc38 | `scripts/darwin/macos.sh` | `local.brew-update` の `launchctl bootout`/`bootstrap` を追加。既存ホストが plist 更新だけでは古い ProgramArguments を掴み続ける問題への対処 |
| 16bf4df | `install.sh` | `DOTFILES_DIR` を `${DOTFILES_DIR:-...}` 化。`CLAUDE.md` 新ルール「配置場所を直書きしない」と整合させつつ default は維持 |
| ee86e1b | `home/.config/zellij/layouts/code.kdl` | `dotfiles` タブの pane cwd を `Code/nozomiishii/dotfiles` に。他タブと揃った |
| 86f7c9b | `README.ja.md` / `README.md` | `git clone <url> <path>` は親ディレクトリを自動作成（git 2.13+）。冗長な `mkdir -p` を削除 |

## レビューで指摘されたが落としたもの

- `readlink -f` の BSD 非対応: 対象 OS を macOS 26+ に確定してあり、手元実機でも `readlink -f /etc` → `/private/etc` が返るのを実証済み
- VS Code targetPath の二重存在問題: 実装側の不具合ではなく既存ホストの移行作業の話。マージ後の手作業で対応
- worktree で `make link` を走らせると `~/.local/bin` の symlink が worktree を指す: 運用注意の領域
- `brew_update.sh` の自己参照式のネスト深さ: コメントは前 PR で既に簡略化済み、コードはこのままで読める範囲

## 動作確認

- `bash -n` / `shellcheck -x` / `plutil -lint` 全 pass
- lefthook（commitlint / readme-sync-check）各 commit で pass

実機検証は #1067 の移行手順とあわせて、repo を `~/Code/nozomiishii/dotfiles` へ動かしたあと `make link` を走らせて確認する。
