### PR TITLE
chore: move pull-request permission to job level for revert support

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -7,9 +7,10 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
+permissions: {}
 
 jobs:
   pull-request:
+    permissions:
+      pull-requests: write  # write: format revert PR titles, read: validate PR titles
     uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0

--- a/home/.agents/skills/ta/SKILL.md
+++ b/home/.agents/skills/ta/SKILL.md
@@ -25,6 +25,17 @@ description: >-
 
 変更をステージしてコミットし、リモートへ push する。
 
+`git push` が `could not read Username for 'https://github.com': Device not configured` で失敗した場合:
+
+- `gh auth status` で GitHub CLI の認証状態を確認する
+- remote URL が `https://github.com/...` なら、永続設定を変更せずに次を試す
+
+```sh
+git -c credential.helper='!gh auth git-credential' push -u origin <branch>
+```
+
+`gh auth setup-git` は Git 設定を永続変更するため使わない。ユーザー認証や外部サービス状態に触れる操作を支援エージェントが実行できない repo では、同じコマンドをユーザーに渡す。
+
 ## 2. PR 作成（必要な場合のみ）
 
 既存の OPEN な PR がない場合、PR を作成する。


### PR DESCRIPTION
pull-request reusable workflow が revert PR タイトルの自動変換で pull-requests: write を必要とするようになったため、job レベルに permission を移動。関連: https://github.com/nozomiishii/workflows/pull/71