### PR TITLE
chore: whitelist personal repos for direnv

### DIFF
--- a/home/.config/direnv/direnv.toml
+++ b/home/.config/direnv/direnv.toml
@@ -1,5 +1,4 @@
 [whitelist]
 prefix = [
-  "~/.codex/worktrees/",
-  "~/.claude/worktrees/",
+  "~/Code/nozomiishii/",
 ]


### PR DESCRIPTION
## Summary
- replace agent-specific direnv whitelist entries with the personal repository root
- allow Claude Code repo-local worktrees under ~/Code/nozomiishii without per-worktree approval

## Test
- env XDG_CONFIG_HOME=/Users/nozomiishii/.codex/worktrees/1ab2/dotfiles/home/.config direnv status