### PR TITLE
chore: move pull-request permission to job level for revert support

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -7,9 +7,10 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
+permissions: {}
 
 jobs:
   pull-request:
+    permissions:
+      pull-requests: write  # write: format revert PR titles, read: validate PR titles
     uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0


### PR DESCRIPTION
pull-request reusable workflow が revert PR タイトルの自動変換で pull-requests: write を必要とするようになったため、job レベルに permission を移動。関連: https://github.com/nozomiishii/workflows/pull/71