### PR TITLE
feat: add deterministic hooks for agents.md rules

### DIFF
--- a/.github/workflows/claude-hooks-test.yaml
+++ b/.github/workflows/claude-hooks-test.yaml
@@ -1,0 +1,31 @@
+name: Claude hooks test
+
+on:
+  pull_request:
+    paths:
+      - "home/.claude/hooks/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read # required by actions/checkout to fetch repository code
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run hook tests
+        run: for t in home/.claude/hooks/*.test.sh; do bash "$t" || exit 1; done

--- a/.github/workflows/cloud-setup.yaml
+++ b/.github/workflows/cloud-setup.yaml
@@ -41,6 +41,7 @@ jobs:
           tar czf _site/cloud-setup.tar.gz \
             home/AGENTS.md \
             home/.claude/settings.json \
+            home/.claude/hooks/ \
             home/.agents/skills/ \
             home/.codex/hooks.json
 

--- a/home/.claude/hooks/ask-one-question.sh
+++ b/home/.claude/hooks/ask-one-question.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# AGENTS.md「質問は1つずつする」の決定的ガード (PreToolUse / AskUserQuestion)。
+# questions が 2 件以上なら deny し、モデルに 1 問へ絞り直させる。
+# 1 質問内の選択肢 (options) が複数あるのは正常系なので見ない。
+# 判定不能・入力欠損は通す。
+input=$(cat)
+count=$(jq '.tool_input.questions // [] | length' <<<"$input" 2>/dev/null) || exit 0
+
+if [ "$count" -gt 1 ]; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny",
+    permissionDecisionReason: "質問は1つずつ (AGENTS.md)。最も重要な1問に絞って出し直し、残りは回答後に聞く。"}}'
+fi
+exit 0

--- a/home/.claude/hooks/ask-one-question.test.sh
+++ b/home/.claude/hooks/ask-one-question.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ask-one-question.sh のテスト。hook の JSON 入出力契約を検証する。
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="$script_dir/ask-one-question.sh"
+fails=0
+
+decision() { jq -r '.hookSpecificOutput.permissionDecision // "none"'; }
+
+# 2 問以上の AskUserQuestion は deny される
+test_denies_multiple_questions() {
+  out=$(printf '%s' '{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"a"},{"question":"b"}]}}' | bash "$hook")
+  [ "$(decision <<<"$out")" = "deny" ]
+}
+
+# 1 問なら出力なしで通過する
+test_allows_single_question() {
+  out=$(printf '%s' '{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"a"}]}}' | bash "$hook")
+  [ -z "$out" ]
+}
+
+# questions が無い入力は通過する (スキーマ変化への耐性)
+test_allows_missing_questions() {
+  out=$(printf '%s' '{"tool_name":"AskUserQuestion","tool_input":{}}' | bash "$hook")
+  [ -z "$out" ]
+}
+
+run() {
+  if "$1"; then echo "ok - $1"; else echo "not ok - $1"; fails=$((fails + 1)); fi
+}
+
+run test_denies_multiple_questions
+run test_allows_single_question
+run test_allows_missing_questions
+exit "$fails"

--- a/home/.claude/hooks/block-lint-suppression.sh
+++ b/home/.claude/hooks/block-lint-suppression.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# grep の「不一致 = exit 1」を制御フローに使うため -e は付けない
+set -uo pipefail
+
+# AGENTS.md「静的解析ルールの抑制禁止」の決定的ガード (PreToolUse / Edit|Write)。
+# 抑制コメントの出現数が編集前より増える場合だけ ask にする
+# (既存の抑制行の移動・周辺編集は増分ゼロなので発火しない)。
+# AGENTS.md は「どうしても必要なときは相談し、承認なしに抑制しない」としており、
+# ask のユーザー承認がその手続きに対応する。
+suppress_pattern='eslint-disable|@ts-ignore|@ts-expect-error|@ts-nocheck|biome-ignore|prettier-ignore|stylelint-disable|deno-lint-ignore|noqa|type:[[:space:]]*ignore([[:space:]]|\[|$)|nolint|nosec|rubocop:disable|pylint:[[:space:]]*disable|shellcheck[[:space:]]+disable|swiftlint:disable|pragma[[:space:]]+warning[[:space:]]+disable|istanbul[[:space:]]+ignore|c8[[:space:]]+ignore'
+
+input=$(cat)
+tool_name=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null) || exit 0
+file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input")
+
+# ドキュメント類は抑制パターンの「言及」が正当なので対象外
+case "$file_path" in
+*.md | *.mdx | *.markdown | *.txt) exit 0 ;;
+esac
+
+count_suppressions() {
+  grep -oiE "$suppress_pattern" <<<"${1:-}" | wc -l | tr -d ' '
+}
+
+case "$tool_name" in
+Edit)
+  new=$(jq -r '.tool_input.new_string // ""' <<<"$input")
+  old=$(jq -r '.tool_input.old_string // ""' <<<"$input")
+  ;;
+Write)
+  new=$(jq -r '.tool_input.content // ""' <<<"$input")
+  old=""
+  if [ -n "$file_path" ] && [ -f "$file_path" ]; then
+    old=$(cat "$file_path")
+  fi
+  ;;
+*) exit 0 ;;
+esac
+
+if [ "$(count_suppressions "$new")" -gt "$(count_suppressions "$old")" ]; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask",
+    permissionDecisionReason: "静的解析ルールの抑制は禁止 (AGENTS.md)。まずコードを直す。拒否された場合は抑制なしで直す方法を探し、どうしても必要なら理由を添えてユーザーに相談する。"}}'
+fi
+exit 0

--- a/home/.claude/hooks/block-lint-suppression.test.sh
+++ b/home/.claude/hooks/block-lint-suppression.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# block-lint-suppression.sh のテスト。hook の JSON 入出力契約を検証する。
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="$script_dir/block-lint-suppression.sh"
+fails=0
+
+decision() { jq -r '.hookSpecificOutput.permissionDecision // "none"'; }
+
+run_edit() {
+  jq -n --arg fp "$1" --arg old "$2" --arg new "$3" \
+    '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: $old, new_string: $new}}' \
+    | bash "$hook"
+}
+
+run_write() {
+  jq -n --arg fp "$1" --arg content "$2" \
+    '{tool_name: "Write", tool_input: {file_path: $fp, content: $content}}' \
+    | bash "$hook"
+}
+
+# Edit で抑制コメントを新規追加すると ask になる
+test_asks_on_new_suppression_in_edit() {
+  out=$(run_edit "/tmp/app.ts" "const a = 1;" "// eslint-disable-next-line no-console
+const a = 1;")
+  [ "$(decision <<<"$out")" = "ask" ]
+}
+
+# 既存の抑制行を含むコードの移動 (old にも同数) は通過する
+test_allows_moving_existing_suppression() {
+  out=$(run_edit "/tmp/app.ts" "// @ts-ignore
+const a = 1;" "const b = 2;
+// @ts-ignore
+const a = 1;")
+  [ -z "$out" ]
+}
+
+# Write で新規ファイルに抑制コメントを含めると ask になる
+test_asks_on_suppression_in_new_file() {
+  dir=$(mktemp -d)
+  out=$(run_write "$dir/new.py" "x = 1  # noqa: E501")
+  rm -rf "$dir"
+  [ "$(decision <<<"$out")" = "ask" ]
+}
+
+# Write の全文書き換えで既存の抑制を維持するだけなら通過する
+test_allows_rewrite_keeping_existing_suppression() {
+  dir=$(mktemp -d)
+  printf '%s\n' "// eslint-disable-next-line no-console" "console.log(1);" >"$dir/app.js"
+  out=$(run_write "$dir/app.js" "// eslint-disable-next-line no-console
+console.log(2);")
+  rm -rf "$dir"
+  [ -z "$out" ]
+}
+
+# ドキュメント (.md) での抑制パターンの言及は通過する
+test_allows_suppression_mention_in_markdown() {
+  out=$(run_edit "/tmp/AGENTS.md" "" "eslint-disable は禁止。")
+  [ -z "$out" ]
+}
+
+# type: ignoreCase のような前方一致は誤検知しない
+test_allows_type_ignore_case_prefix() {
+  out=$(run_edit "/tmp/config.ts" "" "const opts = { type: ignoreCase };")
+  [ -z "$out" ]
+}
+
+run() {
+  if "$1"; then echo "ok - $1"; else echo "not ok - $1"; fails=$((fails + 1)); fi
+}
+
+run test_asks_on_new_suppression_in_edit
+run test_allows_moving_existing_suppression
+run test_asks_on_suppression_in_new_file
+run test_allows_rewrite_keeping_existing_suppression
+run test_allows_suppression_mention_in_markdown
+run test_allows_type_ignore_case_prefix
+exit "$fails"

--- a/home/.claude/hooks/block-pr-merge.sh
+++ b/home/.claude/hooks/block-pr-merge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# PR マージ操作の決定的ガード (PreToolUse / Bash)。PR のマージはユーザーが行う。
+#
+# permissions.deny の "Bash(gh pr merge:*)" は先頭一致のため、
+# `cd x && gh pr merge` や `bash -c "gh pr merge"` のような複合・間接実行を
+# 防げない。この hook はコマンド文字列全体をスキャンして deny する。
+input=$(cat)
+cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+
+# 行頭・区切り記号・引用符の直後の gh pr merge (間接・複合実行を含む)
+gh_pr_merge="(^|[;&|[:space:]\`(\"'])gh[[:space:]]+pr[[:space:]]+merge([[:space:]\"']|\$)"
+# gh api の REST merge エンドポイント
+rest_merge="repos/[^[:space:]]+/pulls/[^[:space:]]+/merge"
+# graphql のマージ系 mutation (auto-merge 予約も勝手なマージに含める)
+graphql_merge="mergePullRequest|enablePullRequestAutoMerge"
+
+if grep -qE "$gh_pr_merge" <<<"$cmd" \
+  || grep -qE "$rest_merge" <<<"$cmd" \
+  || grep -qE "$graphql_merge" <<<"$cmd"; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny",
+    permissionDecisionReason: "PR のマージはユーザーが行う。マージはせず、PR の URL とマージ可能な状態を報告してユーザーに依頼する。"}}'
+fi
+exit 0

--- a/home/.claude/hooks/block-pr-merge.test.sh
+++ b/home/.claude/hooks/block-pr-merge.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# block-pr-merge.sh のテスト。hook の JSON 入出力契約を検証する。
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="$script_dir/block-pr-merge.sh"
+fails=0
+
+decision() { jq -r '.hookSpecificOutput.permissionDecision // "none"'; }
+
+run_hook() {
+  jq -n --arg cmd "$1" '{tool_name: "Bash", tool_input: {command: $cmd}}' | bash "$hook"
+}
+
+# gh pr merge の直接実行は deny される
+test_denies_gh_pr_merge() {
+  [ "$(run_hook 'gh pr merge 123' | decision)" = "deny" ]
+}
+
+# 複合コマンド内の gh pr merge も deny される
+test_denies_compound_command() {
+  [ "$(run_hook 'cd ~/Code/nozomiishii/dotfiles && gh pr merge 123 --squash' | decision)" = "deny" ]
+}
+
+# bash -c 経由の間接実行も deny される
+test_denies_indirect_execution() {
+  [ "$(run_hook 'bash -c "gh pr merge 123"' | decision)" = "deny" ]
+}
+
+# gh api の REST merge エンドポイントは deny される
+test_denies_rest_merge_endpoint() {
+  [ "$(run_hook 'gh api -X PUT repos/nozomiishii/dotfiles/pulls/123/merge' | decision)" = "deny" ]
+}
+
+# graphql の mergePullRequest mutation は deny される
+test_denies_graphql_merge_mutation() {
+  [ "$(run_hook 'gh api graphql -f query="mutation { mergePullRequest(input: {pullRequestId: \"x\"}) { clientMutationId } }"' | decision)" = "deny" ]
+}
+
+# graphql の auto-merge 有効化 (マージ予約) は deny される
+test_denies_graphql_auto_merge() {
+  [ "$(run_hook 'gh api graphql -f query="mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"x\"}) { clientMutationId } }"' | decision)" = "deny" ]
+}
+
+# gh pr view は通過する
+test_allows_gh_pr_view() {
+  out=$(run_hook 'gh pr view 123')
+  [ -z "$out" ]
+}
+
+# ローカルの git merge は通過する
+test_allows_git_merge() {
+  out=$(run_hook 'git merge main')
+  [ -z "$out" ]
+}
+
+# command が無い入力は通過する
+test_allows_missing_command() {
+  out=$(printf '%s' '{"tool_name":"Bash","tool_input":{}}' | bash "$hook")
+  [ -z "$out" ]
+}
+
+run() {
+  if "$1"; then echo "ok - $1"; else echo "not ok - $1"; fails=$((fails + 1)); fi
+}
+
+run test_denies_gh_pr_merge
+run test_denies_compound_command
+run test_denies_indirect_execution
+run test_denies_rest_merge_endpoint
+run test_denies_graphql_merge_mutation
+run test_denies_graphql_auto_merge
+run test_allows_gh_pr_view
+run test_allows_git_merge
+run test_allows_missing_command
+exit "$fails"

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -107,6 +107,40 @@
     "defaultMode": "auto"
   },
   "enabledMcpjsonServers": [],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/block-pr-merge.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/ask-one-question.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/block-lint-suppression.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
   "worktree": {
     "bgIsolation": "none"
   },

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -1,6 +1,6 @@
 # ~/.claude/settings.json リファレンス
 
-最終更新: 2026-07-17
+最終更新: 2026-07-28
 
 ## 背景
 
@@ -141,11 +141,32 @@ Auto mode の利用可能条件: Max / Team / Enterprise / API プラン + 対�
 
 ### hooks
 
-グローバルの hooks は定義しない（キー自体を置かない）。
+グローバルの hooks は AGENTS.md ルールの決定的ガードのみ置く。スクリプトの実体は `~/.claude/hooks/`（正本は `home/.claude/hooks/`、テストは同ディレクトリの `*.test.sh`）。
+
+```jsonc
+"hooks": {
+  "PreToolUse": [
+    { "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/block-pr-merge.sh", "timeout": 5 }] },
+    { "matcher": "AskUserQuestion", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/ask-one-question.sh", "timeout": 5 }] },
+    { "matcher": "Edit|Write", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/block-lint-suppression.sh", "timeout": 10 }] }
+  ]
+}
+```
+
+- block-pr-merge: PR マージ操作（`gh pr merge`、REST の `pulls/*/merge`、graphql の merge 系 mutation）を deny。permissions.deny の `Bash(gh pr merge:*)` は先頭一致のため `cd x && gh pr merge` 等の複合・間接実行をすり抜ける。hook はコマンド全文をスキャンして塞ぐ（permissions.deny 側も defense-in-depth として残す）
+- ask-one-question: AskUserQuestion の questions が 2 件以上なら deny（AGENTS.md「質問は1つずつ」）。モデルが即座に 1 問へ絞ってリトライできるため deny
+- block-lint-suppression: Edit/Write で抑制コメント（eslint-disable / @ts-ignore / noqa 等）の出現数が編集前より増える場合に ask（AGENTS.md「静的解析ルールの抑制禁止」）。承認なしの抑制を止めつつ、ユーザー承認という正規の手続きを ask がそのまま表現する。`.md` 等ドキュメントでの言及は対象外
+- 既知の抜け道: Bash 経由の書き込み（`sed -i` 等）、lint 設定ファイルでの rule off、GitHub MCP ツール経由の merge は検知しない。hook はガードの一層で、AGENTS.md のルールが正本
+- settings と hook はセッション開始時にスナップショットされるため、変更は `make link` 後の新セッションから有効
+- `~/.claude/hooks/` は stow の folder-symlink になる。手でローカル限定ファイルを置くと repo working tree に書き込まれ、次回 `make link` が未コミット変更検出で中断する
+
+グローバルに置かないもの:
 
 - repo のセットアップ（deps install 等）は各 repo が持つ: `.claude/settings.json` の SessionStart hook が `.hooks/setup.sh` を呼び、Codex は `.codex/hooks.json` から同じスクリプトを呼ぶ（[dotfiles#1268](https://github.com/nozomiishii/dotfiles/issues/1268)）。セットアップ内容はパッケージマネージャ等 repo 固有のため正本を repo に置き、グローバルからの自動実行をやめることで、clone した他人の repo でスクリプトが意図せず発火することも構造的になくなる（repo に入る hook はその repo の PR レビューを通る）。worktree の起点の鮮度は Claude Code 本体が担う（v2.1.208+ で origin/HEAD 起点 + 自動 fetch）
 - `.envrc` の env（[infra](https://github.com/nozomiishii/infra) の `AWS_PROFILE` 等）は自動注入しない。env に依存するコマンドを `direnv exec . <コマンド>` で実行する運用（AGENTS.md の実装ルール）。hook の `CLAUDE_ENV_FILE` 注入は Codex に効かず蓄積バグもあり（[anthropics/claude-code#67067](https://github.com/anthropics/claude-code/issues/67067)）、shell rc 方式は Claude Code の shell snapshot が env を保存しない（PATH のみ）ため機能しない。direnv の whitelist / allow による信頼ゲートは `direnv exec` にも効く
-- hook で判断制御（allow/deny）を返す場合、旧フィールド `decision`/`reason` は deprecated。`hookSpecificOutput.permissionDecision` / `hookSpecificOutput.permissionDecisionReason` を使うこと
+- 外部 repo への gh 書き込みの /oss ガード・Draft PR ガード・direnv exec リマインドは将来候補（今回は見送り）
+
+hook で判断制御（allow/deny）を返す場合、旧フィールド `decision`/`reason` は deprecated。`hookSpecificOutput.permissionDecision` / `hookSpecificOutput.permissionDecisionReason` を使うこと（参考: [hooks リファレンス](https://code.claude.com/docs/en/hooks)）。
 
 ### worktree
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -46,3 +46,6 @@ pre-commit:
     - name: settings-sync-check
       glob: 'home/.claude/settings.{json,md}'
       run: git diff --cached --name-only | bash scripts/check-settings-sync.sh
+    - name: claude-hooks-test
+      glob: 'home/.claude/hooks/*'
+      run: for t in home/.claude/hooks/*.test.sh; do bash "$t" || exit 1; done

--- a/scripts/cloud/setup.sh
+++ b/scripts/cloud/setup.sh
@@ -9,6 +9,7 @@ curl -fsSL "https://nozomiishii.github.io/dotfiles/cloud-setup.tar.gz" | tar xz
 mkdir -p ~/.claude
 cp home/AGENTS.md ~/.claude/CLAUDE.md
 jq 'del(.statusLine, .sandbox)' home/.claude/settings.json >~/.claude/settings.json
+cp -R home/.claude/hooks ~/.claude/hooks
 
 # Codex
 mkdir -p ~/.codex


### PR DESCRIPTION
## 概要

グローバル AGENTS.md のルールのうち、決定的に検知できる違反を Claude Code の PreToolUse hook で機械的にガードする。LLM への指示はコンテキスト希薄化で守られなくなるため、仕組みで強制できるものを hooks に落とす。

## 背景

特に問題になっていた 3 つを対象にする。

- PR を勝手にマージする: `Bash(gh pr merge:*)` は permissions.deny 済みだが、先頭一致のため `cd x && gh pr merge` や `bash -c "gh pr merge"` のような複合・間接実行がすり抜ける (op CLI で同じ問題に対処した #1355 の block-op-cli.sh と同型の対策)
- 質問を一括で投げてくる: AskUserQuestion に複数 questions を積む
- lint 抑制を承認なしに入れる: eslint-disable / @ts-ignore 等の新規追加

## 変更内容

`home/.claude/hooks/` を新設し、hook 3 本とテスト 3 本を追加。

- block-pr-merge.sh: コマンド全文をスキャンし、`gh pr merge`・REST の `pulls/*/merge`・graphql の merge 系 mutation (auto-merge 予約含む) を deny
- ask-one-question.sh: questions が 2 件以上なら deny し、1 問に絞ってのリトライを促す
- block-lint-suppression.sh: 抑制コメントの出現数が編集前より増える場合だけ ask (既存行の移動は発火しない)。AGENTS.md の「どうしても必要なときは相談し、承認なしに抑制しない」を ask の承認フローがそのまま表現する。`.md` 等ドキュメントでの言及は対象外

配線:

- home/.claude/settings.json に hooks セクションを追加し、settings.md の hooks 節を「決定的ガードのみ置く」方針に更新 (同一コミット)
- cloud-setup.yaml の tarball と scripts/cloud/setup.sh に hooks 配布を追加
- lefthook pre-commit と専用 workflow (claude-hooks-test.yaml) でテストを実行

既知の限界 (settings.md に記載): Bash 経由の書き込み (sed -i 等)・lint 設定ファイルでの rule off・GitHub MCP 経由の merge は検知しない。hook はガードの一層で、AGENTS.md のルールが正本。

## 検証

- 各 hook のテスト (計 18 ケース) が全て green
- lefthook pre-commit (settings-sync-check / claude-hooks-test / commitlint) 通過
- 変更ファイルの prettier / markdownlint 通過 (既存の warn は対象外)

## マージ後の作業

- この PR は cloud-setup.yaml の paths (`home/.claude/**`) に触れるため、マージ後に /cloud-bump の実行が必要
- ローカルは main を pull すると lefthook post-merge が `make link` を自動実行する。hook はその後の新セッションから有効