### PR TITLE
feat: sync personal skills to cloud setup

### DIFF
--- a/.github/workflows/cloud-setup.yaml
+++ b/.github/workflows/cloud-setup.yaml
@@ -43,6 +43,7 @@ jobs:
             home/.hooks/ \
             home/AGENTS.md \
             home/.claude/settings.json \
+            home/.agents/skills/ \
             home/.codex/hooks.json
 
       - name: Upload pages artifact

--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -19,6 +19,11 @@ mkdir -p ~/.codex
 cp home/AGENTS.md ~/.codex/AGENTS.md
 cp home/.codex/hooks.json ~/.codex/hooks.json
 
+# Skills
+mkdir -p ~/.agents/skills ~/.claude/skills
+cp -R home/.agents/skills/. ~/.agents/skills/
+cp -R home/.agents/skills/. ~/.claude/skills/
+
 # direnv (各 repo の .hooks/apply-direnv.sh hook が .envrc を評価するのに必要)
 # 公式 install.sh は api.github.com を叩く。cloud の egress IP は共有のため未認証
 # rate limit (60 req/h) を使い切ると 403 で落ちる。release asset を直接取る。


### PR DESCRIPTION
## 概要

クラウド／モバイルセッションでは `home/.agents/skills/` 配下の個人スキルが読み込まれていなかった。cloud-setup の tarball にスキルを含めておらず、`scripts/cloud/setup.sh` 側にも配置処理がなかったため。

## 変更内容

- `.github/workflows/cloud-setup.yaml`: tarball のパッケージ対象に `home/.agents/skills/` を追加
- `scripts/cloud/setup.sh`: 展開したスキルを Codex が読む `~/.agents/skills` と Claude が読む `~/.claude/skills` の両方へコピー

Mac は `make link`（stow）が `~/.claude/skills -> ~/.agents/skills` を張るため対応不要。

## 検証

実ファイルを使った e2e で以下を確認。

- 修正前: tarball 展開後も `~/.claude/skills/wt` が存在しない (FAIL)
- 修正後: `~/.agents/skills/wt`・`~/.claude/skills/wt` が生成され、harness 管理スキル（`session-start-hook`）も温存 (PASS)
- `bash -n` 構文チェック・commitlint 通過


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdbejKwkkrzPwVnSnitbWS)_