### PR TITLE
fix: treat branch with no open pr as not-found in pr skill arg parsing

### DIFF
--- a/home/.agents/skills/pr/SKILL.md
+++ b/home/.agents/skills/pr/SKILL.md
@@ -62,7 +62,10 @@ elif [[ -z "$ARG" ]]; then
   OWNER=$(gh repo view --json owner --jq .owner.login)
   NAME=$(gh repo view --json name --jq .name)
   if git symbolic-ref -q HEAD >/dev/null; then
-    NUM=$(gh pr view --json number --jq .number)
+    if ! NUM=$(gh pr view --json number --jq .number); then
+      printf 'no open PR for branch %s\n' "$(git branch --show-current)" >&2
+      exit 1
+    fi
   else
     HEAD_SHA=$(git rev-parse HEAD)
     OPEN_PRS=$(gh api "repos/$OWNER/$NAME/commits/$HEAD_SHA/pulls" \
@@ -89,7 +92,7 @@ fi
 [[ "$NUM" =~ ^[1-9][0-9]*$ ]] || exit 2
 ```
 
-detached HEAD の commit に open PR が無い場合は PR 未検出として止まる。複数ある場合は候補 URL を列挙し、対象を 1 つだけユーザーに確認する。
+引数なしで open PR が見つからない場合は、branch 上でも detached HEAD でも PR 未検出として止まり、「PR の状態を確認」の PR 無し導線に従ってユーザーに案内する。detached HEAD で複数見つかる場合は候補 URL を列挙し、対象を 1 つだけユーザーに確認する。
 
 PR を特定したら `gh pr view --repo "$OWNER/$NAME" "$NUM" --json headRefName,baseRefName,headRepository,headRepositoryOwner` を 1 回実行し、`HEAD_REF`、`BASE_REF`、`HEAD_REPO_OWNER`、`HEAD_REPO_NAME` を取得する。branch 名は `git check-ref-format --branch`、head repo owner / name は「引数の解釈」と同じ allowlist で検証し、失敗したら fetch・checkout・rebase より前に停止する。URL / owner#N の target を cwd repo に解決しない。head repo が base repo と同じなら、target worktree の検証後に `PUSH_REMOTE_URL=$(git remote get-url origin)` を使う。fork では `gh config get git_protocol -h github.com` を確認し、`ssh` なら検証済みの owner / repo から `git@github.com:<head-owner>/<head-repo>.git`、それ以外は `https://github.com/<head-owner>/<head-repo>.git` を組み立てる。head repo が削除済み、または push 権限が無い場合は変更を始めずユーザーへ返す。
 


### PR DESCRIPTION
## 概要

pr スキルの「引数の解釈」bash コード例で、引数なし・branch 上・PR 無しのケースが「PR 未検出」にならず「不正入力」(exit 2) に化ける分岐バグを修正する。

現行コードでは `NUM=$(gh pr view --json number --jq .number)` が PR 無しで失敗して `NUM` が空になり、末尾の `[[ "$NUM" =~ ^[1-9][0-9]*$ ]] || exit 2` で終了する。detached HEAD の PR 0 件は exit 1 + 「PR 未検出として止まる」で扱われているのに、branch 上の PR 0 件だけが「PR の状態を確認」に定義された tha skill への案内導線に到達しない。

## 変更内容

- `gh pr view` の失敗を検出し、detached HEAD の 0 件と同じ「PR 未検出」(exit 1 + `no open PR for branch <name>`) として止まるようにした
- コード例直後の地の文を「引数なしで open PR が見つからない場合は、branch 上でも detached HEAD でも PR 未検出として止まり、『PR の状態を確認』の PR 無し導線に従ってユーザーに案内する」に更新した。案内文の正本は「PR の状態を確認」節のまま

## テスト記録 (ドキュメント TDD)

### RED: 現行版で失敗を再現

シナリオ: 引数なし・branch 上・open PR 無しの worktree でコード例を一括実行。

- branch 上 (PR 0 件): exit 2。stderr は gh の `no pull requests found for branch "claude/focused-davinci-573307"` のみで、スクリプト自身のメッセージ無し。exit 2 は文書上「invalid PR input」「multiple open PRs」の系統
- 対照 (detached HEAD・PR 0 件): exit 1 + `no open PR for ce324f26...`。文書の「PR 未検出として止まる」と整合
- 現行版の読者 subagent (Claude Code) はコード例を分解して個別実行したため `gh pr view` の exit 1 を直接観察でき、たまたま tha 導線に到達した。コード例を一括実行する読者は exit 2 になり導線に到達しない

### GREEN → REFACTOR: 読者テスト

修正版の作業コピーを一時ディレクトリに置き、両ホストの読者に「引数なし・branch 上・PR 無し」の同じ依頼を投げた。

- Claude Code (subagent): コード例一括実行で exit 1 + `no open PR for branch ...` → 追記した導線文 → 「PR の状態を確認」の案内文を結論として返答。tha skill は勝手に実行せず
- Codex CLI 0.145.0 (`codex exec`、一時 clone + workspace-write sandbox): 1 回目は exit 1 で正しく停止したが、tha 案内に到達せず「open PR はありません。ここで停止」とだけ報告。案内文が「PR の状態を確認」節にあり、PR 特定に失敗した読者はその節をスキップするため
- 対処: コード例直後の文に「『PR の状態を確認』の PR 無し導線に従ってユーザーに案内する」を追記し、両ホストで再テスト。どちらも tha skill への案内を含めて停止することを確認
- 両読者とも修正版にしか無い文言を引用しており、読み込み元が作業コピーであることを確認済み

リグレッション確認: URL 形式・`owner/repo#N`・数字は exit 0 で正しく解決、不正入力は exit 2、detached HEAD の 0 件は従来どおり exit 1。スニペットは shellcheck 通過。

### 最終検証: Claude Code / Codex 同等性

参照した公式ドキュメント (2026-07-27 取得):

- Agent Skills 仕様: <https://agentskills.io/specification> — 本文 Markdown はモデルへの指示で形式制限なし
- Claude Code skills: <https://code.claude.com/docs/en/skills> — Agent Skills open standard 準拠。本文はスキル発動時にロード、コードブロックの自動実行なし
- Codex skills: <https://developers.openai.com/codex/skills> (→ learn.chatgpt.com/docs/build-skills) — `$HOME/.agents/skills` から検出、本文はモデルへの指示、デフォルト instruction-only

今回の編集は bash コード例と地の文のみで、frontmatter・配置・scripts 参照・ホスト固有機能に触れない。使用コマンドは bash / gh / git でホスト非依存。

| 観点 | Claude Code local | Codex CLI 0.145.0 | Claude Code cloud / Codex App |
| --- | --- | --- | --- |
| コード例実行の停止条件 (exit 1) | 実動合格 | 実動合格 | 静的合格 (実動未確認) |
| PR 無し時の報告内容 (tha 案内) | 実動合格 | 実動合格 | 静的合格 (実動未確認) |
| frontmatter・配置・scripts 参照 | 変更なし | 変更なし | 変更なし |

## マージ後の作業

`home/.agents/**` は cloud-setup.yaml の paths に含まれるため、マージ後に /cloud-bump で cloud 環境スナップショットの再構築が必要。
