### PR TITLE
chore: add direnv whitelist for agent worktrees

### DIFF
--- a/home/.config/direnv/direnv.toml
+++ b/home/.config/direnv/direnv.toml
@@ -1,0 +1,5 @@
+[whitelist]
+prefix = [
+  "~/.codex/worktrees/",
+  "~/.claude/worktrees/",
+]


### PR DESCRIPTION
## Summary
- add a direnv whitelist for Codex and Claude worktree directories
- keep the configuration minimal and comment-free

## Test
- checked direnv status with the new config during implementation