### PR TITLE
chore: update install URL to https://dotfiles.nozo.sh

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,14 +25,14 @@
 忙しい？下のコマンドをそのまま実行してね;)
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash
+curl -fsSL https://dotfiles.nozo.sh | bash
 ```
 
 <!-- <details>
 <summary>with full version of Brewfile</summary>
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash -s -- --full
+curl -fsSL https://dotfiles.nozo.sh | bash -s -- --full
 ``` -->
 
 <!-- これにするのが目標
@@ -115,10 +115,10 @@ App Store から Xcode を手動でインストールしてください。
 ```
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash
+curl -fsSL https://dotfiles.nozo.sh | bash
 ```
 
--L (--location): リダイレクトを有効化
+-fsSL: -L は dotfiles.nozo.sh のリダイレクトを追跡, -f は HTTP エラーで中断 (壊れた応答を bash に渡さない), -sS は進捗を隠しつつエラーは表示。
 
 ### インストール後の作業
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ English | [日本語](README.ja.md)
 Busy? Just run command below;)
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash
+curl -fsSL https://dotfiles.nozo.sh | bash
 ```
 
 <!-- <details>
 <summary>with full version of Brewfile</summary>
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash -s -- --full
+curl -fsSL https://dotfiles.nozo.sh | bash -s -- --full
 ``` -->
 
 </details>
@@ -109,10 +109,10 @@ Wait about 3 hours(Go grab some food and take a nap 🍕😪)
 ```
 
 ```shell
-curl -L https://nozomiishii.dev/dotfiles/install | bash
+curl -fsSL https://dotfiles.nozo.sh | bash
 ```
 
--L (--location): Enable redirection.
+-fsSL: -L follows the dotfiles.nozo.sh redirect, -f aborts on HTTP errors (so a broken response is never piped to bash), -sS hide progress but still show errors.
 
 ### After installation
 


### PR DESCRIPTION
## 概要

install コマンドの URL を vanity URL `https://dotfiles.nozo.sh` に変更する。

## 変更

- README.md / README.ja.md の install コマンドを `curl -fsSL https://dotfiles.nozo.sh | bash` に統一
- 旧 `curl -L https://nozomiishii.dev/dotfiles/install` から移行
- `-L` のみだった説明行を `-fsSL` の各フラグ説明に更新 (パイプ実行の安全化: HTTP エラー時に壊れた応答を bash に渡さない)
- コメントアウト中の full 版スニペットも URL を揃えた

## 関連

- redirect 自体は infra 側で管理: nozomiishii/infra#56 (`dotfiles.nozo.sh` -> install.sh の single redirect)

## 補足

- README.ja.md にだけ残る「これにするのが目標」コメント (`curl -L dot.nozomiishii.dev | sh`) は別系統の URL なので今回は触っていない。今回の vanity URL でこの目標自体は達成されているため、別途整理してもよい
