### PR TITLE
feat: add cloud-bump skill to force environment snapshot rebuild

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-bump
 description: >-
-  claude.ai の cloud 環境の Setup script 欄の日付コメントを Claude in Chrome で更新し、
+  claude.ai の cloud 環境の Setup script 欄の日時コメントを Claude in Chrome で更新し、
   環境スナップショットの再構築を発火させる。
   ユーザーが /cloud-bump と入力したとき、または dotfiles の main にマージした変更が
   cloud 配信対象 (cloud-setup.yaml の paths) に触れていたときに使用する。
@@ -23,9 +23,9 @@ cloud 環境の setup script は毎セッション走らない。環境スナッ
 https://claude.ai/code を開き、対象環境の設定ダイアログの Setup script 欄を編集する。環境が複数あるときは、どれを bump するかユーザーに確認する。
 
 - 編集前に欄の現在値を読み取り、会話に控える
-- 変更は先頭の日付コメント行 `# bump YYYY-MM-DD` の追加・更新のみ。他の行に触れない
+- 変更は先頭の日時コメント行 `# bump YYYY-MM-DD HH:MM` の追加・更新のみ。他の行に触れない。再構築のトリガーは欄のテキストが変わることなので、同日に複数回 bump しても変化が出るよう時刻まで書く
 - 保存前に差分を提示して承認を得る
-- 操作に失敗したらリトライで粘らず、手動手順を案内して止まる: https://claude.ai/code で対象環境の設定を開き、日付コメントを手で書き換える
+- 操作に失敗したらリトライで粘らず、手動手順を案内して止まる: https://claude.ai/code で対象環境の設定を開き、日時コメントを手で書き換える
 
 Setup script が非 0 で終了する状態になると新規セッションが全て起動不能になる。欄を壊さないことを何より優先する。
 

--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cloud-bump
+description: >-
+  claude.ai の cloud 環境の Setup script 欄の日付コメントを Claude in Chrome で更新し、
+  環境スナップショットの再構築を発火させる。
+  ユーザーが /cloud-bump と入力したとき、または dotfiles の main にマージした変更が
+  cloud 配信対象 (cloud-setup.yaml の paths) に触れていたときに使用する。
+model: sonnet
+---
+
+# /cloud-bump
+
+cloud 環境の setup script は毎セッション走らない。環境スナップショットの再構築時にだけ走り、再構築のトリガーは Setup script 欄の変更・allowed network hosts の変更・約 7 日のキャッシュ失効だけ ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))。main にマージして tarball が再デプロイされても、bump しない限り新規セッションは最大 7 日前のスナップショットで起動する。「マージされたので自動で反映済み」は誤り。設計の経緯は [dotfiles#1347](https://github.com/nozomiishii/dotfiles/issues/1347)。
+
+## 発火の判定
+
+対象は main にマージ済みの変更だけ。マージ前に bump すると古い main でスナップショットが焼き直されるだけになる。
+
+判定リストの正本は `.github/workflows/cloud-setup.yaml` の `paths`。スキルに書き写さず、workflow ファイルを読んで merge diff と突き合わせる。触れていなければ bump 不要と伝えて終わる。
+
+## 欄の書き換え (Claude in Chrome)
+
+https://claude.ai/code を開き、対象環境の設定ダイアログの Setup script 欄を編集する。環境が複数あるときは、どれを bump するかユーザーに確認する。
+
+- 編集前に欄の現在値を読み取り、会話に控える
+- 変更は先頭の日付コメント行 `# bump YYYY-MM-DD` の追加・更新のみ。他の行に触れない
+- 保存前に差分を提示して承認を得る
+- 操作に失敗したらリトライで粘らず、手動手順を案内して止まる: https://claude.ai/code で対象環境の設定を開き、日付コメントを手で書き換える
+
+Setup script が非 0 で終了する状態になると新規セッションが全て起動不能になる。欄を壊さないことを何より優先する。
+
+## 反映範囲
+
+再構築が効くのは bump 後に開始した新規セッションだけ。実行中・再開セッションには効かない。


### PR DESCRIPTION
## 概要

#1347 の実装。cloud 環境のスナップショットは Setup script 欄の変更・allowed network hosts の変更・約 7 日の失効でしか再構築されず、main にマージしただけでは新規セッションに届かない ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))。/cloud-bump はマージ済み diff を cloud-setup.yaml の paths (正本) と突き合わせ、必要なら Claude in Chrome で Setup script 欄の先頭の日時コメント (`# bump YYYY-MM-DD HH:MM`) だけを更新して再構築を発火させる。再構築のトリガーは欄のテキストが変わることなので、同日に複数回 bump しても変化が出るよう時刻まで書く。

frontmatter は `model: sonnet`。

## スキル TDD 記録 (/skill)

RED (スキルなし):

- パイプライン (workflow・tarball・deploy 状態) は自力で特定できたが、「setup.sh はセッション起動ごとに走る」と誤解し、「既に自動で反映済み、追加作業は不要」と誤結論した。スナップショットキャッシュを知らないため、最大 7 日遅れの静かな劣化を見逃す

REFACTOR (スキルあり、2 テスト合格):

- 配信対象に触れるコミット (3536048): bump 必要と判定し、「マージ済み = 反映済みではない」を明言。欄の現在値の控え・日時コメント行のみ変更・保存前承認の制約つきで操作手順を提示した
- 対象外コミット (bae9648, `package.json` のみ): workflow の paths と突き合わせて bump 不要で終了し、ブラウザ操作に進まなかった

## 未検証の範囲

Claude in Chrome での実ブラウザ操作は cloud セッションでは実行できないため未検証。Mac のローカルセッションで初回実行時に、欄の読み取り → 日時行のみの差分 → 承認 → 保存の流れを確認してから常用する。

Closes #1347