### PR TITLE
fix: document codex github merge protection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -279,7 +279,7 @@ Finder Sidebar
 
 ### 🤖 Codex
 
-`~/.codex/config.toml` は dotfiles で管理しない。Codex が project の `trust_level`（絶対パス入り）や `model` などマシン固有の状態を自動追記し、version control に向かないため。[Codex の設定リファレンス](https://developers.openai.com/codex/config-reference/#configtoml)に従い、TUI 設定と GitHub connector の PR マージ禁止を手動で入れる。保存後は Codex を再起動する:
+`~/.codex/config.toml` は dotfiles で管理しない。Codex が project の `trust_level`（絶対パス入り）や `model` などマシン固有の状態を自動追記し、[openai/codex#14601](https://github.com/openai/codex/issues/14601) が解消されるまでは version control に向かないため。[Codex の設定リファレンス](https://developers.openai.com/codex/config-reference/#configtoml)に従い、TUI 設定と GitHub connector の PR マージ禁止を手動で入れる。保存後は Codex を再起動する:
 
 ```toml
 # ~/.codex/config.toml

--- a/README.ja.md
+++ b/README.ja.md
@@ -279,12 +279,19 @@ Finder Sidebar
 
 ### 🤖 Codex
 
-`~/.codex/config.toml` は dotfiles で管理しない。Codex が project の `trust_level`（絶対パス入り）や `model` などマシン固有の状態を自動追記し、version control に向かないため。TUI の設定だけ手動で入れる:
+`~/.codex/config.toml` は dotfiles で管理しない。Codex が project の `trust_level`（絶対パス入り）や `model` などマシン固有の状態を自動追記し、version control に向かないため。[Codex の設定リファレンス](https://developers.openai.com/codex/config-reference/#configtoml)に従い、TUI 設定と GitHub connector の PR マージ禁止を手動で入れる。保存後は Codex を再起動する:
 
 ```toml
 # ~/.codex/config.toml
 [tui]
 alternate_screen = "always"
+
+# PR のマージは手動で行い、agent に実行させない
+[apps.github.tools."github.merge_pull_request"]
+enabled = false
+
+[apps.github.tools."github.enable_auto_merge"]
+enabled = false
 ```
 
 ### 😼 SSH & Git

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Finder Sidebar
 
 ### 🤖 Codex
 
-`~/.codex/config.toml` is not tracked by dotfiles. Codex auto-writes machine-local state into it (project `trust_level` with absolute paths, `model`, and more) that doesn't belong in version control. Following the [Codex configuration reference](https://developers.openai.com/codex/config-reference/#configtoml), set the TUI preference and block GitHub connector PR merges by hand. Restart Codex after saving:
+`~/.codex/config.toml` is not tracked by dotfiles. Until [openai/codex#14601](https://github.com/openai/codex/issues/14601) is resolved, Codex auto-writes machine-local state into this file (project `trust_level` with absolute paths, `model`, and more), making it unsuitable for version control. Following the [Codex configuration reference](https://developers.openai.com/codex/config-reference/#configtoml), set the TUI preference and block GitHub connector PR merges by hand. Restart Codex after saving:
 
 ```toml
 # ~/.codex/config.toml

--- a/README.md
+++ b/README.md
@@ -273,12 +273,19 @@ Finder Sidebar
 
 ### 🤖 Codex
 
-`~/.codex/config.toml` is not tracked by dotfiles. Codex auto-writes machine-local state into it (project `trust_level` with absolute paths, `model`, and more) that doesn't belong in version control. Set the TUI preference by hand:
+`~/.codex/config.toml` is not tracked by dotfiles. Codex auto-writes machine-local state into it (project `trust_level` with absolute paths, `model`, and more) that doesn't belong in version control. Following the [Codex configuration reference](https://developers.openai.com/codex/config-reference/#configtoml), set the TUI preference and block GitHub connector PR merges by hand. Restart Codex after saving:
 
 ```toml
 # ~/.codex/config.toml
 [tui]
 alternate_screen = "always"
+
+# Merge PRs manually; do not let the agent perform merges
+[apps.github.tools."github.merge_pull_request"]
+enabled = false
+
+[apps.github.tools."github.enable_auto_merge"]
+enabled = false
 ```
 
 ### 😼 SSH & Git


### PR DESCRIPTION
## 概要

Codex の GitHub connector で PR マージを禁止する設定を README に追加しました。

- `github.merge_pull_request` を無効化
- `github.enable_auto_merge` を無効化
- Codex 公式設定リファレンスと、保存後の再起動を日英 README に記載

## 背景

[#1422](https://github.com/nozomiishii/dotfiles/pull/1422) で tha / pr skill の GitHub 操作を connector に一元化しました。merge tool の無効化は machine-local な `~/.codex/config.toml` に置く必要がありますが、dotfiles ではこのファイルを追跡しないため、新しい環境向けの再現手順がありませんでした。

## 検証

- `bash scripts/check-readme-sync.sh`
- `pnpm exec markdownlint-cli2 README.md README.ja.md`
- `pnpm exec prettier --ignore-unknown --check README.md README.ja.md`
- `pnpm test`
- `codex --strict-config doctor --summary --no-color --ascii`: config の読み込みは成功。コマンド全体は sandbox 内のネットワーク疎通と `TERM=dumb` により終了コード 1
