### PR TITLE
fix: require frequency prefix in routine names

### DIFF
--- a/home/.agents/skills/routine/SKILL.md
+++ b/home/.agents/skills/routine/SKILL.md
@@ -54,6 +54,10 @@ ls "$BRAIN/.routines/"
 
 routine name は `^[a-z0-9]+(?:-[a-z0-9]+)*$` に一致する値だけを受け付ける。file path、branch、title に入れる前に検証し、slash、`..`、空白、shell metacharacter を含む値は拒否する。
 
+name は `<頻度>-<対象>` の形にする。頻度語は schedule の発火間隔から選ぶ。daily, weekly, biweekly, monthly, quarterly, biannual。
+
+頻度は省かない。当てはまる語が無い、既存語と紛らわしいと感じたときも、最も近い語を選ぶ。平日のみの毎日は daily、隔週は biweekly。既存 routine の name がこの形でない場合も、新しい name はこの形にする。
+
 #### 目的のすり合わせ
 
 - この routine で何を達成したいか

--- a/home/.agents/skills/routine/SKILL.md
+++ b/home/.agents/skills/routine/SKILL.md
@@ -54,7 +54,7 @@ ls "$BRAIN/.routines/"
 
 routine name は `^[a-z0-9]+(?:-[a-z0-9]+)*$` に一致する値だけを受け付ける。file path、branch、title に入れる前に検証し、slash、`..`、空白、shell metacharacter を含む値は拒否する。
 
-name は `<頻度>-<対象>` の形にする。頻度語は schedule の発火間隔から選ぶ。daily, weekly, biweekly, monthly, quarterly, biannual。
+name とファイル名を `<頻度>-<対象>` の形に揃える。頻度語は schedule の発火間隔から選ぶ。daily, weekly, biweekly, monthly, quarterly, biannual。
 
 頻度は省かない。当てはまる語が無い、既存語と紛らわしいと感じたときも、最も近い語を選ぶ。平日のみの毎日は daily、隔週は biweekly。既存 routine の name がこの形でない場合も、新しい name はこの形にする。
 


### PR DESCRIPTION
## 背景

nozomiishii/brain の `.routines/` 18 件のうち 2 件 (`config-staleness-audit`, `pnpm-oom-issue-tracker`) が頻度 prefix なしの name になっていた。どちらも週次。ファイル側のリネームは nozomiishii/brain#361 で対応する。

規則がスキルに書かれておらず、既存ファイルの例示だけが命名の根拠になっていた。

## 変更

`home/.agents/skills/routine/SKILL.md` の「ユーザーと対話して routine を設計する」に 2 段落追加した。

```
name とファイル名を `<頻度>-<対象>` の形に揃える。頻度語は schedule の発火間隔から選ぶ。daily, weekly, biweekly, monthly, quarterly, biannual。

頻度は省かない。当てはまる語が無い、既存語と紛らわしいと感じたときも、最も近い語を選ぶ。平日のみの毎日は daily、隔週は biweekly。既存 routine の name がこの形でない場合も、新しい name はこの形にする。
```

## テスト記録

### 環境

現行スキル一式と `origin/main` 時点の `.routines/` を一時ディレクトリへ複製し、agent ごとに brain fixture を隔離した。RED 用コピーは installed 版と byte 一致を確認済みで、読み込み元が混ざっても結果は変わらない。GREEN 用コピーは installed 版と差分があるため、追加した規則の逐語引用を作業コピーを読んだ証拠として使った。

### RED 1 回目: 再現せず

コーパスに前例のある頻度で 3 件依頼したところ、全件が prefix 付きになった。

| シナリオ | 選ばれた name |
|---|---|
| 週次 (木) renovate release notes | `weekly-renovate-release-notes` |
| 週次 (火) Tailwind CSS 追跡 | `weekly-tailwind-news` |
| 月次 Raycast extension | `monthly-raycast-extension-news` |

2 件が「既存の週次 routine に揃えた」と明言。既存 18 件中 16 件が prefix 付きのため、コーパスが規約を教えていた。

### RED 2 回目: 再現

コーパスに前例のない頻度で再試行し、agent ごとに fixture を分けた。

| シナリオ | 選ばれた name | 判定 |
|---|---|---|
| 四半期 サブスク料金棚卸し | `quarterly-subscription-pricing-audit` | prefix あり |
| 隔週 Terraform provider 点検 | `biweekly-terraform-provider-audit` | prefix あり |
| 平日毎朝 Renovate PR の CI 失敗 | `renovate-ci-failure-audit` | prefix なし |

失敗した理由の逐語:

> 同じ nozomiishii/renovate を対象にする既存 routine (`pnpm-oom-issue-tracker`) がトピック先頭の命名なので、それに合わせた

> 頻度プレフィックス案 (`weekday-`) は既存の `weekly-` と 1 文字違いで取り違えやすいため避けた

観測できた失敗は 2 種類。頻度なしの既存 routine に倣うことと、当てはまる語が無い・紛らわしいと感じたときに意図的に省くこと。後者は「わかっていて飛ばす」型なので、禁止と言い訳への反論の形で書いた。

### REFACTOR 1 回目

失敗した平日毎朝のタスクを修正版スキルで再実行した。

| シナリオ | 結果 |
|---|---|
| RED と同一タスク | `daily-renovate-ci-failures`。追加した 2 段落を逐語引用 |
| 同タスク + 時間・サンクコスト・権威の 3 圧力 | ユーザー指定の `renovate-ci-failure-audit` を採用しつつ、規約違反であることと本来の `daily-renovate-ci-failure` を明示 |

圧力シナリオでは、ユーザーが明示指定した name に従いながら規約との食い違いを表面化させた。黙って落としていないので合格とした。

### ファイル名の扱い: RED 再現せず

追加した文が `name` しか指しておらず、ファイル名に及ぶかが読み取りにくかったため、変更・リネーム経路で RED を取った。過去に壊れた `monthly-insights-reminder` と同じ経路。

| シナリオ | ファイル名 | frontmatter name | 一致 |
|---|---|---|---|
| 月次 → 週次に変更 | `weekly-orbstack-landscape.md` | `weekly-orbstack-landscape` | 一致 |
| 対象変更で改名 | `weekly-superwhisper-watch.md` | `weekly-superwhisper-watch` | 一致 |
| 3 圧力でファイル名据え置きを強制 | 据え置き | 据え置き | 一致 |

3 件とも崩れず、非圧力の 2 件は既存記述「routine prompt の正本は `nozomiishii/brain` repo の `.routines/<name>.md`」を逐語引用して根拠にしていた。3 件目は ``name`` が trigger の読むパスそのものであることを理由に、ファイル名据え置きなら `name` も動かせないと判断した。

新しい規則を足す根拠にはならないため、独立した一文は追加せず、既に追加した文を `name とファイル名を〜揃える` に直して曖昧さだけ消した。

### REFACTOR 2 回目

文言を変えたので再検証した。

| シナリオ | ファイル名 | frontmatter name |
|---|---|---|
| 新規作成 (平日毎朝) | `daily-renovate-ci-failures.md` | `daily-renovate-ci-failures` |
| 月次 → 週次に変更 | `weekly-orbstack-landscape.md` | `weekly-orbstack-landscape` |

両方とも新しい文言を逐語引用した。

### 最終検証: Claude Code と Codex

対象 surface は Claude Code local と Codex CLI。今回の変更は本文の散文追加のみで、frontmatter、ホスト別 metadata、引数展開、ツール、scripts / references / assets のいずれも使っていない。検証が要るのは「同じ入力に対する成果物 (選ばれる name とファイル名)」の 1 項目。

公式ドキュメント (2026-07-26 取得):

- https://code.claude.com/docs/en/skills — Claude Code の skill は Agent Skills 標準に従い、本文は使用時に読み込まれる。Claude Code 固有の拡張は invocation control、subagent execution、dynamic context injection で、いずれも今回の変更は使っていない
- https://agentskills.io — SKILL.md は frontmatter と本文の指示。progressive disclosure で活性化時に本文全体を読み込む
- https://learn.chatgpt.com/docs/build-skills — Codex も SKILL.md 形式に対応。frontmatter 直下の散文がワークフローを導く。Codex 固有の任意 metadata は `agents/openai.yaml` で、今回は使っていない

実動結果:

| 項目 | Claude Code local | Codex CLI 0.145.0 |
|---|---|---|
| 新規作成で選ばれる name | 実動合格。`daily-renovate-ci-failures` | 実動合格。`daily-renovate-ci-failures` |
| 頻度変更でのファイル名と name | 実動合格。`weekly-orbstack-landscape` | 実動合格。`weekly-orbstack-landscape` |
| 追加した規則の逐語引用 | あり | あり |
| frontmatter / metadata / 引数展開 | 該当なし | 該当なし |
| ツール / 権限 / 承認 | 該当なし | 該当なし |
| scripts / references / assets | 該当なし | 該当なし |

両ホストで同一の name とファイル名を選び、根拠として追加した文を逐語引用した。ホスト固有の語や手順を共通手順として要求していないことも確認済み。両ホスト実動同等。
