### PR TITLE
fix: trust external brew formulae

### DIFF
--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -29,6 +29,17 @@ fix_brew_link_conflicts() {
   done
 }
 
+trust_brew_bundle_formulae() {
+  if ! brew help trust >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Brewfile の外部 tap formula だけを信頼する。
+  brew trust --formula \
+    smudge/smudge/nightlight \
+    stripe/stripe-cli/stripe
+}
+
 if [[ "$OS_NAME" == "Darwin" ]]; then
   if ! command -v brew >/dev/null 2>&1; then
     echo -e "🍺 Installing Homebrew for Apple Silicon"
@@ -53,6 +64,8 @@ elif [[ "${OS_NAME}" == "Linux" ]]; then
   fi
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
+
+trust_brew_bundle_formulae
 
 max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1


### PR DESCRIPTION
## 概要

- Homebrew の tap trust チェックで `smudge/smudge/nightlight` が拒否される CI 失敗に対応
- `brew bundle` 前に Brewfile で使う外部 tap formula を `brew trust --formula` で信頼
- `brew trust` がない Homebrew では何もしないようにガード

## 確認

- `bash -n scripts/homebrew.sh`
- `shellcheck scripts/homebrew.sh`

## 関連

- https://github.com/nozomiishii/dotfiles/actions/runs/27516973367/job/81327289981