### PR TITLE
chore: remove vscode-icons .opentofu-version workaround

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -488,13 +488,6 @@
       "extends": "brew"
     },
     {
-      "icon": "opentofu",
-      "extensions": [".opentofu-version"],
-      "filename": true,
-      "format": "svg",
-      "extends": "opentofu"
-    },
-    {
       "icon": "swift",
       "extensions": ["Mintfile", ".swiftformat"],
       "filename": true,


### PR DESCRIPTION
## Summary
- upstream [vscode-icons/vscode-icons#4031](https://github.com/vscode-icons/vscode-icons/pull/4031) がマージ・リリースされたため、`.opentofu-version` の手動アイコンマッピングを削除

Closes #853