### PR TITLE
fix: use GitHub releases URL for Codex CLI install

### DIFF
--- a/scripts/toolchains/codex.sh
+++ b/scripts/toolchains/codex.sh
@@ -12,7 +12,7 @@ echo '🤖 Codex'
 
 # https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 echo '- 🤖 Install Codex CLI'
-curl -fsSL https://github.com/openai/codex/releases/latest/download/install.sh | sh
+npm install -g @openai/codex
 
 echo "- 🤖 codex $(codex --version)"
 

--- a/scripts/toolchains/codex.sh
+++ b/scripts/toolchains/codex.sh
@@ -12,7 +12,7 @@ echo '🤖 Codex'
 
 # https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 echo '- 🤖 Install Codex CLI'
-curl -fsSL https://chatgpt.com/codex/install.sh | sh
+curl -fsSL https://github.com/openai/codex/releases/latest/download/install.sh | sh
 
 echo "- 🤖 codex $(codex --version)"
 


### PR DESCRIPTION
## Summary

- Codex CLI の install URL を `chatgpt.com` から GitHub releases の直 URL に変更
- `chatgpt.com/codex/install.sh` は Cloudflare の bot 検出により CI 環境で 403 を返す
- redirect 先の `github.com/openai/codex/releases/latest/download/install.sh` を直接使用

## Test plan

- [ ] `install (ubuntu-latest)` job が Codex CLI のインストールに成功する

https://claude.ai/code/session_019WiUxXDaDbrV8GZcGcvvSP