### PR TITLE
fix: pass --force --no-mas to brew bundle cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,8 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	# Brewfile のパッケージをインストール
-	cat ./Brewfile ./Brewfile.optional | brew bundle install --verbose --file=-
-	# Brewfile にないパッケージを削除。App Store を対象外。
-	cat ./Brewfile ./Brewfile.optional | brew bundle cleanup --force --no-mas --file=-
+	# Brewfile を正にする（入れて、Brewfile にないものを削除。App Store は対象外）
+	cat ./Brewfile ./Brewfile.optional | HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle --verbose --cleanup --force --file=-
 	# 古いバージョン・キャッシュを削除してディスクを空ける
 	brew cleanup --verbose
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	cat ./Brewfile ./Brewfile.optional | brew bundle --verbose --cleanup --force --no-mas --file=-
+	cat ./Brewfile ./Brewfile.optional | HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle --verbose --cleanup --force --file=-
 	brew cleanup --verbose
 
 .PHONY: macos

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	cat ./Brewfile ./Brewfile.optional | brew bundle --verbose --cleanup --file=-
+	cat ./Brewfile ./Brewfile.optional | brew bundle --verbose --cleanup --force --no-mas --file=-
 	brew cleanup --verbose
 
 .PHONY: macos

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	cat ./Brewfile ./Brewfile.optional | HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle --verbose --cleanup --force --file=-
+	# Brewfile のパッケージをインストール
+	cat ./Brewfile ./Brewfile.optional | brew bundle install --verbose --file=-
+	# Brewfile にないパッケージを削除。App Store を対象外。
+	cat ./Brewfile ./Brewfile.optional | brew bundle cleanup --force --no-mas --file=-
+	# 古いバージョン・キャッシュを削除してディスクを空ける
 	brew cleanup --verbose
 
 .PHONY: macos

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -58,17 +58,20 @@ max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1
 backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
 
-# Brewfile のパッケージをインストール（ネットワーク失敗に備えてリトライ）
+# Brewfile を正にする（入れて、Brewfile にないものを削除。App Store は対象外）。
+# install と cleanup は一体にする（分けると node 等の依存を巻き添え削除するため）。
 while [ "$attempt" -le "$max_attempts" ]; do
-  echo "brew bundle install attempt ${attempt}/${max_attempts}"
-  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" brew bundle install \
+  echo "brew bundle attempt ${attempt}/${max_attempts}"
+  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle \
     --verbose \
+    --cleanup \
+    --force \
     --file="$SCRIPT_DIR/Brewfile"; then
-    echo "brew bundle install succeeded"
+    echo "brew bundle succeeded"
     break
   fi
   if [ "$attempt" -eq "$max_attempts" ]; then
-    echo "brew bundle install failed after ${max_attempts} attempts"
+    echo "brew bundle failed after ${max_attempts} attempts"
     exit 1
   fi
 
@@ -77,9 +80,6 @@ while [ "$attempt" -le "$max_attempts" ]; do
   sleep "$((backoff_base * attempt))"
   attempt="$((attempt + 1))"
 done
-
-# Brewfile にないパッケージを削除。App Store を対象外。
-brew bundle cleanup --force --no-mas --file="$SCRIPT_DIR/Brewfile"
 
 # 古いバージョン・キャッシュを削除してディスクを空ける
 brew cleanup --verbose

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -61,13 +61,13 @@ backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
 while [ "$attempt" -le "$max_attempts" ]; do
   echo "brew bundle attempt ${attempt}/${max_attempts}"
   # --force: 非対話で cleanup を実行（無いと「削除対象あり」で exit 1）。
-  # --no-mas: App Store を cleanup 対象外にする。cleanup は Brewfile 外の mas アプリを
-  # 全削除する破壊的挙動になったため除外する（Homebrew/brew#22450）。
-  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" brew bundle \
+  # HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1: App Store を cleanup 対象外にする。cleanup は
+  # Brewfile 外の mas アプリを全削除する破壊的挙動になったため除外（Homebrew/brew#22450）。
+  # --no-mas は cleanup サブコマンド専用で install の --cleanup では使えないため env var で指定。
+  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle \
     --verbose \
     --cleanup \
     --force \
-    --no-mas \
     --file="$SCRIPT_DIR/Brewfile"; then
     echo "brew bundle succeeded"
     break

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -60,9 +60,14 @@ backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
 
 while [ "$attempt" -le "$max_attempts" ]; do
   echo "brew bundle attempt ${attempt}/${max_attempts}"
+  # --force: 非対話で cleanup を実行（無いと「削除対象あり」で exit 1）。
+  # --no-mas: App Store を cleanup 対象外にする。cleanup は Brewfile 外の mas アプリを
+  # 全削除する破壊的挙動になったため除外する（Homebrew/brew#22450）。
   if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" brew bundle \
     --verbose \
     --cleanup \
+    --force \
+    --no-mas \
     --file="$SCRIPT_DIR/Brewfile"; then
     echo "brew bundle succeeded"
     break

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -58,22 +58,17 @@ max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1
 backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
 
+# Brewfile のパッケージをインストール（ネットワーク失敗に備えてリトライ）
 while [ "$attempt" -le "$max_attempts" ]; do
-  echo "brew bundle attempt ${attempt}/${max_attempts}"
-  # --force: 非対話で cleanup を実行（無いと「削除対象あり」で exit 1）。
-  # HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1: App Store を cleanup 対象外にする。cleanup は
-  # Brewfile 外の mas アプリを全削除する破壊的挙動になったため除外（Homebrew/brew#22450）。
-  # --no-mas は cleanup サブコマンド専用で install の --cleanup では使えないため env var で指定。
-  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle \
+  echo "brew bundle install attempt ${attempt}/${max_attempts}"
+  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" brew bundle install \
     --verbose \
-    --cleanup \
-    --force \
     --file="$SCRIPT_DIR/Brewfile"; then
-    echo "brew bundle succeeded"
+    echo "brew bundle install succeeded"
     break
   fi
   if [ "$attempt" -eq "$max_attempts" ]; then
-    echo "brew bundle failed after ${max_attempts} attempts"
+    echo "brew bundle install failed after ${max_attempts} attempts"
     exit 1
   fi
 
@@ -83,4 +78,8 @@ while [ "$attempt" -le "$max_attempts" ]; do
   attempt="$((attempt + 1))"
 done
 
+# Brewfile にないパッケージを削除。App Store を対象外。
+brew bundle cleanup --force --no-mas --file="$SCRIPT_DIR/Brewfile"
+
+# 古いバージョン・キャッシュを削除してディスクを空ける
 brew cleanup --verbose


### PR DESCRIPTION
## 概要

`brew bundle --cleanup` に `--force --no-mas` を付け、CI 失敗を直す。

## 背景

2026 年の Homebrew で `--cleanup` の挙動が変わり、CI の install ジョブが落ちていた（main 由来・特定の PR とは無関係）。

- `--cleanup` が `--force`（または `--force-cleanup` / `$HOMEBREW_ASK`）を要求するようになった → install が exit 1
- さらに cleanup が Brewfile にない Mac App Store アプリを mas 経由で全削除する破壊的挙動になった（[Homebrew/brew#22450](https://github.com/homebrew/brew/issues/22450)）

## 変更

- `scripts/homebrew.sh` と `Makefile` の brew bundle に `--force --no-mas` を追加
- `--force`: 非対話で cleanup を実行（CI 失敗の直接原因を解消）
- `--no-mas`: App Store を cleanup 対象外に（mas アプリの巻き添え削除を回避）

## 補足

brew 依存の autoremove 巻き添え（[Homebrew/brew#21350](https://github.com/homebrew/brew/issues/21350)）は別問題。発動条件がレアなため、必要になれば `HOMEBREW_NO_INSTALL_CLEANUP=1` を追加で対応する。