### PR TITLE
chore: remove stale pretooluse timestamp hook

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -125,16 +125,6 @@
             "timeout": 5
           }
         ]
-      },
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"'$(date '+%Y-%m-%d %H:%M:%S %Z')'\"}}'",
-            "timeout": 5
-          }
-        ]
       }
     ]
   },


### PR DESCRIPTION
## 概要

- Claude Code の `PreToolUse` で毎回 timestamp だけを追加する hook を削除
- `Bash` 用の `block-op-cli` hook は維持

## 確認

- `jq empty home/.claude/settings.json` で JSON が valid なことを確認
- `hookSpecificOutput` / `additionalContext` / timestamp hook が残っていないことを確認