### PR TITLE
chore: enable active app and selection context in superwhisper main mode

### DIFF
--- a/home/Documents/superwhisper/modes/main.json
+++ b/home/Documents/superwhisper/modes/main.json
@@ -6,9 +6,9 @@
 
   ],
   "autocapitalizeInsert" : true,
-  "contextFromActiveApplication" : false,
+  "contextFromActiveApplication" : true,
   "contextFromClipboard" : false,
-  "contextFromSelection" : false,
+  "contextFromSelection" : true,
   "contextTemplate" : "Use the copied text as context to complete this task.\n\nCopied text: ",
   "description" : "",
   "diarize" : false,


### PR DESCRIPTION
## 概要

superwhisper の main モードで、文字起こし時のコンテキスト取得を有効化する。

- `contextFromActiveApplication`: `false` → `true`（アクティブなアプリの内容をコンテキストに含める）
- `contextFromSelection`: `false` → `true`（選択中のテキストをコンテキストに含める）

## 意図

アクティブアプリと選択テキストを文脈として渡すことで、変換精度を上げる狙い。