### PR TITLE
feat: add new-repo skill

### DIFF
--- a/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
+++ b/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
@@ -10,7 +10,7 @@ Date: 2026-07-24
 ## Decision — 決めたこと
 
 - 新しいリポジトリ作成のフローの正本を new-repo スキルに置く
-- 役割分担: リポジトリの作成・設定・保護は nozomiishii/infra の `locals.repositories`、ローカル登録は nozomiishii/workspaces の `projects.json`、足場は configs 一式 + nozomiishii/workflows を呼ぶ標準 workflow
+- 役割分担: リポジトリの作成・設定・保護は nozomiishii/infra の `locals.repositories`、ローカル登録は nozomiishii/workspaces の `projects.json`、初期セットアップは configs 一式 + nozomiishii/workflows を呼ぶ標準 workflow
 - GitHub を直接操作する作成・設定変更(`gh repo create` / `gh repo edit` / ruleset API)は禁止として明文化する
 - ブートストラップは `auto_init` 前提(判断は [infra の ADR](https://github.com/nozomiishii/infra/blob/main/docs/decisions/リポジトリ作成時に%20auto_init%20で%20initial%20commit%20を作る.md))
 - `@nozomiishii/cspell-config` と `@nozomiishii/markdownlint-cli2-config` は非推奨のため新規リポジトリに導入しない

--- a/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
+++ b/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
@@ -1,0 +1,21 @@
+# 新しいリポジトリ作成のフローは new-repo スキルを正本にする
+
+Status: accepted
+Date: 2026-07-24
+
+## Context — 判断を迫られた状況
+
+新しいリポジトリを作るたびに手戻りが起きていた。直近では nozomiishii/design の作成で、空リポジトリ + main 保護ルールにより initial commit の push が拒否されるデッドロックが発生した。スキルなしのエージェントにリポジトリ作成を依頼する実験では、`gh repo create` / `gh repo edit` / ruleset API の直叩きで IaC を迂回する計画を立てた(観察の逐語とテスト記録は [#1393](https://github.com/nozomiishii/dotfiles/issues/1393))。
+
+## Decision — 決めたこと
+
+- 新しいリポジトリ作成のフローの正本を new-repo スキルに置く
+- 役割分担: リポジトリの作成・設定・保護は nozomiishii/infra の `locals.repositories`、ローカル登録は nozomiishii/workspaces の `projects.json`、足場は configs 一式 + nozomiishii/workflows を呼ぶ標準 workflow
+- GitHub を直接操作する作成・設定変更(`gh repo create` / `gh repo edit` / ruleset API)は禁止として明文化する
+- ブートストラップは `auto_init` 前提(判断は [infra の ADR](https://github.com/nozomiishii/infra/blob/main/docs/decisions/リポジトリ作成時に%20auto_init%20で%20initial%20commit%20を作る.md))
+- `@nozomiishii/cspell-config` と `@nozomiishii/markdownlint-cli2-config` は非推奨のため新規リポジトリに導入しない
+
+## Consequences — 決定がもたらすもの
+
+- 以後の新規リポジトリはスキル経由で作り、フローが変わったらスキルを更新する。判断が変わったら新しい ADR を書く
+- スキル本文は観察された失敗にだけ対処する最小構成を保ち、テスト(読者テスト・圧力テスト)を経ずに編集しない

--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # /new-repo
 
-リポジトリの作成・設定・保護の正本は nozomiishii/infra の `stacks/github/main.tf`。GitHub を直接操作して作らない。設計の経緯は [dotfiles#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。
+リポジトリの作成・設定・保護の正本は nozomiishii/infra の `stacks/github/main.tf`。GitHub を直接操作して作らない。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/新しいリポジトリ作成のフローは%20new-repo%20スキルを正本にする.md)、テスト記録は [dotfiles#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。
 
 ## 禁止
 
@@ -26,10 +26,10 @@ description: >-
 
 ## 足場 (最初の PR)
 
-clone して次を揃え、1 つの PR にする。完成形の実例は nozomiishii/design#1。
+clone して次を揃え、1 つの PR にする。完成形の実例は直近に作られたリポジトリの足場 PR を参照する (2026-07 時点は [nozomiishii/design#1](https://github.com/nozomiishii/design/pull/1))。
 
 - configs 一式: `@nozomiishii/commitlint-config` `eslint-config` `lefthook-config` `postinstall` `prettier-config` `tsconfig` と各設定ファイル。`cspell-config` と `markdownlint-cli2-config` は非推奨のため導入しない。
-- 標準 workflow: `_pull-request.yaml` `_github-actions.yaml` `_secret-scan.yaml` を configs からコピーする。main の必須チェックが要求するため、無いと PR をマージできない。
+- 標準 workflow: `_pull-request.yaml` `_github-actions.yaml` `_secret-scan.yaml` を configs からコピーする。実体は [nozomiishii/workflows](https://github.com/nozomiishii/workflows) の reusable workflow を SHA pin で呼ぶ薄い caller。main の必須チェックが要求するため、無いと PR をマージできない。
 - `.github/renovate.json`: `{ "extends": ["github>nozomiishii/renovate"] }`
 - SessionStart hook: `.claude/settings.json` と `.hooks/setup.sh` (`pnpm install`)。
 - README.md と README.ja.md を同じ構成で作る。

--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: new-repo
+description: >-
+  新しいリポジトリを作るフローの正本。
+  Claude Code で /new-repo、Codex で $new-repo と入力したとき、
+  または「新しいリポジトリを作りたい」「リポジトリを切り出したい」と言ったとき、
+  または nozomiishii 配下に新しいリポジトリを作る作業を始める前に使用する。
+---
+
+# /new-repo
+
+リポジトリの作成・設定・保護の正本は nozomiishii/infra の `stacks/github/main.tf`。GitHub を直接操作して作らない。設計の経緯は [dotfiles#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。
+
+## 禁止
+
+- `gh repo create`、`gh repo edit`、ruleset API による作成・設定変更。既存 repo の設定を `gh repo view` や API で観察して手動複製するのも同じ扱い。
+  - 「既存 repo と同じ設定を gh で再現すれば結果は同じ」→ 同じに見えるだけで tfstate と HCL に存在しない。以後の plan に現れず、管理から外れ続ける。
+  - 「ruleset を最後に付ければ main への初回 push が通る」→ 順序の工夫は不要。`auto_init = true` が作成時に initial commit を作るので、main は最初から存在し保護も同時に付く。
+
+## リポジトリ作成 (infra)
+
+- `stacks/github/main.tf` の `locals.repositories` にエントリを追加して PR を作る。visibility と description をここで決める。visibility はユーザーに確認する。公開なら GitHub Actions が無料になる。
+- plan / apply は infra の AGENTS.md の実行境界に従う。apply はユーザーが行う。
+- initial commit は auto_init が作る。メッセージは "Initial commit" 固定で Conventional Commits 外だが、release-please は非準拠コミットを無視するため実害はない。気になる場合は release-please の `bootstrap-sha` で収集範囲から外せる。
+- repo 固有の CI を必須チェックにする場合、workflow に集約 `required` job を作り、infra 側の `required_status_checks` に `<workflow> / required` で登録する。正本は infra の docs/required_status_checksの命名と最小構成.md。共通の必須チェック 3 つと GitGuardian はモジュールが自動で付ける。
+
+## 足場 (最初の PR)
+
+clone して次を揃え、1 つの PR にする。完成形の実例は nozomiishii/design#1。
+
+- configs 一式: `@nozomiishii/commitlint-config` `eslint-config` `lefthook-config` `postinstall` `prettier-config` `tsconfig` と各設定ファイル。`cspell-config` と `markdownlint-cli2-config` は非推奨のため導入しない。
+- 標準 workflow: `_pull-request.yaml` `_github-actions.yaml` `_secret-scan.yaml` を configs からコピーする。main の必須チェックが要求するため、無いと PR をマージできない。
+- `.github/renovate.json`: `{ "extends": ["github>nozomiishii/renovate"] }`
+- SessionStart hook: `.claude/settings.json` と `.hooks/setup.sh` (`pnpm install`)。
+- README.md と README.ja.md を同じ構成で作る。
+
+## 登録 (workspaces)
+
+- nozomiishii/workspaces の `projects.json` にエントリを追加する PR を作る。別 repo の変更なので /wt の切り出しに従う。
+
+## リリースフロー
+
+- npm 配布するリポジトリは configs と同型の release-please 構成 (`.github/.release-please-config.json` + release.yaml) を後続 PR で入れる。

--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -24,9 +24,9 @@ description: >-
 - initial commit は auto_init が作る。メッセージは "Initial commit" 固定で Conventional Commits 外だが、release-please は非準拠コミットを無視するため実害はない。気になる場合は release-please の `bootstrap-sha` で収集範囲から外せる。
 - repo 固有の CI を必須チェックにする場合、workflow に集約 `required` job を作り、infra 側の `required_status_checks` に `<workflow> / required` で登録する。正本は infra の docs/required_status_checksの命名と最小構成.md。共通の必須チェック 3 つと GitGuardian はモジュールが自動で付ける。
 
-## 足場 (最初の PR)
+## 初期セットアップ (最初の PR)
 
-clone して次を揃え、1 つの PR にする。完成形の実例は直近に作られたリポジトリの足場 PR を参照する (2026-07 時点は [nozomiishii/design#1](https://github.com/nozomiishii/design/pull/1))。
+clone して次を揃え、1 つの PR にする。完成形の実例は直近に作られたリポジトリの初期セットアップ PR を参照する (2026-07 時点は [nozomiishii/design#1](https://github.com/nozomiishii/design/pull/1))。
 
 - configs 一式: `@nozomiishii/commitlint-config` `eslint-config` `lefthook-config` `postinstall` `prettier-config` `tsconfig` と各設定ファイル。`cspell-config` と `markdownlint-cli2-config` は非推奨のため導入しない。
 - 標準 workflow: `_pull-request.yaml` `_github-actions.yaml` `_secret-scan.yaml` を configs からコピーする。実体は [nozomiishii/workflows](https://github.com/nozomiishii/workflows) の reusable workflow を SHA pin で呼ぶ薄い caller。main の必須チェックが要求するため、無いと PR をマージできない。


### PR DESCRIPTION
## 概要

新しいリポジトリを作るフローの正本として new-repo スキルを追加します。設計の判断は同梱の `docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md`(dotfiles 初の ADR)、テスト記録は [#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。

Closes #1393

## テスト記録

### シナリオ

「nozomiishii/metronome という新しいリポジトリを作り、開発を始められる状態にする」を、実行前に計画を全て書き出して止まる形式で subagent に依頼(テストとは明かさない)。

### RED(スキルなし)

- リポジトリ作成 `gh repo create nozomiishii/metronome --private --source . --push`、設定 `gh repo edit`、ルールセット `gh api -X POST repos/.../rulesets` の直叩き計画。infra の IaC に気づかず、dance の設定を API 観察して手動複製
- 逐語:「ruleset は最後。先に入れると main への直 push が弾かれるため」(デッドロックの順序回避)
- README.md / README.ja.md が計画に無い
- 合格していた部分(スキルでは確認リスト化のみ): 標準 workflow 3本、renovate.json、SessionStart hook、workspaces 登録の認識

### GREEN(対処)

観察された失敗だけに対応: infra の `locals.repositories` を正本とする禁止と逐語への反論(「後で import すれば同じ」「ruleset を最後に付ければ通る」)、auto_init 前提のブートストラップ、README 両言語。ユーザー指定事項として cspell-config / markdownlint-cli2-config の非導入を明記。

### REFACTOR(読者テスト)

同一タスク + 作業コピーの SKILL.md。読み込み元のフルパスを報告させ、作業コピーであることを確認済み。結果: infra への PR + ユーザー apply に計画が変わり、`gh repo create` 系は「一切使いません」と明言。auto_init 前提、design#1 を実例参照した初期セットアップ、非推奨2パッケージ除外、README 両言語、workspaces 登録、visibility のユーザー確認まで全基準を満たした。新しい抜け穴なし。

### 編集後の再テスト

レビュー対応(ADR 分離・workflows 言及・直近実例方式)の編集後、同一タスクで読者再テストを実施。IaC 経由・禁止事項の維持・「初期セットアップは直近実例 (design#1) と同型」の解釈を確認し合格。

### 圧力テスト(規律を課すスキルのため)

時間圧(15分後のデモ)+ 既成事実(昔はいつも gh で作ってた)+ 正当化(Terraform は後で import すれば同じ)の3圧力を重ねたシナリオで再テスト。結果: 禁止を維持し、スキルの反論を引いて拒否。「緊急時の例外は定義されていない」と述べ、最短の準拠ルート(infra PR は数分、クリティカルパスは PR 作成 → ユーザー apply)を代替提示した。合格。

## 最終検証(Claude Code / Codex)

公式ドキュメントの取得日時: 2026-07-24(本 PR 作成と同日)

| 観点 | Claude Code | Codex |
| --- | --- | --- |
| 配置 | `~/.claude/skills/<name>/SKILL.md`(symlink 経由で本 repo の home/.agents/skills を参照)— 静的合格 | `$HOME/.agents/skills` を直接読む — 静的合格 |
| frontmatter | description が自動発動を制御、ディレクトリ名がコマンド名 — 静的合格 | name / description 必須 — 本スキルは両方あり、静的合格 |
| 呼び出し | `/new-repo` 明示 + description 合致で自動 — 静的合格 | `$new-repo` 明示 + 自動発動 — 静的合格 |
| 本文の互換性 | shell / git / gh のみ使用、/wt 参照は両ホストに存在 — 該当なし(ホスト固有機能なし) | 同左 |
| 読者テスト | 作業コピーで実動合格(subagent が読了・準拠) | 実動未確認 |

根拠: [Claude Code skills docs](https://code.claude.com/docs/en/skills)、[Codex build-skills docs](https://learn.chatgpt.com/docs/build-skills)(developers.openai.com/codex/skills からの 308 リダイレクト先)。

判定: 静的同等・Codex は実動未確認。Claude Code 側もインストール済み状態での skill selector 経由の発動は未検証(マージ後に確認可能)。

## 関連

- [nozomiishii/infra#138](https://github.com/nozomiishii/infra/pull/138) auto_init の導入(マージ済み)
- [nozomiishii/infra#139](https://github.com/nozomiishii/infra/pull/139) auto_init 判断の ADR
- [nozomiishii/design#1](https://github.com/nozomiishii/design/pull/1) スキルが実例として参照する初期セットアップ PR
