### PR TITLE
feat: add lint rule consultation requirement to global guidelines

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -14,8 +14,8 @@
 ## 実装
 - 設計ドキュメント・brainstormingの成果はGitHub issueにまとめる。
 
-## Lint
-- lint rule の無効化・緩和は、必ず相談してから行う。
+## 静的解析
+- linter・型検査・セキュリティスキャナなど静的解析ツールの警告やエラーの無効化・緩和は、必ず相談してから行う。
   - rule を off にする、error を warn に下げる、disable コメントで抑制する、いずれも対象。
 
 ## PR

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -14,6 +14,10 @@
 ## 実装
 - 設計ドキュメント・brainstormingの成果はGitHub issueにまとめる。
 
+## Lint
+- lint rule の無効化・緩和は、必ず相談してから行う。
+  - rule を off にする、error を warn に下げる、disable コメントで抑制する、いずれも対象。
+
 ## PR
 - プロジェクトで指定がない場合、PR本文は日本語で書く。
 


### PR DESCRIPTION
## Summary
- lint rule の無効化・緩和をエージェントが独断で行わないよう、必ず相談するルールを AGENTS.md に追加
  - rule を off にする、error を warn に下げる、disable コメントで抑制する、いずれも対象
- 背景: https://github.com/nozomiishii/configs/pull/2495 でエージェントが `import-x/extensions: "off"` を独断で追加した

## Test plan
- [ ] 新しいセッションで lint エラーに遭遇した際、エージェントが rule を無効化せず相談してくるか確認

https://claude.ai/code/session_01VPNmJnzi9rdcjKExvW8rgB