### PR TITLE
feat: add pwdc alias to copy /add-dir path to clipboard

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -62,6 +62,7 @@ cwb() {
 }
 alias cwr="claude --worktree --resume"
 alias cwt="claude --worktree --teleport"
+alias pwdc='printf "/add-dir %s" "$PWD" | pbcopy'
 
 # ----------------------------------------------------------------
 # git


### PR DESCRIPTION
## 概要
- `pwdc` エイリアスを追加。実行すると `/add-dir <現在のディレクトリ>` をクリップボードにコピーする
- Claude Code で別ディレクトリを追加する際にペーストするだけで済む

## テスト
- [ ] `exec $SHELL` 後に `pwdc` を実行し、クリップボードに `/add-dir ...` が入ることを確認

https://claude.ai/code/session_01NUcAB4EPauRmtA4Jcy5yt1