### PR TITLE
fix: let stow link Claude skills

### DIFF
--- a/home/.claude/skills
+++ b/home/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -38,18 +38,6 @@ mkdir -p "$HOME/.local/bin"
 stow --adopt --verbose --restow --target="$HOME" home
 git restore home
 
-# skills: Codex 標準の ~/.agents/skills を正本にし、Claude の定位置へ配る。
-SKILLS_DIR="$HOME/.agents/skills"
-if [ -d "$SKILLS_DIR" ]; then
-  echo "Linking ~/.agents/skills to Claude..."
-  mkdir -p "$HOME/.claude/skills"
-  for skill_dir in "$SKILLS_DIR"/*/; do
-    [ -d "$skill_dir" ] || continue
-    name=$(basename "$skill_dir")
-    ln -sfn "$SKILLS_DIR/$name" "$HOME/.claude/skills/$name"
-  done
-fi
-
 # plist が指すための入口を ~/.local/bin に張る (Darwin のみ)。新しい launchd 入口を
 # 増やす場合はこの配列に追加する。
 if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary
- Add `home/.claude/skills -> ../.agents/skills`
- Remove the `scripts/symlink.sh` loop that created one symlink per skill under `~/.claude/skills`

## Notes
- #1144 is already merged, so this PR now contains only the Claude skills symlink change on top of `main`.
- Local stale `~/.claude/skills` directory from the old loop was removed once before verification.

## Verification
- `bash -n scripts/symlink.sh`
- `git diff --check origin/main..HEAD`
- `make link`
- Verified `~/.claude/skills` resolves through `home/.claude/skills -> ../.agents/skills` and skill files such as `a` and `q` are readable