### PR TITLE
fix: replace discontinued chatgpt-atlas with chatgpt desktop app

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -230,8 +230,8 @@ if OS.mac?
   # GIT client　https://fork.dev/
   cask "fork"
 
-  # OpenAI's official browser with ChatGPT built in https://chatgpt.com/atlas
-  cask "chatgpt-atlas"
+  # OpenAI's official ChatGPT desktop app https://chatgpt.com/
+  cask "chatgpt"
 
   # Web browser. https://www.google.com/chrome
   cask "google-chrome"


### PR DESCRIPTION
## 概要

ChatGPT Atlas の廃止に伴い、Brewfile の `chatgpt-atlas` を ChatGPT デスクトップアプリ（`chatgpt`）に置き換える。

## 背景

- OpenAI が 2026-07-09 に Atlas の廃止を発表。2026-08-09 以降は起動不可になる
  - [Evolving Atlas into ChatGPT for browser-based agentic work — OpenAI Help Center](https://help.openai.com/en/articles/20001371-evolving-atlas-into-chatgpt-for-browser-based-agentic-work)
- Atlas の agentic browsing 機能と Codex デスクトップアプリ（`codex-app` cask、こちらも discontinued）の移行先は ChatGPT デスクトップアプリ
- `codex-app` は Brewfile に元々含まれていないため、削除対象は `chatgpt-atlas` のみ

## 変更内容

- `cask "chatgpt-atlas"` を削除し `cask "chatgpt"` を追加

## 補足

インストール済みの Atlas は `brew bundle` では削除されない。bookmarks の export 後に `brew uninstall --cask chatgpt-atlas` を各マシンで実行する。
