### PR TITLE
chore: simplify comments in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,31 +1,23 @@
-# 開発環境のセットアップ。対話シェルでは direnv が cd 時に、エージェントの非対話
-# シェルでは hooks の session-env.sh が SessionStart / CwdChanged で評価する。
-# 冪等に保つ: 通常パスはガード判定だけで数十 ms で終わる。
+# worktree の開発環境セットアップ。direnv と hooks から冪等に評価される。
 # 設計: https://github.com/nozomiishii/dotfiles/issues/1268
 
-# Codex はサブディレクトリを cwd に hook を回すことがあるため repo root を起点にする
 cd "$(git rev-parse --show-toplevel)" || exit 0
 
-# Claude Code の worktree 作成 (EnterWorktree) が共有 .git/config に core.hooksPath を
-# 書き込む。値はデフォルトと同じで冗長だが、lefthook が「独自パス」とみなし commit ごとに
-# "Skipping hook sync" 警告を出すため打ち消す (--unset-all は未設定だと exit 5 なので保険付き)。
-# 上流バグ: https://github.com/anthropics/claude-code/issues/27474
+# Claude Code が共有 .git/config に残す core.hooksPath を打ち消す
+# https://github.com/anthropics/claude-code/issues/27474
 git config --unset-all --local core.hooksPath 2>/dev/null || true
 
-# fetch は FETCH_HEAD の鮮度 10 分でスロットルし、cd のたびのネットワーク待ちを避ける
+# fetch は 10 分間隔にスロットル
 if ! find "$(git rev-parse --git-common-dir)/FETCH_HEAD" -mmin -10 2>/dev/null | grep -q .; then
   git fetch origin --quiet || true
 fi
 
-# linked worktree のときだけ HEAD を origin/main まで進める。main checkout は手動 pull に
-# 任せる (cd で戻っただけで取り込まれるのを防ぐ)。merge-base --is-ancestor により自分の
-# commit があるブランチは触らず、ff-only なので merge commit も作らない。
+# linked worktree だけ origin/main に ff で追従。自分の commit があるブランチは触らない
 if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] &&
   git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
   git merge --ff-only origin/main --quiet || true
 fi
 
-# fresh worktree 初回など
 if [ ! -d node_modules ]; then
   pnpm install
 fi


### PR DESCRIPTION
## 概要

.envrc のコメントを簡略化する横断展開。元 commit: [Brooklyn@aebae19](https://github.com/nozomiishii/Brooklyn/commit/aebae191bf9e2146d06ef1ece60ff30e59798dab)

## 変更内容

- 冗長なコメントを 1 行に圧縮。コードの変更なし
