### PR TITLE
feat: add Linear desktop app

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -227,6 +227,9 @@ if OS.mac?
   # Collaborative interface design tool. https://www.figma.com
   cask "figma"
 
+  # Product development and issue tracking app https://linear.app/
+  cask "linear"
+
   # GIT client　https://fork.dev/
   cask "fork"
 


### PR DESCRIPTION
## 概要

- macOS 向け `Brewfile` に Linear デスクトップアプリの cask を追加
- `brew bundle` によるセットアップ対象へ Linear を追加

## 背景

開発環境のセットアップ時に Linear デスクトップアプリを自動で導入できるようにするためです。

## 影響

macOS で `Brewfile` を適用すると、Linear が `/Applications` にインストールされます。

## 検証

- `brew info --cask linear`
- `brew bundle list --cask --file=Brewfile`
- `brew install --cask linear`
- `ruby -c Brewfile`
- `pnpm prettier Brewfile --check`
- `git diff --check`
