### PR TITLE
fix: document routine connector handling

### DIFF
--- a/home/.agents/skills/routine/SKILL.md
+++ b/home/.agents/skills/routine/SKILL.md
@@ -71,6 +71,7 @@ name とファイル名を `<頻度>-<対象>` の形に揃える。頻度語は
 - 実行頻度の妥当性（daily / weekly / monthly、曜日・時刻）
 - model の選定（調査・要約中心なら sonnet、判断・分析が必要なら opus）
 - 既存 routine と責務が被らないか（`.routines/` の一覧を見て確認）
+- connector の要否。既定は無し。prompt の手順が MCP ツールを必要とするときだけ足す
 - エラー時の振る舞い（部分的な結果で続行するか、止めるか）
 
 #### monthly の発火日を決める
@@ -106,6 +107,7 @@ routine を 4 つの型のどれかに分類する。型ごとの雛形が `.rou
 `.routines/_templates/<type>.md` をコピーし、`<...>` の placeholder と各セクションを埋める。
 
 - `repos` には対象 repo と `nozomiishii/brain` の両方を含める
+- `connectors` には使う connector 名だけを書く。使わないなら `[]`
 - schedule の cron は UTC で書き、コメントに JST を添える（20:00 UTC = 翌日 05:00 JST。日またぎで曜日・日付がずれる点に注意）
 - 雛形にないセクションの追加は自由。雛形の必須セクションを削る場合は理由をユーザーと合意する
 
@@ -145,6 +147,9 @@ cloud trigger を create / update する前に、brain repo で `git fetch origi
 - repos: 対象 repo + nozomiishii/brain
 - schedule: frontmatter と同じ cron
 - model: frontmatter と同じ model
+- connectors: frontmatter と同じ connector
+
+trigger を新規作成すると、アカウントで有効な connector がすべて自動で付く。connector が付いた routine は実行中にその全ツールを無確認で使えるため、作成直後に [Routine 管理画面](https://claude.ai/code/routines) の Edit を開き、frontmatter の `connectors` と一致させる。API では connector を変更・削除できない。
 
 ### 発火時刻の確認
 
@@ -168,6 +173,7 @@ diff がない場合（直接 frontmatter を変更する依頼の場合）は�
 
 - `model` → `job_config.ccr.session_context.model`（frontmatter 値に `claude-` を prefix）
 - `schedule` → `cron_expression`
+- `connectors` → `mcp_connections`。API では変更できないため [Routine 管理画面](https://claude.ai/code/routines) の Edit で操作する
 - `type` → 同期しない（`.routines/` ローカル専用のフィールド）
 
 update 時は `environment_id` を既存 trigger から取得して含める（API が要求するため）。照合できない routine はスキップし、ユーザーに報告する。
@@ -188,6 +194,7 @@ schedule を update した場合は、レスポンスの `next_run_at` を JST �
 - `schedule`: frontmatter の cron と trigger の `cron_expression` が一致するか
 - `model`: frontmatter の model と trigger の `session_context.model` が一致するか（`claude-` prefix を考慮）
 - `repos`: frontmatter の repos と trigger の `sources` が一致するか
+- `connectors`: frontmatter の connectors と trigger の `mcp_connections` が一致するか
 - `prompt`: trigger の events に `.routines/<name>.md を Read し、その指示に従って実行お願い。` が設定されているか
 
 trigger 側で値が未設定の場合も差分として扱う。
@@ -198,6 +205,7 @@ trigger 側で値が未設定の場合も差分として扱う。
 
 - routine prompt は brain repo `.routines/` が正本。cloud trigger に prompt 本文を直接書かない
 - frontmatter の `repos` に `nozomiishii/brain` を必ず含める
+- trigger の connector は frontmatter の `connectors` に揃える。新規作成では自動で付くため必ず確認する
 - monthly の発火日は JST 2〜28 日から空き日を選び、name とファイル名の 2 桁に入れる
 - cron は UTC で記述し、JST をコメントで添える
 - frontmatter を変更したら main への merge 後に skill を再実行し、cloud trigger も必ず同期する


### PR DESCRIPTION
## 背景

routine の cloud trigger を API で新規作成すると、アカウントで有効な connector がすべて自動で付く。付いていれば routine 実行中にその全ツールを無確認で使えるが、skill にその挙動も外し方も書かれておらず、気づけない状態だった。

## 変更

`/routine` に connector の扱いを追加した。

- 設計時に connector の要否を決める。既定は無し
- `.routines/<name>.md` の `connectors` には使う connector 名だけを書く。使わないなら `[]`
- trigger 新規作成の直後に Routine 管理画面の Edit を開き、frontmatter の `connectors` と一致させる。API では connector を変更・削除できない
- 同期手順に `connectors` → `mcp_connections` の対応を追加
- 整合性チェックの検証項目に `connectors` を追加

## 関連

frontmatter への `connectors` 追加と、実際に付いていた connector の削除は https://github.com/nozomiishii/brain/pull/375
