### PR TITLE
fix: unify homebrew install flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	bash ./scripts/homebrew.sh
+	HOMEBREW_BUNDLE_INCLUDE_OPTIONAL=1 bash ./scripts/homebrew.sh
 
 .PHONY: macos
 macos: ## Configure macOS settings

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ help: ## Show this help
 
 .PHONY: homebrew
 homebrew: ## Install/update Homebrew packages
-	# Brewfile を正にする（入れて、Brewfile にないものを削除。App Store は対象外）
-	cat ./Brewfile ./Brewfile.optional | HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle --verbose --cleanup --force --file=-
-	# 古いバージョン・キャッシュを削除してディスクを空ける
-	brew cleanup --verbose
+	bash ./scripts/homebrew.sh
 
 .PHONY: macos
 macos: ## Configure macOS settings

--- a/README.ja.md
+++ b/README.ja.md
@@ -120,13 +120,15 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 -fsSL: -L は dotfiles.nozo.sh のリダイレクトを追跡, -f は HTTP エラーで中断 (壊れた応答を bash に渡さない), -sS は進捗を隠しつつエラーは表示。
 
+<a id="after-installation"></a>
+
 ### インストール後の作業
 
 1. 再起動  
    設定を反映するために `sudo reboot` を実行してください。
 
-2. （任意）Homebrew  
-   Brewfile.optional のパッケージもインストールしたい場合はこちら：
+2. Homebrew が中断された場合
+   パッケージのダウンロードが途中で失敗した場合は、共通の Homebrew インストーラーを再実行してください：
 
    ```shell
    make homebrew
@@ -232,7 +234,7 @@ sudo reboot
     - [Youtube filter](https://chromewebstore.google.com/detail/dfbfdjepofdfhdddfdggabjjndhiggji)
     - [Screenshot YouTube](https://chromewebstore.google.com/detail/gjoijpfmdhbjkkgnmahganhoinjjpohk)
     - [Requestly](https://chromewebstore.google.com/detail/mdnleldcmiljblolnjhpnblkcekpdkpa)
-    - [Linkumori (URLs Cleaner) ](https://chromewebstore.google.com/detail/jchobbjgibcahbheicfocecmhocglkco)
+    - [Linkumori (URLs Cleaner)](https://chromewebstore.google.com/detail/jchobbjgibcahbheicfocecmhocglkco)
       - URL のクエリパラメータを自動削除
     - [Amazon URL Shortener](https://chromewebstore.google.com/detail/bonkcfmjkpdnieejahndognlbogaikdg)
       - amazon の URL 短くしてくれる
@@ -479,8 +481,7 @@ fork して自分用に使う場合、書き換えが必要な箇所を [docs/fo
 使わなくなった Homebrew の依存パッケージを整理して、最新にアップグレードしましょう
 
 ```shell
-	brew bundle --verbose --cleanup --file="./Brewfile"
-	brew cleanup --verbose
+make homebrew
 ```
 
 ### 開発

--- a/README.md
+++ b/README.md
@@ -114,13 +114,15 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 -fsSL: -L follows the dotfiles.nozo.sh redirect, -f aborts on HTTP errors (so a broken response is never piped to bash), -sS hide progress but still show errors.
 
+<a id="after-installation"></a>
+
 ### After installation
 
 1. **Reboot**  
    Run `sudo reboot` to apply the settings.
 
-2. **(Optional) Homebrew**  
-   To install packages from Brewfile.optional:
+2. **Retry Homebrew if needed**
+   Re-run the unified Homebrew installer if a package download was interrupted:
 
    ```shell
    make homebrew
@@ -226,7 +228,7 @@ Then follow the [After installation](#after-installation) steps above.
     - [Youtube filter](https://chromewebstore.google.com/detail/dfbfdjepofdfhdddfdggabjjndhiggji)
     - [Screenshot YouTube](https://chromewebstore.google.com/detail/gjoijpfmdhbjkkgnmahganhoinjjpohk)
     - [Requestly](https://chromewebstore.google.com/detail/mdnleldcmiljblolnjhpnblkcekpdkpa)
-    - [Linkumori (URLs Cleaner) ](https://chromewebstore.google.com/detail/jchobbjgibcahbheicfocecmhocglkco)
+    - [Linkumori (URLs Cleaner)](https://chromewebstore.google.com/detail/jchobbjgibcahbheicfocecmhocglkco)
       - Automatically removes tracking query parameters from URLs
     - [Amazon URL Shortener](https://chromewebstore.google.com/detail/bonkcfmjkpdnieejahndognlbogaikdg)
       - Shortens Amazon product URLs
@@ -474,8 +476,7 @@ If you fork it, see [docs/forking.md](docs/forking.md) for the list of places to
 Clean unused homebrew dependencies up, and upgrade them
 
 ```shell
-	brew bundle --verbose --cleanup --file="./Brewfile"
-	brew cleanup --verbose
+make homebrew
 ```
 
 ### Dev

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ printf '%s\n' \
   "      sudo reboot" \
   "" \
   "" \
-  "📦 Optional Homebrew packages (Brewfile.optional):" \
+  "📦 If Homebrew was interrupted:" \
   "" \
   "    run:" \
   "      make homebrew" \

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -70,7 +70,7 @@ fi
 trust_brew_bundle_formulae
 
 bundle_brewfile_paths=("$SCRIPT_DIR/Brewfile")
-if [[ "$OS_NAME" == "Darwin" ]]; then
+if [[ "$OS_NAME" == "Darwin" && "${HOMEBREW_BUNDLE_INCLUDE_OPTIONAL:-false}" == "1" ]]; then
   bundle_brewfile_paths+=("$SCRIPT_DIR/Brewfile.optional")
 fi
 

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -67,6 +67,11 @@ fi
 
 trust_brew_bundle_formulae
 
+bundle_brewfile_paths=("$SCRIPT_DIR/Brewfile")
+if [[ "$OS_NAME" == "Darwin" ]]; then
+  bundle_brewfile_paths+=("$SCRIPT_DIR/Brewfile.optional")
+fi
+
 max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1
 backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
@@ -75,11 +80,11 @@ backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
 # install と cleanup は一体にする（分けると node 等の依存を巻き添え削除するため）。
 while [ "$attempt" -le "$max_attempts" ]; do
   echo "brew bundle attempt ${attempt}/${max_attempts}"
-  if HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle \
+  if cat "${bundle_brewfile_paths[@]}" | HOMEBREW_CURL_RETRIES="${HOMEBREW_CURL_RETRIES:-5}" HOMEBREW_BUNDLE_CLEANUP_NO_MAS=1 brew bundle \
     --verbose \
     --cleanup \
     --force \
-    --file="$SCRIPT_DIR/Brewfile"; then
+    --file=-; then
     echo "brew bundle succeeded"
     break
   fi

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -34,10 +34,12 @@ trust_brew_bundle_formulae() {
     return 0
   fi
 
-  # Brewfile の外部 tap formula だけを信頼する。
+  # Brewfile の外部 tap entry だけを信頼する。
   brew trust --formula \
     smudge/smudge/nightlight \
     stripe/stripe-cli/stripe
+  brew trust --cask \
+    nozomiishii/tap/brooklyn
 }
 
 if [[ "$OS_NAME" == "Darwin" ]]; then

--- a/scripts/toolchains/codex.sh
+++ b/scripts/toolchains/codex.sh
@@ -13,7 +13,7 @@ echo '🤖 Codex'
 # https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 echo '- 🤖 Install Codex CLI'
 eval "$(fnm env)"
-npm install -g @openai/codex
+(cd /tmp && npm install -g @openai/codex)
 
 echo "- 🤖 codex $(codex --version)"
 

--- a/scripts/toolchains/codex.sh
+++ b/scripts/toolchains/codex.sh
@@ -12,8 +12,7 @@ echo '🤖 Codex'
 
 # https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 echo '- 🤖 Install Codex CLI'
-eval "$(fnm env)"
-(cd /tmp && npm install -g @openai/codex)
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
 
 echo "- 🤖 codex $(codex --version)"
 

--- a/scripts/toolchains/codex.sh
+++ b/scripts/toolchains/codex.sh
@@ -12,6 +12,7 @@ echo '🤖 Codex'
 
 # https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 echo '- 🤖 Install Codex CLI'
+eval "$(fnm env)"
 npm install -g @openai/codex
 
 echo "- 🤖 codex $(codex --version)"


### PR DESCRIPTION
## 概要

- `make homebrew` を `scripts/homebrew.sh` に委譲
- `scripts/homebrew.sh` で macOS の場合のみ `Brewfile.optional` も同じ `brew bundle` に含める
- インストール後の案内と README の Homebrew 再実行手順を更新

## 確認

- `shellcheck scripts/homebrew.sh scripts/darwin/brew_update.sh install.sh`
- `shfmt -i 2 -d scripts/homebrew.sh scripts/darwin/brew_update.sh install.sh`
- `pnpm exec prettier --check README.md README.ja.md package.json pnpm-workspace.yaml`
- `pnpm exec markdownlint-cli2 README.md README.ja.md`
- `pnpm test`
- `bash -n scripts/homebrew.sh scripts/darwin/brew_update.sh install.sh`
- `make -n homebrew`
- `git diff --check`