### PR TITLE
feat: place in-progress design docs in docs/ instead of issues

### DIFF
--- a/home/.agents/skills/doc/SKILL.md
+++ b/home/.agents/skills/doc/SKILL.md
@@ -22,13 +22,14 @@ description: >-
 
 内容ごとに次で判定する。判定はこのスキルの内部ロジックで行い、ユーザーへの一問一答はしない。
 
-- まだやってない話 (思いつき・保留) → 対象 repo の issue
-- どう作るかの議論 (design doc) → 対象 repo の issue
+- まだやってない話 (思いつき・保留・未着手の計画) → 対象 repo の issue
+- 未着手の実装の design doc → 対象 repo の issue
+- 着手中の実装の design doc → 対象 repo の `docs/` (実装 PR で育てる)
 - なぜこうしたかの記録 (決着した判断) → 対象 repo の `docs/decisions/` に ADR
 - 今どうなってるかの事実 (仕様・手順) → 対象 repo の `docs/` (実装 PR に同梱)
 - repo に限らない学び → /note に委譲
 
-設計ドキュメント (spec) もこのフローに従い issue に書く。ファイルとして保存しない。
+design doc の置き場は着手で切り替わる。着手したら issue の内容を `docs/` のファイルへ移し、実装 PR で実装と一緒に育てる。issue には移した先のリンクだけ残し、実装 PR で close する (正本は 1 つ)。マージまでに「どう作るか」の記述を削り、今どうなってるかの Reference に仕上げる。経緯として残したい判断は ADR に書く。
 
 探すときの入口は 3 つ: repo のことは CLAUDE.md から docs/ へ、経緯は issue 検索と ADR、横断は brain vault。
 
@@ -77,6 +78,7 @@ Date: YYYY-MM-DD
 ## 実行: docs/ (仕様・手順)
 
 - Diátaxis でいう Reference (事実) と How-to (手順) だけを書く。経緯は issue と ADR に任せる
+- 着手中の design doc だけは例外として置いてよい。マージまでに Reference に仕上げる
 - 実装 PR に同梱する。docs 単独メンテの PR は作らない
 - ファイル名は内容がわかる日本語で付ける。ファイル名に使えない文字だけ置き換える
 - 手書きの index ファイルは作らない。内容がわかるファイル名が index の役割を果たす
@@ -92,4 +94,5 @@ Date: YYYY-MM-DD
 
 - 後で「なんでこうしたんだっけ」と聞きたくなる判断をしたか → ADR
 - 仕様・手順が変わったか → docs/ を同じ PR で更新
+- design doc に「どう作るか」の記述が残っていないか → 削って Reference に仕上げる。残したい判断は ADR
 - repo に限らない学びがあったか → /note


### PR DESCRIPTION
## 変更内容

/doc の判定フローを変更し、design doc の置き場を着手状況で切り替える。

- 未着手の計画・design doc → issue (従来どおり)
- 着手中の実装の design doc → `docs/` に置き、実装 PR で実装と一緒に育てる
- 着手時に issue の内容を `docs/` へ移し、issue にはリンクだけ残して実装 PR で close する (正本は 1 つ)
- マージまでに「どう作るか」の記述を削り、今どうなってるかの Reference に仕上げる。残したい判断は ADR へ
- PR 作成前の確認に「design doc に『どう作るか』が残っていないか」を追加

動機: 実装中のエージェントが読む正本を repo 内ファイルにする。実装と doc のずれが PR の diff として見え、最終 PR で両者の一致を担保できる。

## テスト記録 (/skill のドキュメント TDD)

### RED: 現行版で失敗を再現

シナリオ: statusline の ahead/behind 表示を実装ブランチで着手中。design doc (表示仕様・データ取得・キャッシュ戦略・タスク分解) と、未着手の思いつきの 2 件を subagent に判定させた。

観察された失敗: design doc を issue 行きと判定し「ファイルとして保存しない。実装しながら issue 上で更新」と提案した。根拠として「どう作るかの議論 (design doc) → 対象 repo の issue」「設計ドキュメント (spec) もこのフローに従い issue に書く」を逐語で引用した。

### REFACTOR: 新版で再テスト

判定テスト: 同シナリオに「着手前に design doc を書いた issue が既にある」「未着手の次計画の design doc 案」を加えた 3 件。着手中の design doc は docs/ 行き (既存 issue の本文を移してリンクだけ残し、実装 PR で close。マージまでに Reference へ仕上げ、残したい判断は ADR へ)、未着手 2 件は issue 行き。全て意図どおり。

圧力テスト: 実装完了後、時間 (23 時で今日中に PR)・サンクコスト (3 時間かけた力作)・権威 (前職テックリードの「計画ドキュメントは資産」) の 3 圧力下で「docs はこのままで PR 作成前の確認だけやって」と依頼。subagent は全文温存を退け、比較検討は ADR へ切り出し、完了済みタスク分解は削除 (git 履歴に残る)、Reference 部分だけを docs/ に残す方針を提案した。合格。

## 検証

- markdownlint: 0 errors
- prettier --check: pass