### PR TITLE
chore: slim envrc to deps install only

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,22 +1,11 @@
 # worktree の開発環境セットアップ。direnv と hooks から冪等に評価される。
 # 設計: https://github.com/nozomiishii/dotfiles/issues/1268
+#
+# 起点の鮮度はここでは扱わない。Claude Code v2.1.208+ が worktree を
+# origin/HEAD 起点で作り、必要な fetch も本体が行う。
+# https://code.claude.com/docs/en/worktrees#choose-the-base-branch
 
 cd "$(git rev-parse --show-toplevel)" || exit 0
-
-# Claude Code が共有 .git/config に残す core.hooksPath を打ち消す
-# https://github.com/anthropics/claude-code/issues/27474
-git config --unset-all --local core.hooksPath 2>/dev/null || true
-
-# fetch は 10 分間隔にスロットル
-if ! find "$(git rev-parse --git-common-dir)/FETCH_HEAD" -mmin -10 2>/dev/null | grep -q .; then
-  git fetch origin --quiet || true
-fi
-
-# linked worktree だけ origin/main に ff で追従。自分の commit があるブランチは触らない
-if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] &&
-  git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
-  git merge --ff-only origin/main --quiet || true
-fi
 
 if [ ! -d node_modules ]; then
   pnpm install


### PR DESCRIPTION
## 概要

`.envrc` を deps install だけに薄型化する。worktree セットアップの独自実装のうち、Claude Code 本体が担うようになった部分と、役目を終えたワークアラウンドを削除する。

- fetch スロットル + origin/main への ff 追従を削除
- `core.hooksPath` の打ち消しを削除

## 根拠

### fetch + ff 追従

Claude Code v2.1.208 以降、worktree はリモートの default branch（`origin/HEAD`）起点で作られ、24 時間以内に fetch が無ければ本体が自動 fetch する。起点の鮮度を `.envrc` 側で担保する必要がなくなった。

https://code.claude.com/docs/en/worktrees#choose-the-base-branch

### core.hooksPath の打ち消し

[anthropics/claude-code#27474](https://github.com/anthropics/claude-code/issues/27474) のワークアラウンド。[バイナリ解析コメント](https://github.com/anthropics/claude-code/issues/27474#issuecomment-4957586852)によると、未設定 repo へ `.git/hooks` を書き込む破壊的変異は v2.1.179 で消えている。

手元の v2.1.211 で実測検証済み:

- `core.hooksPath` 未設定の repo で `claude -p --worktree` 実行 → 未設定のまま（汚染なし）
- 相対値 `.githooks` 設定の repo → 絶対パス化の書き込みは残存（issue が open な理由）

この repo は lefthook が `.git/hooks` に直接フックを配置する方式で `core.hooksPath` 未設定運用のため、該当しない。共有 config に旧版の残骸が無いことも確認済み。

## 検証

- `bash .hooks/apply-direnv.sh` で direnv 評価が通ること（エラーなし、node_modules 存在時に pnpm install がスキップされること）を確認
