### PR TITLE
feat: add /codex:import skill to hand off codex sessions to claude code

### DIFF
--- a/home/.agents/skills/codex/.claude-plugin/plugin.json
+++ b/home/.agents/skills/codex/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "codex",
+  "description": "Codex セッションを Claude Code 側で扱う個人スキル群。openai-codex plugin の逆方向を補完する。"
+}

--- a/home/.agents/skills/codex/skills/import/SKILL.md
+++ b/home/.agents/skills/codex/skills/import/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: from-codex
+name: import
 description: >-
   Codex CLI / Codex App のセッション内容を現在の Claude Code セッションに引き継ぐ。
-  ユーザーが /from-codex と入力したとき、または「Codex でやっていた作業の続きをやって」
+  ユーザーが /codex:import と入力したとき、または「Codex でやっていた作業の続きをやって」
   「Codex セッションを引き継いで」と言ったときに使用する。
 ---
 
-# /from-codex
+# /codex:import
 
 Codex セッション (rollout JSONL) から依頼・作業内容・残タスクを抽出し、現状と突き合わせてから続きを再開する。openai-codex plugin の /codex:transfer (Claude Code → Codex) の逆方向。
 

--- a/home/.agents/skills/from-codex/SKILL.md
+++ b/home/.agents/skills/from-codex/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: from-codex
+description: >-
+  Codex CLI / Codex App のセッション内容を現在の Claude Code セッションに引き継ぐ。
+  ユーザーが /from-codex と入力したとき、または「Codex でやっていた作業の続きをやって」
+  「Codex セッションを引き継いで」と言ったときに使用する。
+---
+
+# /from-codex
+
+Codex セッション (rollout JSONL) から依頼・作業内容・残タスクを抽出し、現状と突き合わせてから続きを再開する。openai-codex plugin の /codex:transfer (Claude Code → Codex) の逆方向。
+
+## セッションの場所
+
+- 進行中: `~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl`
+- アーカイブ済み: `~/.codex/archived_sessions/`
+- ファイル名の uuid がセッション id。`codex resume <uuid>` に渡せるものと同じ
+- 一覧が空に見えても無いと断定しない。年/月/日のサブディレクトリ構造なので find で再帰する。sandbox の読み取り拒否でも空に見えるため、その場合は sandbox を外して再試行する
+
+## 対象セッションの特定
+
+本文を grep で探さない。1 行目の session_meta にグローバル AGENTS.md 全文が埋め込まれており、リポジトリ名などのキーワードが大量に誤ヒットする。1 行目の payload.cwd で絞り、新しい順に候補を出す:
+
+```sh
+for f in $(find ~/.codex/sessions ~/.codex/archived_sessions -name "*.jsonl" 2>/dev/null | sort -r); do
+  head -1 "$f" | jq -r --arg f "$f" '[.payload.cwd, .payload.originator, $f] | @tsv'
+done
+```
+
+実作業でないセッションを除外する:
+
+- originator が codex_exec のもの (Claude Code の plugin やスクリプト経由の単発呼び出し)
+- user_message が approval 判定・レビュー指示だけのもの (Codex の内部セッション)
+
+候補が近接するときの「最新」は、開始時刻 (ファイル名) でなく各ファイル末尾の timestamp (`tail -1 "$f" | jq -r .timestamp`) で比べる。後から始まったセッションが先に終わっていることがある。
+
+Codex App / Cloud 由来のセッションは cwd がローカルに存在しないパスのことがある。cwd の完全一致で見つからないときはリポジトリ名で緩く照合する。内容の裏取りで対象と確定できればそのまま進み、確定できないときだけ候補を並べてユーザーに確認する。
+
+## 内容の抽出
+
+MB 級のファイルがあるため丸読みしない。jq で必要な行だけ取る:
+
+```sh
+jq -r 'select(.type=="event_msg" and .payload.type=="user_message") | .payload.message + "\n---"' "$F"
+jq -r 'select(.type=="event_msg" and .payload.type=="agent_message") | .payload.message' "$F" | tail -30
+jq -r 'select(.type=="response_item" and .payload.type=="function_call") | .payload.name + " " + .payload.arguments[0:200]' "$F"
+```
+
+上から順に、ユーザーの依頼・Codex の報告 (末尾が最終報告と残タスク)・実行コマンド。
+
+## 再開の前に
+
+セッション内の「残タスク」を鵜呑みにしない。セッション終了後に PR の merge などで現状が進んでいることがある。git log・gh pr list・作業ツリーと突き合わせ、依頼・済んだこと・残り・次の一手を報告してから続きに着手する。


### PR DESCRIPTION
## 概要

Codex CLI / Codex App のセッションを Claude Code に引き継ぐ /codex:import スキルを追加する。openai-codex plugin の /codex:transfer (Claude Code → Codex) の逆方向。

Claude Code 本体には外部エージェントセッションのインポート機能が無く、実装の議論も見当たらない (近い要望は [claude-code#18645](https://github.com/anthropics/claude-code/issues/18645) → [claude-code#17682](https://github.com/anthropics/claude-code/issues/17682) だが Claude 同士のマシン間移行の話で、いずれも CLOSED)。Codex 側は逆方向のインポーターを公式実装済みのため、こちら向きだけスキルで埋める。

## 構成

`/codex:` プレフィックスにするため、skills-dir plugin として置く ([Plugins reference / Skills-directory plugins](https://code.claude.com/docs/en/plugins-reference.md#skills-directory-plugins))。

- `home/.agents/skills/codex/.claude-plugin/plugin.json` — plugin `codex@skills-dir`
- `home/.agents/skills/codex/skills/import/SKILL.md` — `/codex:import`

公式 plugin `codex@openai-codex` とは marketplace 修飾で区別され共存できる ([Skills / Where skills live](https://code.claude.com/docs/en/skills.md#where-skills-live))。コマンド名も import は公式側に存在しない。`claude --plugin-dir <このディレクトリ> -p` でスキル一覧に `codex:import` が載ることを確認済み。

## テスト記録 (/skill のドキュメント TDD)

### RED

- シナリオ 1 (fixture): scratchpad に slugify 実装途中のリポジトリと本物の Codex セッションを用意し、スキルなしの subagent に「Codex の続きをやって」と依頼 → 完遂。失敗なし
- シナリオ 2 (実データ): 実セッション約 150 件 (最大 9.6MB、approval 判定専用セッションや cwd がローカルに無い Codex App 由来セッション入り) で同様に依頼 → 完遂したが探索に無駄が出た
  - 「session_meta にはグローバル AGENTS.md 全文が埋め込まれていて、その本文が dotfiles に言及するためノイズだらけだった」(grep での絞り込みが 40 件超誤ヒットしてやり直し)
  - 「ls -lat ~/.codex/sessions/ は年別サブディレクトリ構造のため一見空に見えた」
  - 73k tokens / 22 tool 呼び出し / 6 分

### GREEN

観察された無駄だけに対処するリファレンス型として作成。セッションの置き場・cwd による特定レシピ・除外規則 (codex_exec、approval 判定)・jq 抽出レシピ・現状との突き合わせ。

### REFACTOR

- 読者テスト 1 回目: 完遂・合格 (16 tool 呼び出し、grep の空振りなし)。指摘 3 件を反映: 「最新」の基準を末尾 timestamp に規定 / ユーザー確認と自力裏取りの線引き / user_message 抽出の境界が消える問題
- 読者テスト 2 回目 (別 subagent): 完遂・合格 (14 tool 呼び出し)。末尾 timestamp 規則が「後から始まって先に終わったセッション」の誤認をそのまま防いだ。指摘 1 件 (function_call の name が無いと MCP 主体のセッションが読めない) をレシピに反映し、同読者がコピペ動作を再検証済み

## 備考

スキルなしでも完遂自体はできたため、これは失敗の修正でなく探索コストと選別の再現性 (デコイ除外・最新判定) を固定するためのスキル。
