### PR TITLE
fix: enable devenv zsh completion

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -3,17 +3,21 @@ export STARSHIP_CONFIG="$HOME/.config/starship/starship.toml"
 eval "$(starship init zsh)"
 
 # Initialize zsh's auto-completion system
+# Enable zsh completions distributed through the Nix profile.
+if [[ -d "$HOME/.nix-profile/share/zsh/site-functions" ]]; then
+  fpath=("$HOME/.nix-profile/share/zsh/site-functions" $fpath)
+fi
 autoload -Uz compinit
 zmodload -i zsh/complist
 compinit
 
 # carapace - multi-shell completion engine
 export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
-export CARAPACE_EXCLUDES='make'
+export CARAPACE_EXCLUDES='make,devenv'
 zstyle ':completion:*:*:make:*' tag-order targets
 if command -v carapace >/dev/null; then
   # shellcheck source=/dev/null
-  source <(carapace _carapace)
+  source <(carapace _carapace zsh)
 fi
 
 # fzf-tab - replace zsh tab completion with fzf preview menu


### PR DESCRIPTION
## 概要

- Nix profile が配布する zsh 補完ディレクトリを `fpath` に追加
- carapace から `devenv` を除外し、devenv 同梱の `_devenv` 補完を使うように変更
- carapace 初期化時に shell を `zsh` と明示

## 確認

- `zsh -n home/.zshrc`
- `zsh -ic 'print -r -- "devenv=$_comps[devenv]"; print -r -- "nix=$_comps[nix]"'`
  - `devenv=_devenv`
  - `nix=_carapace_completer`