### PR TITLE
chore: switch statusline editor link from Cursor to VS Code

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -96,10 +96,10 @@ starship_at() {
   )
 }
 
-# OSC 8 hyperlink で cwd を Cursor で開ける `[editor]` リンクを返す。
-build_cursor_link() {
+# OSC 8 hyperlink で cwd を VS Code で開ける `[editor]` リンクを返す。
+build_editor_link() {
   local url
-  url="cursor://file$(urlencode "$cwd")"
+  url="vscode://file$(urlencode "$cwd")"
   printf '%s]8;;%s%s[editor]%s]8;;%s' "$esc" "$url" "$st" "$esc" "$st"
 }
 
@@ -148,7 +148,7 @@ render_env_line() {
   [[ -n "$five_hour_pct" ]] && parts+=("${yellow}h ${five_hour_pct}%${reset}")
   [[ -n "$seven_day_pct" ]] && parts+=("${yellow}w ${seven_day_pct}%${reset}")
   [[ -n "$surface_ref" ]] && parts+=("${blue_bold}${surface_ref}${reset}")
-  parts+=("${gray}$(build_cursor_link)${reset}")
+  parts+=("${gray}$(build_editor_link)${reset}")
   join ' | ' "${parts[@]}"
 }
 


### PR DESCRIPTION
## 概要

- statusline の `[editor]` リンクの URL scheme を `cursor://file` → `vscode://file` に変更
- 関数名を `build_cursor_link` → `build_editor_link` に汎用化

## Test plan

- [ ] statusline に `[editor]` リンクが表示される
- [ ] クリックで VS Code が開く

https://claude.ai/code/session_01MeyHWpz9ZsVZwBBK6xCDea