### PR TITLE
feat: centralize global agent instructions

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/home/.codex/AGENTS.md
+++ b/home/.codex/AGENTS.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -25,7 +25,7 @@
   - 共通処理でLifecycle Hooksは使わない。ヘルパー関数、`using` 、テスト内に閉じた[Test hooks](https://vitest.dev/api/hooks.html#test-hooks)で組む。
 - tautology testを避ける。実装をなぞる期待値ではなく、仕様から期待値を決める。
 
-## CLAUDE.md・skill・docs・実装コメントなどの書き方
+## AGENTS.md・CLAUDE.md・skill・docs・実装コメントなどの書き方
 - foolproofに書く。
 - 短くわかりやすい日本語で書く。指摘されたら、必要な分だけ伸ばす。
 - コードや他の文書を読めばわかる内容は書かない。


### PR DESCRIPTION
## 概要
- global agent 指示の正を `home/.ai/AGENTS.md` から `home/AGENTS.md` に移動
- `home/.claude/CLAUDE.md` と `home/.codex/AGENTS.md` を `../AGENTS.md` への symlink として追加
- `home/.ai/skills` と `home/.ai/hooks` は変更なし

## 確認
- `git diff --cached --check`
- pre-commit / pre-push hooks 通過