### PR TITLE
feat: add cpm alias and clipboard feedback for cpm/pwdc

### DIFF
--- a/home/.zsh/alias/alias.zsh
+++ b/home/.zsh/alias/alias.zsh
@@ -62,7 +62,8 @@ cwb() {
 }
 alias cwr="claude --worktree --resume"
 alias cwt="claude --worktree --teleport"
-alias pwdc='printf "/add-dir %s" "$PWD" | pbcopy'
+cpm() { printf "/model claude-opus-4-6[1m]" | pbcopy && echo "Copied: /model claude-opus-4-6[1m]"; }
+pwdc() { printf "/add-dir %s" "$PWD" | pbcopy && echo "Copied: /add-dir $PWD"; }
 
 # ----------------------------------------------------------------
 # git


### PR DESCRIPTION
## Summary

- clipboard 系 alias `cpm` / `pwdc` に `Copied: ...` の出力 feedback を追加
- `cpm`: `/model claude-opus-4-6[1m]` を clipboard にコピー（セッション内で model を戻す用途）
- `pwdc`: 既存の `/add-dir $PWD` コピーを関数化し、同様の feedback を追加