### PR TITLE
feat: deploy cloud-setup tarball via GitHub Pages

### DIFF
--- a/.github/workflows/cloud-setup.yaml
+++ b/.github/workflows/cloud-setup.yaml
@@ -1,0 +1,52 @@
+name: Cloud Setup
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'home/.hooks/**'
+      - 'home/.agents/**'
+      - 'home/.claude/**'
+      - 'home/.codex/**'
+      - 'home/AGENTS.md'
+      - 'scripts/cloud/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+    steps:
+      - name: Get code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # cloud-setup tarball を作成して _site/ に配置
+      - name: Build tarball
+        run: |
+          mkdir _site
+          tar czf _site/cloud-setup.tar.gz \
+            home/.hooks/ \
+            home/AGENTS.md \
+            home/.claude/settings.json \
+            home/.codex/hooks.json
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/cloud-setup.yaml
+++ b/.github/workflows/cloud-setup.yaml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read  # required by actions/checkout to fetch repository code
-      pages: write
-      id-token: write
+      pages: write  # required by actions/deploy-pages to publish to GitHub Pages
+      id-token: write  # required by actions/deploy-pages for OIDC-based deployment verification
     environment:
       name: github-pages
     steps:

--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -3,15 +3,20 @@
 #   curl -fsSL https://raw.githubusercontent.com/nozomiishii/dotfiles/main/scripts/cloud/setup.sh | bash
 set -euo pipefail
 
-raw="https://raw.githubusercontent.com/nozomiishii/dotfiles/main"
+curl -fsSL "https://nozomiishii.github.io/dotfiles/cloud-setup.tar.gz" | tar xz
+
+# Hooks
+mkdir -p ~/.hooks
+cp home/.hooks/* ~/.hooks/
 
 # Claude Code
 mkdir -p ~/.claude
-curl -fsSL "$raw/home/AGENTS.md" -o ~/.claude/CLAUDE.md
-curl -fsSL "$raw/home/.claude/settings.json" |
-    jq '{permissions: {deny: .permissions.deny}}' \
-        >~/.claude/settings.json
+cp home/AGENTS.md ~/.claude/CLAUDE.md
+jq 'del(.statusLine, .sandbox)' home/.claude/settings.json >~/.claude/settings.json
 
 # Codex
 mkdir -p ~/.codex
-curl -fsSL "$raw/home/AGENTS.md" -o ~/.codex/AGENTS.md
+cp home/AGENTS.md ~/.codex/AGENTS.md
+cp home/.codex/hooks.json ~/.codex/hooks.json
+
+rm -rf home/


### PR DESCRIPTION
## Summary

- cloud 環境（Claude Code on the web / Codex Cloud）用の setup script を改善
- GitHub API への直接呼び出しを廃止し、GitHub Pages から tarball を配信する構成に変更
- `contents:write` 権限が不要になり、API rate limit の制約もなくなる
- Codex の `hooks.json` インストールが漏れていたのを修正
- `settings.json` の jq filter を deny-only から `del(.statusLine, .sandbox)` に変更し、より多くの設定をクラウド環境に反映

## 前提作業

- [ ] repo settings で GitHub Pages を有効化（Source: GitHub Actions）
  - https://github.com/nozomiishii/dotfiles/settings/pages

## Test plan

- [ ] Pages を有効化した状態で workflow を `workflow_dispatch` で手動実行
- [ ] `https://nozomiishii.github.io/dotfiles/cloud-setup.tar.gz` から tarball がダウンロードできることを確認
- [ ] tarball を展開して期待するファイルが含まれていることを確認
- [ ] Claude Code on the web の setup script 欄で動作確認

https://claude.ai/code/session_011rXKap9gvZB3s5hohdG7oX