### PR TITLE
chore: comment out confirm-close-surface to restore quit dialog

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -29,7 +29,7 @@ font-family = "UDEV Gothic"
 font-feature = -calt, -liga, -dlig
 
 # Show "Quit Ghostty?" dialog
-confirm-close-surface = false
+# confirm-close-surface = false
 
 # Start Ghostty windows maximized
 maximize = true


### PR DESCRIPTION
## 概要

ghostty の `confirm-close-surface = false` をコメントアウトし、デフォルトの `true` に戻す。

これで、プロセス実行中の窓を閉じる/Quit するときに「Quit Ghostty?」ダイアログが出るようになる。

## 背景

`false` にしていたため終了時の確認が一切出ない状態だった。終了時にダイアログを出したいという要望に対し、まずはデフォルト挙動に戻す。

## メモ

`confirm-close-surface` は3値:

- `true`（デフォルト）: shell integration が「プロセス実行中」と判定した窓だけ確認
- `false`: 一切確認なし
- `always`: プロセスの有無に関係なく毎回確認

毎回必ずダイアログを出したい場合は将来 `always` に切り替える余地を残すため、行は削除せずコメントアウトで残した。