### PR TITLE
fix: support github connector fallback

### DIFF
--- a/home/.agents/skills/tha/SKILL.md
+++ b/home/.agents/skills/tha/SKILL.md
@@ -11,6 +11,12 @@ model: sonnet
 
 `git status --short` と `git diff` で変更内容を把握し、以下を順番に実行する:
 
+## GitHub へのアクセス
+
+ブランチ判定での PR 検索、既存 PR の状態・head 情報の取得、新規 PR 作成、draft 判定、pr skill への引き継ぎ後の状態取得に GitHub CLI を使う。GitHub CLI が未導入、未認証、または実行に失敗した場合は、利用可能な GitHub connector / app を自分で検索し、該当する capability を使う。connector の機能名は固定しない。このフォールバックのためだけに GitHub CLI の導入や再認証をユーザーへ求めない。
+
+connector が対象 PR に必要な head repository identity または write capability を返せない場合は、fork かを推測せず停止する。local branch の作成、stage、commit、push は引き続き git で行い、connector に置き換えない。
+
 ## ブランチ判定
 
 現在のブランチを確認する:
@@ -32,10 +38,10 @@ base または head が外部 repo、もしくは所有者を判定できない�
 
 ## PR 作成（必要な場合のみ）
 
-既存の OPEN な PR がない場合、PR を作成する。
+既存の OPEN な PR がない場合、PR を作成する。GitHub CLI で作成できなければ「GitHub へのアクセス」の connector fallback を使う。
 
 ## PR の監視（pr skill へ引き継ぐ）
 
-PR 作成 / push 完了後、sibling の [pr SKILL.md](../pr/SKILL.md) を明示的に読み、その手順で CI 失敗・レビュー指摘・main との conflict を修復して mergeable まで持っていく。pr skill は explicit-only のため、catalog から暗黙に選ばせない。
+PR 作成 / push 完了後、sibling の [pr SKILL.md](../pr/SKILL.md) を明示的に読み、その手順で CI 失敗・レビュー指摘・main との conflict を修復して mergeable まで持っていく。GitHub CLI から connector へ fallback した場合は、PR 番号または URL と利用中の connector を引き継ぎ、pr skill の「gh CLI が無い環境」と同じ connector 手順を使う。pr skill は explicit-only のため、catalog から暗黙に選ばせない。
 
-ただし PR が draft の場合（`gh pr view --json isDraft` が `true`）はスキップする。draft は修正途中である前提なので、CI の失敗を勝手に直さない。
+ただし GitHub CLI または connector が返す PR metadata で draft の場合はスキップする。draft は修正途中である前提なので、CI の失敗を勝手に直さない。


### PR DESCRIPTION
## 概要

現行 `main` では `ta` が `tha` に改名済みのため、正本の `home/.agents/skills/tha/SKILL.md` を更新しました。

- GitHub CLI が未導入・未認証・実行失敗した場合、利用可能な GitHub connector / app を自分で検索して使う
- PR 検索、既存 PR の状態・head 情報、新規 PR 作成、draft 判定、`pr` skill 引き継ぎ後の状態取得を fallback 対象にする
- connector の機能名を固定せず、必要な head repository identity / write capability を返せなければ推測せず停止する
- local branch 作成、stage、commit、push はローカル git のまま維持する
- 既存の fork 安全策と外部 repo の `oss` ゲートを維持する

## 背景

GitHub CLI の token が無効でも、GitHub connector では PR 情報取得・PR 作成・metadata・CI status・review threads の取得が可能でした。GitHub CLI の再認証を要求するだけで停止せず、利用可能な connector へ fallback できるようにします。

## TDD 記録

### RED

- 現行 skill を `/private/tmp/tha-red.1dxAT5/SKILL.md` へコピー
- 本番と一時コピーの SHA-256 が一致することを親側で確認
- Claude Code `2.1.215`、Sonnet、`--safe-mode`、Read tool のみで reader test を実施
- stream trace の Read 対象は一時コピー 1 件だけで、本番 skills は未参照
- 誘導が強すぎた初回シナリオは baseline として無効化
- 非誘導シナリオで次の失敗を観察
  - 「GitHub connectorの利用可能なツール一覧を教えてください」
  - 「またはgh認証の再設定」
- connector の探索をユーザーへ転嫁し、再認証を代替案にしたため RED

### REFACTOR

- 変更後の skill を `/private/tmp/tha-refactor.8kZgpD/SKILL.md` へコピー
- 本番と一時コピーの SHA-256 が一致することを親側で確認
- RED と同じ Claude Code reader / scenario で再実行
- stream trace の Read 対象は変更後の一時コピー 1 件だけ
- connector を自分で探索し、再認証を求めず、既存 PR 検索・新規 PR 作成・draft 判定・`pr` skill 引き継ぎへ継続
- head repository identity / write capability が不足する場合は推測せず停止
- REFACTOR 合格

## 互換性検証

公式情報の取得: 2026-07-27 02:20 JST

### 公式情報による静的確認

- [Agent Skills specification](https://agentskills.io/specification)
  - `SKILL.md`、`name`、`description`、skill root からの相対参照を確認
- [Claude Code skills](https://code.claude.com/docs/en/slash-commands)
  - `/skill-name`、`disable-model-invocation`、`model` frontmatter を確認
- [Claude Code feature loading](https://code.claude.com/docs/en/features-overview)
  - MCP tool name の先行読み込みと schema の遅延取得、tool search を確認
- [Codex manual](https://developers.openai.com/codex/codex-manual.md)
  - `.agents/skills`、`$skill-name`、connector / app の利用と承認モデルを確認
  - helper の結果は「local manual was already current」

今回の変更は Markdown body の手順追加のみで、共通 Agent Skills の必須 metadata とホスト別 frontmatter は変更していません。

### ホスト別

- Agent Skills 共通: 静的合格
  - `name: tha` は directory と一致、description は 90 文字、本文は 47 行、sibling 参照を確認
- Claude Code local `2.1.215`: 実動合格
  - 一時コピーだけを読む reader が期待する fallback と停止条件を実行
- Codex CLI `0.145.0`: 実動合格
  - 使い捨て `CODEX_HOME` と一時 git fixture で、一時コピーだけを読み、connector capability search、PR 検索、作成・metadata・`pr` 引き継ぎを正しく計画
  - read-only GitHub connector の PR 検索も実動確認
- Codex App 現在セッション: 実動合格
  - app version 文字列は current session の tool schema に露出なし
  - GitHub app の PR 検索、PR 作成、PR metadata、commit status、review threads capability の schema を確認

目的、入力、成果物、ユーザーの決定権、fork / external repo の安全策、connector capability 不足時の停止条件は両ホストで同等です。

## 検証

- `pnpm exec markdownlint-cli2 home/.agents/skills/tha/SKILL.md`: 0 issues
- `pnpm exec prettier --ignore-unknown --check home/.agents/skills/tha/SKILL.md`: pass
- `pnpm test`: pass (`node v24.18.0`)
- `git diff --check`: pass
- pre-commit `lint-docs`: pass
- commitlint: pass
- pre-push `check-pr-not-merged`: pass
- repo 全体の `pnpm lint`: 既存 27 ファイル 173 件で failure
  - 今回の対象 `home/.agents/skills/tha/SKILL.md` は 0 issues
  - 無関係な既存問題は変更していません
