### PR TITLE
fix: drop stale AGENTS bridge from link script

### DIFF
--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -38,14 +38,6 @@ mkdir -p "$HOME/.local/bin"
 stow --adopt --verbose --restow --target="$HOME" home
 git restore home
 
-# instructions: AGENTS.md を Claude(CLAUDE.md) と Codex(AGENTS.md) の定位置へ。
-# Claude は CLAUDE.md しか自動で読まないため symlink で橋渡しする。
-if [ -f "$HOME/AGENTS.md" ]; then
-  mkdir -p "$HOME/.claude" "$HOME/.codex"
-  ln -sfn "$HOME/AGENTS.md" "$HOME/.claude/CLAUDE.md"
-  ln -sfn "$HOME/AGENTS.md" "$HOME/.codex/AGENTS.md"
-fi
-
 # skills: Codex 標準の ~/.agents/skills を正本にし、Claude の定位置へ配る。
 SKILLS_DIR="$HOME/.agents/skills"
 if [ -d "$SKILLS_DIR" ]; then


### PR DESCRIPTION
## Summary
- Remove the stale `scripts/symlink.sh` block that rewrites `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md` to direct `$HOME/AGENTS.md` symlinks
- Let stow own `home/.claude/CLAUDE.md` and `home/.codex/AGENTS.md` instead

## Why
After #1143, `make link` conflicted with:
- `.agents/skills/a`
- `.agents/skills/ad`
- `.agents/skills/src`
- `.agents/skills/sync-settings-doc`
- `.claude/CLAUDE.md`
- `.codex/AGENTS.md`

The local stale skill links were repaired directly, but the bridge block would recreate the AGENTS conflicts on every `make link`.

## Verification
- `bash -n scripts/symlink.sh`
- `git diff --check`
- `make link`
- `make link` again to confirm the conflict does not recur