### PR TITLE
feat: add attribution.sessionUrl to suppress session link footer

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -6,7 +6,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "allow": [

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -49,7 +49,7 @@ Agent Teams はタスクに応じて Claude が自動提案するか、明示的
 ### attribution
 
 ```jsonc
-"attribution": { "commit": "", "pr": "" }  // PR・コミットの Claude Code フッター非表示
+"attribution": { "commit": "", "pr": "", "sessionUrl": false }  // PR・コミット・セッション URL の Claude Code フッター非表示
 ```
 
 ### permissions


### PR DESCRIPTION
## 概要

- `attribution.sessionUrl: false` を追加し、Web / Remote Control セッション時の `Claude-Session` URL trailer を非表示にする
- settings.md のドキュメントを更新