### PR TITLE
fix: cloud-bump heads-up at PR creation and description fallback

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   環境スナップショットの再構築を発火させる。
   Claude Code で /cloud-bump、Codex で $cloud-bump と入力したとき、または dotfiles の main にマージした変更が
   cloud 配信対象 (cloud-setup.yaml の paths) に触れていたときに使用する。
+  dotfiles を変更する PR を作成するときも、マージ後の bump の要否判定と予告のために使用する。
 model: sonnet
 allowed-tools: mcp__claude-in-chrome__javascript_tool
 ---
@@ -15,9 +16,11 @@ cloud 環境の setup script は毎セッション走らない。環境スナッ
 
 ## 発火の判定
 
-対象は main にマージ済みの変更だけ。マージ前に bump すると古い main でスナップショットが焼き直されるだけになる。
+判定リストの正本は `.github/workflows/cloud-setup.yaml` の `paths`。スキルに書き写さず、workflow ファイルを読んで diff と突き合わせる。触れていなければ bump 不要と伝えて終わる。
 
-判定リストの正本は `.github/workflows/cloud-setup.yaml` の `paths`。スキルに書き写さず、workflow ファイルを読んで merge diff と突き合わせる。触れていなければ bump 不要と伝えて終わる。
+bump してよいのは main にマージ済みの変更だけ。マージ前に bump すると古い main でスナップショットが焼き直されるだけになる。
+
+cloud 配信対象に触れる PR を作成した時点では bump せず、マージ後に /cloud-bump の実行が必要なことを PR 作成の報告に書いて予告する。マージ後の bump は忘れられやすく、予告がないとユーザーはセッションを閉じてから気づけない。
 
 ## 権限
 
@@ -131,7 +134,7 @@ if (stripBump(updatedInit) !== stripBump(originalInit)) {
 
 const updated = {
   name: env.name,
-  description: env.description,
+  description: env.description ?? '',
   config: { ...env.config, init_script: updatedInit }
 };
 assertClaudeContext();
@@ -149,7 +152,7 @@ const after = await verifyResp.json();
 const beforeRest = { ...env.config }; delete beforeRest.init_script;
 const afterRest = { ...after.config }; delete afterRest.init_script;
 if (after.config.init_script !== updatedInit ||
-    after.name !== env.name || after.description !== env.description ||
+    after.name !== env.name || (after.description ?? '') !== (env.description ?? '') ||
     JSON.stringify(afterRest) !== JSON.stringify(beforeRest)) {
   throw new Error('POST verification mismatch');
 }
@@ -186,7 +189,7 @@ UI の「Setup script」は `config.init_script`、「Environment variables」�
 
 ### POST リクエストの必須フィールド
 
-`name`, `description`, `config` が必要。`description` を含む GET の既存値をそのまま返し、空文字列で上書きしない。
+`name`, `description`, `config` が必要。`description` は GET に既存値があればそのまま返し、既存の説明文を空文字列で上書きしない。GET に `description` が無い環境では空文字列で補う。実測では undefined は JSON.stringify で field ごと脱落して 400 (`description: Field required`)、null も 400、空文字列は成功する。
 
 ## エンドポイントの再発見
 


### PR DESCRIPTION
## 概要

/cloud-bump スキルの実運用で観察された 2 つの失敗に対処する。

- 予告タイミングの前倒し: 現行は main マージ後にしか発火せず、マージ後の実行が忘れられかけた (セッションをアーカイブする直前だった)。cloud 配信対象に触れる PR を作成した時点で「マージ後に /cloud-bump が必要」と予告する挙動を description と本文に追加する。bump 自体はマージ後のまま変えない。
- description 欠落環境の 400 修正: GET レスポンスに `description` フィールドが無い環境 (実測: env_01WMd5p6g3WNpLFuG5sENKLE) では、POST スクリプトの `description: env.description` が undefined になり JSON.stringify で field ごと脱落し、API が 400 `description: Field required` を返す。実測で `null` も 400、空文字列は成功 (送った空文字は永続化されず GET には現れない)。スクリプトを `env.description ?? ''` に直し、検証 GET の比較も `?? ''` で正規化し、「空文字列で上書きしない」の注記を「既存値があればそのまま、無ければ空文字で補う」に調整する。

## テスト記録 (/skill)

### RED (現行版での失敗再現)

- PR 作成時の予告: 現行版の作業コピーを含む模擬 dotfiles repo で、cloud 配信対象 (`home/.agents/skills/q/SKILL.md`) に触れる PR 作成タスクを subagent に依頼。報告の「この後やること」は push と PR 作成のコマンドのみで、/cloud-bump への言及なし。実運用の「忘れ」がそのまま再現。
- description 脱落: 現行版承認後スクリプトのロジックを Node 22 で fixture 実行し、POST body に `description` キーが含まれないことを確認 (`'description' in JSON.parse(body)` が false)。
- 400 対処: 現行版を読んだ subagent は原因分析はできたが、「`""` 埋めでの再送はスキル本文の記述を超える対処になるため、API 経由の再送か手動フォールバックかの選択はユーザー判断になります」と自走できず停止。「空文字列で上書きしない」が障害であることを逐語で確認。

### GREEN

- description に PR 作成時の発火条件と用途 (マージ後の bump の要否判定と予告) を追加
- 「発火の判定」に PR 作成時は bump せず予告する規則を追加
- `description: env.description ?? ''`、検証比較を `(after.description ?? '') !== (env.description ?? '')` に変更
- 「POST リクエストの必須フィールド」を「既存値があればそのまま返し、無ければ空文字列で補う」に変更し、実測 (undefined 脱落 400 / null 400 / 空文字成功) を記載

### REFACTOR (新版での読者テスト)

- Claude Code subagent (PR 作成タスク): cloud-bump 本文と cloud-setup.yaml を突き合わせて配信対象と判定し、PR 本文に「マージ後の作業: /cloud-bump が必要」を記載、報告でも予告。マージ前 bump なし。description の 3 文言 (v1〜v3) すべてで合格。
- Claude Code subagent (400 シナリオ): 新版の必須フィールド節を逐語引用して `"description": ""` での再送を自走提案。「矛盾はありません」と明言し、RED のユーザー差し戻しが解消。
- 機械的検証: 新版ロジックで body に `"description": ""` が含まれ、検証比較は description 非永続化環境 (実測) と永続化環境の双方で偽陽性なし。

### 最終検証 (両ホスト)

公式情報 (いずれも本セッション 2026-07-24〜25 (UTC) に取得):

- [Claude Code skills](https://code.claude.com/docs/en/skills.md): description は「Claude uses this to decide when to apply the skill」。listing は description + when_to_use で 1,536 文字 truncate。
- [Codex skills](https://developers.openai.com/codex/skills) (→ learn.chatgpt.com/docs/build-skills): 「implicit matching depends on `description`」、検索パスは `$CWD/.agents/skills` / `$REPO_ROOT/.agents/skills` / `$HOME/.agents/skills` / `/etc/codex/skills` (dotfiles の stow 先 `~/.agents/skills` と一致)、明示呼び出しは `$skill-name`。
- [Agent Skills specification](https://agentskills.io/specification): description 必須・1〜1024 文字。新 description は約 230 文字で適合。

surface 別の結果:

- Claude Code local (このホスト、subagent): 実動合格。予告 (模擬 skill listing 経由)・400 対処・マージ前 bump 抑止を確認。
- Codex CLI 0.145.0 (gpt-5.6-sol、このホスト): 本文解釈は実動合格 (400 シナリオで新版の記述を根拠に空文字再送を提案。読み込み元は作業コピーの canonical path であることをログで確認)。skill listing への新版登録と `$cloud-bump` の解決先も read-only で実動確認。PR 作成時の暗黙発火のみ実動不合格 (下記)。
- Claude Code cloud: 静的合格 (実動未確認)。配信物は同一ファイルで、発火・予告のメカニズムは local と同じ。

### 残論点: Codex の暗黙発火

Codex CLI では、PR 作成タスクからの cloud-bump の暗黙発火が description の 3 文言 (v1: cloud 配信対象に触れる PR / v2: dotfiles を変更する PR / v3: 用途明示) すべてで実動不合格だった。同じセッションで live の skill スキル (「SKILL.md を変更する前に使用する」) には毎回発火しており、implicit matching 自体は動作している。タスクの中心対象を名指しする description には発火し、完了時のフォローアップ用途には発火しにくい実装傾向とみられる。/skill の規律 (3 回で設計を疑う) に従い、description の追加調整は行わず既知の制約として記録する。Codex では `$cloud-bump` 明示呼び出しとマージ後の既存発火条件は機能する。

## マージ後の作業

この PR は cloud 配信対象 (`home/.agents/skills/**`) に触れる。マージ後に /cloud-bump の実行が必要。
