### PR TITLE
feat: show dev server url in statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -186,6 +186,24 @@ render_env_line() {
   join ' | ' "${parts[@]}"
 }
 
+# 3行目: 応答している dev サーバーの URL。スマホから打ち込めるよう LAN IP の URL も添える。
+# サーバーが立っていないときは行ごと出さない。ポートは使う開発サーバーに合わせて足す。
+render_dev_line() {
+  local ports=(5173 3000)
+  local lan_ip
+  lan_ip=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)
+  local parts=() port part
+  for port in "${ports[@]}"; do
+    # 応答しないポートは接続拒否で即返る。-m はハング対策
+    curl -sf -m 0.2 -o /dev/null "http://127.0.0.1:${port}/" || continue
+    part="${green_bold}dev${reset} http://localhost:${port}"
+    [[ -n "$lan_ip" ]] && part+=" ${gray}phone${reset} http://${lan_ip}:${port}"
+    parts+=("$part")
+  done
+  ((${#parts[@]} == 0)) && return
+  join ' | ' "${parts[@]}"
+}
+
 # --- output ---
 
 # project_dir (claude 起動時の固定 cwd) が消えた場合 (git worktree remove 等)
@@ -195,4 +213,10 @@ if [[ ! -d "$project_dir" ]]; then
   exit 0
 fi
 
-printf '%s\n%s' "$(render_top_line)" "$(render_env_line)"
+dev_line=$(render_dev_line)
+
+if [[ -n "$dev_line" ]]; then
+  printf '%s\n%s\n%s' "$(render_top_line)" "$(render_env_line)" "$dev_line"
+else
+  printf '%s\n%s' "$(render_top_line)" "$(render_env_line)"
+fi

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -196,8 +196,9 @@ render_dev_line() {
   for port in "${ports[@]}"; do
     # 応答しないポートは接続拒否で即返る。-m はハング対策
     curl -sf -m 0.2 -o /dev/null "http://127.0.0.1:${port}/" || continue
-    part="${green_bold}dev${reset} http://localhost:${port}"
-    [[ -n "$lan_ip" ]] && part+=" ${gray}phone${reset} http://${lan_ip}:${port}"
+    # 緑の ● = 稼働中ランプ。括弧内はスマホから打ち込む LAN IP の URL
+    part="${green_bold}●${reset} http://localhost:${port}"
+    [[ -n "$lan_ip" ]] && part+=" (http://${lan_ip}:${port})"
     parts+=("$part")
   done
   ((${#parts[@]} == 0)) && return

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -186,21 +186,51 @@ render_env_line() {
   join ' | ' "${parts[@]}"
 }
 
-# 3行目: 応答している dev サーバーの URL。スマホから打ち込めるよう LAN IP の URL も添える。
-# サーバーが立っていないときは行ごと出さない。ポートは使う開発サーバーに合わせて足す。
+# 3行目: このプロジェクトで起動している dev サーバーの URL。スマホから打ち込めるよう
+# LAN IP の URL も添える。サーバーが立っていないときは行ごと出さない。
+# ポート固定だと並行開発 (別 worktree のサーバーや vite の自動ポートずらし) で他の
+# サーバーを拾うため、プロセスの cwd が project_dir 配下にある LISTEN ポートだけを対象にする。
 render_dev_line() {
-  local ports=(5173 3000)
-  local lan_ip
+  # pid:port の一覧 (IPv4 / IPv6 の重複は sort -u で除去)
+  local listen
+  listen=$(lsof -nP -iTCP -sTCP:LISTEN -Fpn 2>/dev/null | awk '
+    /^p/ { pid = substr($0, 2) }
+    /^n/ { n = $0; sub(/^n.*:/, "", n); if (n ~ /^[0-9]+$/) print pid ":" n }
+  ' | sort -u)
+  [[ -z "$listen" ]] && return
+
+  # pid ごとの cwd を一括で引き、project_dir 配下の pid だけ残す
+  local pids project_pids=" " pid="" line proc_cwd
+  pids=$(cut -d: -f1 <<<"$listen" | sort -u | paste -sd, -)
+  while IFS= read -r line; do
+    case "$line" in
+      p*) pid="${line#p}" ;;
+      n*)
+        proc_cwd="${line#n}"
+        if [[ "$proc_cwd" == "$project_dir" || "$proc_cwd" == "$project_dir"/* ]]; then
+          project_pids+="${pid} "
+        fi
+        ;;
+    esac
+  done < <(lsof -a -p "$pids" -d cwd -Fpn 2>/dev/null)
+  [[ "$project_pids" == " " ]] && return
+
+  # 対象 pid のポートのうち HTTP が返るものだけ表示 (inspector 等のノイズ除け)。
+  # 応答しないポートは接続拒否で即返る。-m はハング対策
+  local lan_ip entry port seen=" " part parts=()
   lan_ip=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)
-  local parts=() port part
-  for port in "${ports[@]}"; do
-    # 応答しないポートは接続拒否で即返る。-m はハング対策
+  while IFS= read -r entry; do
+    pid="${entry%%:*}"
+    port="${entry##*:}"
+    [[ "$project_pids" == *" ${pid} "* ]] || continue
+    [[ "$seen" == *" ${port} "* ]] && continue
+    seen+="${port} "
     curl -sf -m 0.2 -o /dev/null "http://127.0.0.1:${port}/" || continue
     # 緑の ● = 稼働中ランプ。括弧内はスマホから打ち込む LAN IP の URL
     part="${green_bold}●${reset} http://localhost:${port}"
     [[ -n "$lan_ip" ]] && part+=" (http://${lan_ip}:${port})"
     parts+=("$part")
-  done
+  done <<<"$listen"
   ((${#parts[@]} == 0)) && return
   join ' | ' "${parts[@]}"
 }


### PR DESCRIPTION
## 概要

機能実装中に dev サーバーの URL がシェルログに埋もれて遡れない問題への対応。
このプロジェクトで起動している dev サーバーがあるときだけ、statusline の 3 行目に URL を常時表示する。

- サーバーの発見はポート固定ではなく、LISTEN 中プロセスの cwd が project_dir 配下かどうかで紐づける。並行開発 (別 worktree のサーバーや vite の自動ポートずらし) でも自分のプロジェクトのものだけが出る
- 先頭の緑の ● が稼働中ランプ。ラベル文字は置かない
- スマホから打ち込めるよう、括弧内に LAN IP (en0 / en1) の URL を添える
- ● は Menlo / SF Mono にある記号で、Nerd Font 不要・絵文字化しない
- HTTP が返るポートだけ表示 (inspector 等の LISTEN はノイズとして除外)。応答チェックは `-m 0.2` でハング対策済み、全体の実行時間は 0.3s 程度

settings.md の statusLine 説明 (表示項目の列挙) にも足したかったが、settings.json との同時変更を要求する settings-sync-check に掛かるため本 PR からは外した。列挙の更新は /sync-settings-doc での同期に任せる。

## Statusline before / after

Before:

```
dance worktree:(iridescent-moseying-balloon) git:(feat/fullscreen-review)
Fable 5 | xhigh | 42% | [editor]
```

After (このプロジェクトの dev サーバー起動中のみ 3 行目が出る。停止中は before と同じ):

```
dance worktree:(iridescent-moseying-balloon) git:(feat/fullscreen-review)
Fable 5 | xhigh | 42% | [editor]
● http://localhost:5173 (http://192.168.100.28:5173)
```

## 検証

- shellcheck パス
- dance worktree A (5173) と worktree B のサーバー並行稼働時、それぞれの project_dir で自分のサーバーだけ表示されることを実レンダリングで確認
- サーバーのないプロジェクト (dotfiles) では 3 行目が出ず 2 行のまま
- docs/statusline.md の手順どおり main repo の実体にも反映済み (Claude Code の再描画で即確認できる)