### PR TITLE
feat: migrate Claude commands to skills

### DIFF
--- a/docs/forking.md
+++ b/docs/forking.md
@@ -42,7 +42,6 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 | [`home/Library/Application Support/Code/User/settings.json`](../home/Library/Application%20Support/Code/User/settings.json) | `dotfiles.repository` / `dotfiles.targetPath` / `projectManager.projectsLocation` / `vscode-kubernetes.minikube-path.mac` / `vscode-kubernetes.kubectl-path.mac` / `rufo.exe` |
 | [`home/.agents/skills/backlog/SKILL.md`](../home/.agents/skills/backlog/SKILL.md) | `BRAIN`（brain vault のパス） |
 | [`home/.agents/skills/broadcast/SKILL.md`](../home/.agents/skills/broadcast/SKILL.md) | projects / repos のパス |
-| [`home/.claude/commands/ad.md`](../home/.claude/commands/ad.md) | 内部参照パス |
 
 ## 任意（個人色、動くが書き換え推奨）
 

--- a/home/.agents/skills/a/SKILL.md
+++ b/home/.agents/skills/a/SKILL.md
@@ -1,8 +1,8 @@
 ---
+name: a
 description: ChatGPT・Claude・Geminiに同じ質問を並列投下して回答を比較
 argument-hint: <question>
-allowed-tools:
-  - Agent
+disable-model-invocation: true
 ---
 
 # /a wrapper

--- a/home/.agents/skills/a/agents/openai.yaml
+++ b/home/.agents/skills/a/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/home/.agents/skills/ad/SKILL.md
+++ b/home/.agents/skills/ad/SKILL.md
@@ -1,8 +1,8 @@
 ---
+name: ad
 description: /a を deep research モードで実行する
 argument-hint: <question>
-allowed-tools:
-  - Agent
+disable-model-invocation: true
 ---
 
 # /ad wrapper
@@ -26,7 +26,7 @@ allowed-tools:
 
 # /ad (deep research モード)
 
-まず最初に `Read` で `/Users/nozomiishii/.claude/commands/a.md` を開き、`## Subagent execution` セクション以降の手順を **基本ワークフロー** として把握する。`/a` 側は `### Stage 1 instructions` と `### Stage 2 instructions` の 2 段構成になっているが、`/ad` ではこのサブエージェント 1 つで両 stage を直列実行する（Stage 1 で得る URL は内部で保持して Stage 2 に流す。途中で別 dispatch には分けない）。Stage 1 の「JSON 1 行だけ返す」制約はサブエージェント間 IPC 用なので `/ad` では無視し、基本的な挙動・タブ準備・送信・回答取得・レポート構成のみ参考にする。
+まず最初に `Read` で `$HOME/.agents/skills/a/SKILL.md` を開き、`## Subagent execution` セクション以降の手順を **基本ワークフロー** として把握する。`/a` 側は `### Stage 1 instructions` と `### Stage 2 instructions` の 2 段構成になっているが、`/ad` ではこのサブエージェント 1 つで両 stage を直列実行する（Stage 1 で得る URL は内部で保持して Stage 2 に流す。途中で別 dispatch には分けない）。Stage 1 の「JSON 1 行だけ返す」制約はサブエージェント間 IPC 用なので `/ad` では無視し、基本的な挙動・タブ準備・送信・回答取得・レポート構成のみ参考にする。
 
 そのうえで、以下の差分を適用する。
 

--- a/home/.agents/skills/ad/agents/openai.yaml
+++ b/home/.agents/skills/ad/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/home/.agents/skills/src/SKILL.md
+++ b/home/.agents/skills/src/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: src
 description: 直近の話題について、公式ドキュメントURLとわかりやすい日本語ブログを提案する
 argument-hint: "[note]"
+disable-model-invocation: true
 allowed-tools:
   - WebSearch
   - WebFetch

--- a/home/.agents/skills/src/agents/openai.yaml
+++ b/home/.agents/skills/src/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/home/.agents/skills/sync-settings-doc/SKILL.md
+++ b/home/.agents/skills/sync-settings-doc/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: sync-settings-doc
+description: Claude Code の settings.json と settings.md をレビューして同期する
+disable-model-invocation: true
+---
+
 # Settings Sync & Review
 
 以下のステップを順番に実行してください。

--- a/home/.agents/skills/sync-settings-doc/agents/openai.yaml
+++ b/home/.agents/skills/sync-settings-doc/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -58,13 +58,6 @@ if [ -d "$SKILLS_DIR" ]; then
   done
 fi
 
-# These custom commands moved to skills. Remove stale command files so Claude
-# exposes only the skill-backed slash commands.
-for command in a ad src sync-settings-doc; do
-  rm -f "$HOME/.claude/commands/$command.md"
-done
-rmdir "$HOME/.claude/commands" 2>/dev/null || true
-
 # plist が指すための入口を ~/.local/bin に張る (Darwin のみ)。新しい launchd 入口を
 # 増やす場合はこの配列に追加する。
 if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -58,6 +58,13 @@ if [ -d "$SKILLS_DIR" ]; then
   done
 fi
 
+# These custom commands moved to skills. Remove stale command files so Claude
+# exposes only the skill-backed slash commands.
+for command in a ad src sync-settings-doc; do
+  rm -f "$HOME/.claude/commands/$command.md"
+done
+rmdir "$HOME/.claude/commands" 2>/dev/null || true
+
 # plist が指すための入口を ~/.local/bin に張る (Darwin のみ)。新しい launchd 入口を
 # 増やす場合はこの配列に追加する。
 if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary
- Move `a`, `ad`, `src`, and `sync-settings-doc` from `home/.claude/commands` to `home/.agents/skills`
- Mark the migrated skills as manual-only for Claude with `disable-model-invocation: true`
- Add Codex sidecars with `allow_implicit_invocation: false`

## Notes
- `src` keeps its existing Claude `allowed-tools` entries for `WebSearch` and `WebFetch`.
- `a` and `ad` drop `allowed-tools: Agent` because the Agent tool call itself does not need to be preapproved.
- Stale local command symlinks are handled manually outside this PR.

## Verification
- `bash -n scripts/symlink.sh`
- `git diff --check`
- pre-commit hook during `git commit`
- pre-push hook during `git push`
- Local `~/.agents/skills/*/SKILL.md` and `~/.claude/skills/*/SKILL.md` resolution check
- `stow --simulate --verbose --restow --target=/Users/nozomiishii home` from the main dotfiles repo