### PR TITLE
fix: update vscode yaml schema detection and dark theme

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -604,7 +604,24 @@
     "*.ejs": "html",
     "flake.lock": "json",
     ".env*": "dotenv"
-  }
+  },
+  "yaml.disableSchemaDetection": [
+    "**/.github/workflows/*.yml",
+    "**/.github/workflows/*.yaml",
+    "**/.gitea/workflows/*.yml",
+    "**/.gitea/workflows/*.yaml",
+    "**/.forgejo/workflows/*.yml",
+    "**/.forgejo/workflows/*.yaml",
+    "**/docker-compose.yml",
+    "**/docker-compose.yaml",
+    "**/docker-compose.*.yml",
+    "**/docker-compose.*.yaml",
+    "**/compose.yml",
+    "**/compose.yaml",
+    "**/compose.*.yml",
+    "**/compose.*.yaml"
+  ],
+  "workbench.preferredDarkColorTheme": "Monokai Pro"
 
   ///////////////////////////////////////////////////////////////////
 }


### PR DESCRIPTION
## 概要
- VS Code の `yaml.disableSchemaDetection` を追加し、CI/CD ワークフローや docker-compose ファイルでの不要なスキーマ検出を無効化
- ダークテーマを Monokai Pro に変更