### PR TITLE
fix: remove empty .hooks dir from cloud-setup tarball

### DIFF
--- a/.github/workflows/cloud-setup.yaml
+++ b/.github/workflows/cloud-setup.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
     paths:
-      - 'home/.hooks/**'
       - 'home/.agents/**'
       - 'home/.claude/**'
       - 'home/.codex/**'
@@ -40,7 +39,6 @@ jobs:
         run: |
           mkdir _site
           tar czf _site/cloud-setup.tar.gz \
-            home/.hooks/ \
             home/AGENTS.md \
             home/.claude/settings.json \
             home/.agents/skills/ \


### PR DESCRIPTION
## Summary

- `home/.hooks/` は ae537298 で最後のスクリプトが削除されて空ディレクトリになった
- Git は空ディレクトリを追跡しないため、CI の checkout で `home/.hooks/` が存在せず `tar` が失敗していた
- cloud-setup ワークフローの tarball 対象と paths トリガーから `home/.hooks` を除外

Closes: https://github.com/nozomiishii/dotfiles/actions/runs/29656197426/job/88110914743

## Test plan

- [ ] cloud-setup ワークフローの CI が通ること