### PR TITLE
fix: run pr skill ci polling explicitly under bash

### DIFF
--- a/home/.agents/skills/pr/SKILL.md
+++ b/home/.agents/skills/pr/SKILL.md
@@ -240,6 +240,10 @@ polling 例:
 ```bash
 # 初回 5s で素早く確認 → ~10 分まで 60s 間隔 → それ以降は 300s 間隔
 # nozomiishii 配下を実測すると 98 job 中 56% が timeout-minutes:10 のため、10 分で粒度を切り替える
+# zsh は配列 index が 1 始まりで ${intervals[0]} が空になり sleep が落ちるため、bash 明示で実行する。
+# script 内の single quote と衝突するので -c の文字列渡しではなく quoted heredoc で bash に渡す
+export OWNER NAME NUM
+bash <<'POLL'
 intervals=(5 60 60 60 60 60 60 60 60 60 60)
 deadline=$(( $(date +%s) + 60 * 60 ))
 i=0
@@ -279,6 +283,7 @@ while jq -e '
   i=$((i + 1))
   refresh_state
 done
+POLL
 # loop 抜け後の ${TMPDIR:-/tmp}/claude-pr-state-${OWNER}-${NAME}-${NUM}.json が次 iter の入力（「状態の収集」で再取得しない）
 ```
 


### PR DESCRIPTION
## 概要

/pr skill の CI polling 例は配列を使うが、Bash tool の実行 shell は zsh。zsh は配列 index が 1 始まりのため `${intervals[0]}` が空になり、初回の sleep が `invalid time interval` で落ちる。#1285 の監視中に実際に発生した。

## 変更内容

- polling script を quoted heredoc（`bash <<'POLL'`）で bash に渡す形に変更
  - `bash -c '...'` の文字列渡しは script 内の jq の single quote と衝突するため heredoc 渡しにした
- heredoc 内は独立した bash プロセスなので、`export OWNER NAME NUM` で子プロセスに変数を引き継ぐ
- heredoc 本体を抽出して `bash -n` で構文チェック済み

なお「PR の特定と作業ディレクトリの準備」の引数解釈例も `BASH_REMATCH` を使っており bash 前提（zsh はデフォルトでは `$match` を使う）。こちらは Claude が snippet を直接実行せず自分で解釈する運用のため、今回は対象外。

## 関連

- #1285（発生元）