### PR TITLE
fix: drop stale AGENTS.md bridging from symlink.sh

### DIFF
--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -42,14 +42,6 @@ git restore home
 # 実体は home/.ai/（直前の stow で ~/.ai に配置済み）。
 AI_DIR="$HOME/.ai"
 
-# instructions: AGENTS.md を Claude(CLAUDE.md) と Codex(AGENTS.md) の定位置へ。
-# Claude は CLAUDE.md しか自動で読まないため symlink で橋渡しする。
-if [ -f "$AI_DIR/AGENTS.md" ]; then
-  mkdir -p "$HOME/.claude" "$HOME/.codex"
-  ln -sfn "$AI_DIR/AGENTS.md" "$HOME/.claude/CLAUDE.md"
-  ln -sfn "$AI_DIR/AGENTS.md" "$HOME/.codex/AGENTS.md"
-fi
-
 # skills: 各 skill を Claude / Codex の skills dir へ。
 # Codex の global skills は ~/.agents/skills（~/.codex/skills は読まれない）。
 SKILLS_DIR="$AI_DIR/skills"


### PR DESCRIPTION
## 概要

`make link` が stow conflict で失敗する問題への対応（dead code 削除のみ。$HOME の掃除は手動で実施済み）。

```
WARNING! stowing home would cause conflicts:
  * existing target is not owned by stow: .claude/CLAUDE.md
  * existing target is not owned by stow: .codex/AGENTS.md
All operations aborted.
```

## 原因

- #1124 で `symlink.sh` が `~/.claude/CLAUDE.md` と `~/.codex/AGENTS.md` に **絶対 symlink**（`~/.ai/AGENTS.md` 行き）を張った
- #1133 で正本が `home/AGENTS.md` に移り、両ファイルは home/ package 内の**相対 symlink** (`../AGENTS.md`) を stow が配る方式に変わった
- しかし $HOME に残った旧・絶対 symlink（dangling）を stow は所有判定できず（`Ignoring an absolute symlink`）、restow が conflict で中断する

## 変更

- `~/.ai/AGENTS.md` から絶対 symlink を張り直す旧 bridging 処理（dead code）を削除

残置していた絶対 symlink 2本は `rm ~/.claude/CLAUDE.md ~/.codex/AGENTS.md` で手動削除済み。script への migration 処理は入れない（#1124 を経た他マシンで同じ conflict が出た場合は同じ rm で対応）。

## 検証

- 手動削除後、`stow --simulate --restow` で conflict が消えることを確認
- shellcheck OK