### PR TITLE
chore: fix ghv! alias to use --yolo flag

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -72,7 +72,7 @@ alias ghpc="gh pr create --assignee @me --web"
 alias grmb="git branch --merged|egrep -v '\*|master|main|dev|develop|development|stag|staging|prod|production'|xargs git branch -d && git fetch --prune"
 alias gsta="git stash -u"
 alias ghv="bunx git-harvest@latest"
-alias ghv!="bunx git-harvest@latest --all"
+alias ghv!="bunx git-harvest@latest --yolo"
 
 # ----------------------------------------------------------------
 # nozo


### PR DESCRIPTION
## Summary
- `ghv!` alias が存在しない `--all` フラグを渡していて `git-harvest: unknown option: --all` で失敗していた
- 現行 CLI の `--yolo` プリセット（`--files-changed --committed --untouched --detached` 相当）に差し替え

## Test plan
- [ ] `source ~/.zshrc` 後に `ghv!` で `git-harvest --yolo` が起動することを確認