### PR TITLE
fix: allow direnv in codex worktrees

### DIFF
--- a/home/.config/direnv/direnv.toml
+++ b/home/.config/direnv/direnv.toml
@@ -1,4 +1,5 @@
 [whitelist]
 prefix = [
+  "~/.codex/worktrees/",
   "~/Code/nozomiishii/",
 ]


### PR DESCRIPTION
## 概要

- `~/.codex/worktrees/` 配下の `.envrc` を direnv の whitelist prefix に追加
- Codex worktree で `direnv allow` を個別に実行しなくても読み込めるようにする

## 確認

- `direnv status` で `/Users/nozomiishii/.codex/worktrees` が whitelist prefix として解決されることを確認
- `pnpm test`
- `pnpm prettier home/.config/direnv/direnv.toml --check`
- `git diff --check`

## 補足

- `pnpm format` は既存の 22 ファイルの整形差分で失敗。今回の変更ファイルは個別チェック済み。