### PR TITLE
fix: run Context7 lookup through nlx

### DIFF
--- a/home/.agents/skills/find-docs/SKILL.md
+++ b/home/.agents/skills/find-docs/SKILL.md
@@ -32,11 +32,10 @@ Run the CLI through `nlx` so it works without a global Context7 install:
 nlx ctx7@latest <command>
 ```
 
-If `nlx` is unavailable, install `@antfu/ni` or use `pnpm dlx`:
+If `nlx` is unavailable, install `@antfu/ni`:
 
 ```bash
 npm install -g @antfu/ni
-pnpm dlx ctx7@latest <command>
 ```
 
 ## Workflow
@@ -152,8 +151,6 @@ If a command fails with a quota error ("Monthly quota reached" or "quota exceede
 3. If they cannot or choose not to authenticate, answer from training knowledge and clearly note it may be outdated
 
 Do not silently fall back to training data — always tell the user why Context7 was not used.
-
-If `nlx` fails because no package manager can be detected, use `pnpm dlx ctx7@latest ...` directly.
 
 ## Common Mistakes
 

--- a/home/.agents/skills/find-docs/SKILL.md
+++ b/home/.agents/skills/find-docs/SKILL.md
@@ -26,16 +26,17 @@ description: >-
 
 Retrieve current documentation and code examples for any library using the Context7 CLI.
 
-Make sure the CLI is up to date before running commands:
+Run the CLI through `nlx` so it works without a global Context7 install:
 
 ```bash
-npm install -g ctx7@latest
+nlx ctx7@latest <command>
 ```
 
-Or run directly without installing:
+If `nlx` is unavailable, install `@antfu/ni` or use `pnpm dlx`:
 
 ```bash
-npx ctx7@latest <command>
+npm install -g @antfu/ni
+pnpm dlx ctx7@latest <command>
 ```
 
 ## Workflow
@@ -44,13 +45,13 @@ Two-step process: resolve the library name to an ID, then query docs with that I
 
 ```bash
 # Step 1: Resolve library ID
-ctx7 library <name> <query>
+nlx ctx7@latest library <name> <query>
 
 # Step 2: Query documentation
-ctx7 docs <libraryId> <query>
+nlx ctx7@latest docs <libraryId> <query>
 ```
 
-You MUST call `ctx7 library` first to obtain a valid library ID UNLESS the user explicitly provides a library ID in the format `/org/project` or `/org/project/version`.
+You MUST call `nlx ctx7@latest library` first to obtain a valid library ID UNLESS the user explicitly provides a library ID in the format `/org/project` or `/org/project/version`.
 
 IMPORTANT: Do not run these commands more than 3 times per question. If you cannot find what you need after 3 attempts, use the best result you have.
 
@@ -59,9 +60,9 @@ IMPORTANT: Do not run these commands more than 3 times per question. If you cann
 Resolves a package/product name to a Context7-compatible library ID and returns matching libraries.
 
 ```bash
-ctx7 library react "How to clean up useEffect with async operations"
-ctx7 library nextjs "How to set up app router with middleware"
-ctx7 library prisma "How to define one-to-many relations with cascade delete"
+nlx ctx7@latest library react "How to clean up useEffect with async operations"
+nlx ctx7@latest library nextjs "How to set up app router with middleware"
+nlx ctx7@latest library prisma "How to define one-to-many relations with cascade delete"
 ```
 
 Always pass a `query` argument — it is required and directly affects result ranking. Use the user's intent to form the query, which helps disambiguate when multiple libraries share a similar name. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
@@ -97,22 +98,22 @@ If the user mentions a specific version, use a version-specific library ID:
 
 ```bash
 # General (latest indexed)
-ctx7 docs /vercel/next.js "How to set up app router"
+nlx ctx7@latest docs /vercel/next.js "How to set up app router"
 
 # Version-specific
-ctx7 docs /vercel/next.js/v14.3.0-canary.87 "How to set up app router"
+nlx ctx7@latest docs /vercel/next.js/v14.3.0-canary.87 "How to set up app router"
 ```
 
-The available versions are listed in the `ctx7 library` output. Use the closest match to what the user specified.
+The available versions are listed in the `nlx ctx7@latest library` output. Use the closest match to what the user specified.
 
 ## Step 2: Query Documentation
 
 Retrieves up-to-date documentation and code examples for the resolved library.
 
 ```bash
-ctx7 docs /facebook/react "How to clean up useEffect with async operations"
-ctx7 docs /vercel/next.js "How to add authentication middleware to app router"
-ctx7 docs /prisma/prisma "How to define one-to-many relations with cascade delete"
+nlx ctx7@latest docs /facebook/react "How to clean up useEffect with async operations"
+nlx ctx7@latest docs /vercel/next.js "How to add authentication middleware to app router"
+nlx ctx7@latest docs /prisma/prisma "How to define one-to-many relations with cascade delete"
 ```
 
 ### Writing good queries
@@ -120,7 +121,7 @@ ctx7 docs /prisma/prisma "How to define one-to-many relations with cascade delet
 The query directly affects the quality of results. Be specific and include relevant details. Do not include any sensitive or confidential information such as API keys, passwords, credentials, personal data, or proprietary code in your query.
 
 | Quality | Example |
-|---------|---------|
+| ------- | ------- |
 | Good | `"How to set up authentication with JWT in Express.js"` |
 | Good | `"React useEffect cleanup function with async operations"` |
 | Bad | `"auth"` |
@@ -139,21 +140,24 @@ Works without authentication. For higher rate limits:
 export CONTEXT7_API_KEY=your_key
 
 # Option B: OAuth login
-ctx7 login
+nlx ctx7@latest login
 ```
 
 ## Error Handling
 
 If a command fails with a quota error ("Monthly quota reached" or "quota exceeded"):
+
 1. Inform the user their Context7 quota is exhausted
-2. Suggest they authenticate for higher limits: `ctx7 login`
+2. Suggest they authenticate for higher limits: `nlx ctx7@latest login`
 3. If they cannot or choose not to authenticate, answer from training knowledge and clearly note it may be outdated
 
 Do not silently fall back to training data — always tell the user why Context7 was not used.
 
+If `nlx` fails because no package manager can be detected, use `pnpm dlx ctx7@latest ...` directly.
+
 ## Common Mistakes
 
 - Library IDs require a `/` prefix — `/facebook/react` not `facebook/react`
-- Always run `ctx7 library` first — `ctx7 docs react "hooks"` will fail without a valid ID
+- Always run `nlx ctx7@latest library` first — `nlx ctx7@latest docs react "hooks"` will fail without a valid ID
 - Use descriptive queries, not single words — `"React useEffect cleanup function"` not `"hooks"`
 - Do not include sensitive information (API keys, passwords, credentials) in queries


### PR DESCRIPTION
## 概要

- find-docs skill の Context7 実行例を `nlx ctx7@latest` に更新
- `nlx` がない場合の fallback として `@antfu/ni` / `pnpm dlx` を案内

## 確認

- `pnpm exec markdownlint-cli2 home/.agents/skills/find-docs/SKILL.md`
- `nlx ctx7@latest --help`
- `nlx ctx7@latest library react "useEffect cleanup"`