### PR TITLE
chore: use ubuntu-slim runner for readme-sync workflow

### DIFF
--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read  # required by actions/checkout to fetch repository code


### PR DESCRIPTION
## Summary
- `readme-sync.yaml` の `runs-on` を `ubuntu-latest` から `ubuntu-slim` に変更
- checkout + `gh pr diff` + shell script のみの軽量 job なので ubuntu-slim で十分
- コスト 25% に削減（1 vCPU コンテナベース）

## Test plan
- [ ] CI が green になることを確認
- [ ] README.md と README.ja.md の両方を変更する PR で readme-sync check が正常に動作することを確認

https://claude.ai/code/session_01MvfZpN2Yb7e8JimyApXWos