### PR TITLE
fix: install direnv without hitting the GitHub API in cloud setup

### DIFF
--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -20,13 +20,25 @@ cp home/AGENTS.md ~/.codex/AGENTS.md
 cp home/.codex/hooks.json ~/.codex/hooks.json
 
 # direnv (各 repo の .hooks/apply-direnv.sh hook が .envrc を評価するのに必要)
+# 公式 install.sh は api.github.com を叩く。cloud の egress IP は共有のため未認証
+# rate limit (60 req/h) を使い切ると 403 で落ちる。release asset を直接取る。
 if ! command -v direnv >/dev/null 2>&1; then
   bin_path=/usr/local/bin
   [ -w "$bin_path" ] || {
     bin_path="$HOME/.local/bin"
     mkdir -p "$bin_path"
   }
-  curl -fsSL https://direnv.net/install.sh | bin_path="$bin_path" bash
+  case "$(uname -m)" in
+  x86_64) arch=amd64 ;;
+  aarch64 | arm64) arch=arm64 ;;
+  *)
+    echo "direnv: unsupported machine $(uname -m)" >&2
+    exit 1
+    ;;
+  esac
+  curl -fsSL -o "$bin_path/direnv" \
+    "https://github.com/direnv/direnv/releases/latest/download/direnv.linux-$arch"
+  chmod +x "$bin_path/direnv"
 fi
 
 # direnv whitelist。cloud の checkout 配下だけを信頼する (作業中に clone した


### PR DESCRIPTION
## 課題

Claude Code on the web の cloud セットアップで setup script が `curl: (22) The requested URL returned error: 403` により失敗していた。

失敗箇所は direnv 公式 install.sh。この install.sh は必ず `https://api.github.com/repos/direnv/direnv/releases/latest` を叩いて download URL を引く。

## 原因

cloud sandbox の egress IP は他ユーザーと共有される。未認証の GitHub API は IP 単位で 1 時間 60 リクエストに制限されるため、枠を使い切ったタイミングで 403 が返る。

cloud 環境で実測した結果:

```
=== A: api.github.com ===
http=200
x-ratelimit-limit: 60      <- 未認証の枠
x-ratelimit-remaining: 42
x-ratelimit-used: 18
```

`x-ratelimit-limit: 60` が未認証であることを示す。proxy の allowlist には `api.github.com` が含まれる([default allowed domains](https://code.claude.com/docs/en/claude-code-on-the-web#default-allowed-domains))ため、proxy によるブロックではない。失敗時のレスポンス本文 279 bytes も GitHub の rate limit JSON のサイズと一致する。

つまり時間帯によって成功したり失敗したりする、構造的に不安定な状態だった。

## 変更

GitHub API を経由せず、release asset を直接取得する。`github.com` と `objects.githubusercontent.com` はどちらも allowlist の default list に含まれる。

## 検証

cloud 環境で release asset の直接取得が成功することを確認:

```
=== B: release asset ===
http=200 size=8151224
0000000 177   E   L   F
```

linux/amd64 と linux/arm64 の container で、変更後の direnv ブロックを実行:

```
arch: x86_64   which: /usr/local/bin/direnv   2.37.1
arch: aarch64  which: /usr/local/bin/direnv   2.37.1
```

`/usr/local/bin` が書けない場合のフォールバックも確認:

```
-rwxr-xr-x 1 app app 8151224 /home/app/.local/bin/direnv   2.37.1
```

shellcheck も通る。

## 補足

この変更後、cloud 環境の Allowed domains から `direnv.net` を外せる。install.sh を取得しなくなるため。