### PR TITLE
feat: move pm shortcut to zsh

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -49,9 +49,6 @@ keybind = shift+enter=text:\n
 # undo
 keybind = super+z=text:\x1f
 
-# pm
-keybind = super+alt+j=text:pm\n
-
 # Disable OSC 9;4 progress bar (the blue bar at the top during long-running commands)
 # https://ghostty.org/docs/config/reference#progress-style
 progress-style = false

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -65,9 +65,8 @@ fi
 export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
-# Option+j
+# Option+j (Codex: ∆)
 bindkey -s '^[j' 'pm^M'
-# Codex terminal sends Option+j as ∆
 bindkey -s '∆' 'pm^M'
 
 # direnv

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -65,6 +65,9 @@ fi
 export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
+# Option+j
+bindkey -s '^[j' 'pm^M'
+bindkey -s '∆' 'pm^M'
 
 # direnv
 if command -v direnv >/dev/null; then

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -65,7 +65,7 @@ fi
 export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
-# Option+j (Codex: ∆)
+# Option+j (ESC+j / ∆)
 bindkey -s '^[j' 'pm^M'
 bindkey -s '∆' 'pm^M'
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -67,6 +67,7 @@ export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
 # Option+j
 bindkey -s '^[j' 'pm^M'
+# Codex terminal sends Option+j as ∆
 bindkey -s '∆' 'pm^M'
 
 # direnv


### PR DESCRIPTION
## 概要

- Ghostty 固有の `super+alt+j` による `pm` 入力を削除
- `.zshrc` に `Option+j` 用の `bindkey` を追加
- `^[j` と `∆` の両方を `pm` + Enter に割り当て、Ghostty / Terminal.app / Codex terminal の入力差を吸収

## 確認

- `zsh -n home/.zshrc`
- `git diff --check`
- pre-commit / commit-msg hook
- pre-push hook