### PR TITLE
chore: add pre-PR diff check to ta and archive skills

### DIFF
--- a/home/.agents/skills/archive/SKILL.md
+++ b/home/.agents/skills/archive/SKILL.md
@@ -108,6 +108,8 @@ git commit -m "chore: remove <何を>"
 git push -u origin <branch>
 ```
 
+PR 作成前に `git diff origin/main..HEAD --stat` で無関係なファイルが混入していないか確認する。あれば `git rebase origin/main` で起点を揃える。
+
 PR 本文には archives 側の PR へのリンクを含める。
 
 両方の PR の URL をまとめて返す。

--- a/home/.agents/skills/ta/SKILL.md
+++ b/home/.agents/skills/ta/SKILL.md
@@ -26,6 +26,10 @@ model: sonnet
 
 把握した変更のうち関連するものだけをステージしてコミットし、リモートへ push する。無関係な変更を巻き込まない。
 
+## PR 作成前の diff 検証
+
+`git diff origin/main..HEAD --stat` で、意図したファイルだけが含まれているか確認する。無関係なファイルがあれば `git rebase origin/main` で起点を揃えてから進む。
+
 ## PR 作成（必要な場合のみ）
 
 既存の OPEN な PR がない場合、PR を作成する。


### PR DESCRIPTION
## 概要

`/ta` と `/archive` スキルに、PR 作成前の diff 検証ステップを追加する。

`git diff origin/main..HEAD --stat` で無関係なファイルが混入していないか確認し、あれば `git rebase origin/main` で起点を揃えてから PR を作成する。

## 背景

worktree の起点が origin/main より古い状態でブランチを切ると、GitHub の PR diff に意図しないファイルが含まれることがある（[#1327](https://github.com/nozomiishii/dotfiles/pull/1327) で発生）。
