### PR TITLE
chore: add cloud setup script with codex support

### DIFF
--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Claude Code on the web / Codex Cloud の Setup script 欄に貼る:
-#   bash <(curl -fsSL https://raw.githubusercontent.com/nozomiishii/dotfiles/main/scripts/cloud/setup.sh)
+#   curl -fsSL https://raw.githubusercontent.com/nozomiishii/dotfiles/main/scripts/cloud/setup.sh | bash
 set -euo pipefail
 
 raw="https://raw.githubusercontent.com/nozomiishii/dotfiles/main"

--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Claude Code on the web / Codex Cloud の Setup script 欄に貼る:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/nozomiishii/dotfiles/main/scripts/cloud/setup.sh)
 set -euo pipefail
 
 raw="https://raw.githubusercontent.com/nozomiishii/dotfiles/main"

--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+raw="https://raw.githubusercontent.com/nozomiishii/dotfiles/main"
+
+# Claude Code
+mkdir -p ~/.claude
+curl -fsSL "$raw/home/AGENTS.md" -o ~/.claude/CLAUDE.md
+curl -fsSL "$raw/home/.claude/settings.json" |
+    jq '{permissions: {deny: .permissions.deny}}' \
+        >~/.claude/settings.json
+
+# Codex
+mkdir -p ~/.codex
+curl -fsSL "$raw/home/AGENTS.md" -o ~/.codex/AGENTS.md


### PR DESCRIPTION
## Summary
- `scripts/cloud/setup.sh` を新規追加し、クラウド環境（Claude Code on the web / Codex Cloud）でグローバル指示を反映できるようにした
- ソースは `home/AGENTS.md`（実ファイル）。`~/.claude/CLAUDE.md` と `~/.codex/AGENTS.md` の両方に配置する
- Claude の `permissions.deny` は `~/.claude/settings.json` として書き出す。Codex には bash パターン単位の deny 相当が無い（[`PermissionProfileToml`](https://github.com/openai/codex/blob/main/codex-rs/config/src/permissions_toml.rs) は filesystem/network のみ）ため Codex 側には移植しない
- [Claude Code on the web の公式 docs](https://code.claude.com/docs/en/claude-code-on-the-web) に "user-level settings don't carry over to cloud sessions" と明記されており、`~/.claude/` 配下を setup script で配置する運用が正しい

## Test plan
- [x] `HOME=$TMPDIR/...` でスクリプトを実行し `~/.claude/CLAUDE.md`・`~/.claude/settings.json`・`~/.codex/AGENTS.md` が生成されることを確認
- [ ] Claude Code on the web のセットアップスクリプト欄に登録して新規セッションで反映されることを確認
- [ ] Codex Cloud のセットアップスクリプト欄に登録して `~/.codex/AGENTS.md` が読まれることを確認