### PR TITLE
fix: prevent statusline field index shift when rate limits are absent

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -28,11 +28,11 @@ done < <(jq -r '
   (.context_window.used_percentage // 0 | floor | tostring),
   .cwd // "",
   .workspace.project_dir // .cwd // "",
-  (.rate_limits.five_hour.used_percentage // empty | floor | tostring),
-  (.rate_limits.seven_day.used_percentage // empty | floor | tostring),
-  (.rate_limits.five_hour.resets_at // empty | tostring),
-  (.rate_limits.seven_day.resets_at // empty | tostring),
-  (.effort.level // empty)
+  (.rate_limits.five_hour.used_percentage // null | if . then floor | tostring else "" end),
+  (.rate_limits.seven_day.used_percentage // null | if . then floor | tostring else "" end),
+  (.rate_limits.five_hour.resets_at // null | if . then tostring else "" end),
+  (.rate_limits.seven_day.resets_at // null | if . then tostring else "" end),
+  (.effort.level // "")
 ' <<<"$input")
 
 model="${fields[0]:-Claude}"


### PR DESCRIPTION
## Summary

- セッション開始直後（rate limit 未取得）に statusline が `h high% ()` と壊れた表示になるバグを修正
- jq の `// empty` が null のとき出力行を省略し、後続フィールドのインデックスがずれる問題
- `// empty` → null ガード付き空文字出力に置き換え、配列インデックスを固定化

## Statusline before / after

Before:

```
configs worktree:(inherited-waddling-turing)
Opus 4.6 (1M context) | 0% | h high% () | [editor]
```

After:

```
configs worktree:(inherited-waddling-turing)
Opus 4.6 (1M context) | high | 0% | [editor]
```

## Test plan

- [ ] 新規セッション開始直後の statusline 表示が正常であること
- [ ] 1回メッセージ送信後（rate limit 取得後）の表示が従来通りであること

https://claude.ai/code/session_01SfosPA42LSLCvDKgbiYQLD