### PR TITLE
fix: exclude make from carapace to fix ghost completion targets

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -9,6 +9,8 @@ compinit
 
 # carapace - multi-shell completion engine
 export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
+export CARAPACE_EXCLUDES='make'
+zstyle ':completion:*:*:make:*' tag-order targets
 if command -v carapace >/dev/null; then
   # shellcheck source=/dev/null
   source <(carapace _carapace)


### PR DESCRIPTION
## 概要

- `make<Tab>` の補完候補に `azhw` や `fzf-tab-lscolors:` など Makefile に存在しないターゲットが表示される問題を修正
- carapace の make 補完がコロンを含む zsh 内部関数名を Makefile ターゲットとして誤認識していたことが原因
- `CARAPACE_EXCLUDES` で make を除外し zsh 標準 `_make` にフォールバック、`zstyle` でターゲットのみ補完するよう制限

## テスト

- [x] `make<Tab>` で Makefile のターゲットのみが補完候補に出ることを確認
- [x] ファイル名やシェル内部関数名が混入しないことを確認

https://claude.ai/code/session_01JB3snNQ1UVCoThuYfDNZST