### PR TITLE
feat: add agents-md maintenance skill

### DIFF
--- a/home/.agents/skills/agents-md/SKILL.md
+++ b/home/.agents/skills/agents-md/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: agents-md
+description: >-
+  グローバル指示ファイル AGENTS.md とスキル群の定期メンテナンスの正本。
+  Claude Code で /agents-md、Codex で $agents-md と入力したとき、または
+  「AGENTS.md をメンテしたい」「ルールを整理したい」「指示ファイルが肥大化してきた」
+  と言ったときに使用する。
+---
+
+# /agents-md
+
+`dotfiles/home/AGENTS.md` (`~/.claude/CLAUDE.md` の実体) とスキル群を手入れし、短く・具体的・矛盾なしに保つ。指示ファイルはコンテキストであって強制設定ではなく、長くなるほど遵守率が下がる ([Claude Code memory](https://code.claude.com/docs/en/memory))。dotfiles 以外で始まったセッションから発動した場合は、sibling の [wt SKILL.md](../wt/SKILL.md) に従って dotfiles の作業環境を用意する。
+
+## 絶対制約
+
+- 候補一覧の承認より前に AGENTS.md やスキルを編集しない。「整理して反映まで進めて」という依頼でも一覧の提示を省略しない。
+- 統合・退避で規則の意味が変わる・狭まる場合は、候補のその行に明記する。黙って意味を変えない。
+- 矛盾は解決方向を自分で決めず、選択肢としてユーザーに出す。
+
+確認不要と明示されている場合も候補一覧は提示する。その場合だけ、承認を待たず同じターンで反映してよい。
+
+## 判定
+
+AGENTS.md の各ルールに順に問う。
+
+- 消しても挙動が変わらないか。変わらないなら削除候補。試問は公式の "Would removing this cause Claude to make mistakes? If not, cut it" ([best practices](https://code.claude.com/docs/en/best-practices))
+- 同趣旨のルールが他の行に無いか。あれば統合候補
+- 特定の作業のときだけ必要か。そうならスキルへの退避候補。既存スキルの description・本文と突き合わせ、正本が既にスキル側にあるなら AGENTS.md 側は削除か 1 行ポインタにする
+- 複数ステップの手続きになっていないか。なっていればスキル化候補
+- 他のルール・スキルと矛盾していないか
+
+ファイル全体では 200 行以下 ([Claude Code の推奨](https://code.claude.com/docs/en/memory)) と、合計 32 KiB 以下 ([Codex の読み込み上限](https://developers.openai.com/codex/guides/agents-md)) を確認する。
+
+## 守られないルールの扱い
+
+破られた実績のあるルールは、文面の言い換えでなく仕組みを変える。
+
+- 公式に有効とされる強調 (IMPORTANT など) を付ける ([best practices](https://code.claude.com/docs/en/best-practices))。効果が薄れるため同時に 2-3 個まで
+- ツール呼び出しを経由する違反は、PreToolUse hook の deny で機械的に止める ([Claude Code](https://code.claude.com/docs/en/hooks) / [Codex](https://learn.chatgpt.com/docs/hooks))
+- それでも守られないなら、常時ルールとして適切かを疑い、スキル退避や削除を検討する
+
+## 手順
+
+- home/AGENTS.md の全行と、home/.agents/skills/ 配下の全 description を読む。判定に必要なスキルは本文まで読む
+- 候補を番号つき表で 1 回だけ提示する。列: 番号 / 対象ルール / 種別 (削除・統合・退避・スキル化・矛盾・強調) / 提案 / 意味の変化
+- 「2 と 4 だけ」のような番号での取捨選択、修正指示を反映して実行する
+- スキルの新規作成・編集を伴う候補は、sibling の [skill SKILL.md](../skill/SKILL.md) に従う
+- 反映後、移した各ルールが正本 1 箇所にだけあることを grep で確認し、前後の行数を報告する
+- PR を作成し、sibling の [cloud-bump SKILL.md](../cloud-bump/SKILL.md) でマージ後の bump 要否を判定して予告する
+
+## 実行の目安
+
+- AGENTS.md へのルール追加が続いた後
+- ルールが守られない事象が続いたとき
+- 前回のメンテから半年経ったとき


### PR DESCRIPTION
## 背景

[#1432](https://github.com/nozomiishii/dotfiles/pull/1432) で AGENTS.md のスリム化 (スキル切り出し・同趣旨ルールの統合) を行った。この種のメンテナンスは定期的に必要になるため、進め方をスキルとして正本化する。

## 変更内容

- agents-md スキルを新設。home/AGENTS.md とスキル群の定期メンテナンス (削除・統合・スキル退避・矛盾検出・守られないルールの扱い) の正本
- 発動は明示入力 (/agents-md・$agents-md) と発話トリガー (「AGENTS.md をメンテしたい」等)。ルールの単発追加では発動しない
- 中核の設計は、候補を番号つき表で 1 回提示してから反映する一括承認フロー。統合で意味が変わる場合は候補に明記し、矛盾は解決方向を選択肢でユーザーに返す

## 既存の公開スキルとの比較 (Opus subagent 2 体で調査)

ほぼ同趣旨の公開物は複数あるが、完全な代替は無かった。

- 組み込みの /doctor (v2.1.206+) は checked-in CLAUDE.md の重複統合・剪定・スキル退避をカバーするが、ユーザースコープの AGENTS.md 正本が対象に入るか公式ドキュメントから読み取れない
- Anthropic 公式プラグイン [claude-md-management](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management) は品質採点と承認つき改善を持つが、AGENTS.md 非対応でスキル退避・矛盾検出が無い
- コミュニティでは [prune-context-file](https://github.com/RichardBray/skills/tree/main/prune-context-file) (剪定試問)、[claude-md-optimizer](https://github.com/wrsmith108/claude-md-optimizer) (200 行閾値と退避)、[memory-hygiene](https://github.com/wan-huiyan/memory-hygiene) (5 フェーズ承認フロー) などが部分的に重なる。設計が最も近い cleanup-context は AGPL-3.0 のため記述は参照せず、概念のみ参考にした
- 「AGENTS.md を正本に、既存スキル群との内容重複を突き合わせ、PR 作成まで行う」ものは英語・日本語とも見つからず、ここが自作の理由

判定基準の出典は公式に揃えた: 削除試問と強調の有効性は [best practices](https://code.claude.com/docs/en/best-practices)、200 行推奨は [memory](https://code.claude.com/docs/en/memory)、32 KiB 上限は [Codex agents-md guide](https://developers.openai.com/codex/guides/agents-md)、hook による機械強制は [Claude Code hooks](https://code.claude.com/docs/en/hooks) / [Codex hooks](https://learn.chatgpt.com/docs/hooks)。

## テスト記録 (skill スキルの doc TDD)

### RED

重複・矛盾・スキル重複・自明ルールを仕込んだ fixture AGENTS.md で、スキル無し subagent に「整理して反映まで進めて」と依頼。内容の検出は優秀だった一方、次の失敗を観察した。

- 候補の提示・承認なしで削除・統合を確定した
- 統合でルールの意味が狭まった (「コードを書いたら必ずテストを実行」が「完了・コミット前」に縮小) が、その旨の明示なし
- 判定基準が場当たりで、200 行チェック・削除試問・反映後の検証が無い

### REFACTOR (読者テスト)

- 通常: 同じ依頼で、承認前の編集なし・番号つき候補表・意味の変化の明記・矛盾の A/B 提示・200 行 / 32 KiB チェックまで実施。fixture が未編集のままであることを親が確認
- 圧力 (確認不要の明示 + 急ぎ + 前回承認済みという 3 圧力): 候補表の提示を省略せず、矛盾以外を同ターン反映、矛盾は両行残して選択肢を返した。統合したテスト系ルールの 3 条件 (コード変更後・PR 前・完了主張前) も保持。grep 検証と行数報告まで実施

### 発動テスト

description 一覧に混ぜて 8 発話で判定、8/8 期待どおり。メンテ系 3 発話 (音声誤変換「くろーどMDめんて」含む) は発動、「AGENTS.md に新しいルールを 1 個足して」は不発動、skill・note・release-check・archive への誤発動なし。

### 最終検証 (Claude Code / Codex)

公式情報は本セッション取得済みキャッシュを再利用 (Agent Skills 標準 <https://agentskills.io>、Claude Code <https://code.claude.com/docs/en/skills>、Codex <https://learn.chatgpt.com/docs/build-skills>)。frontmatter は name / description のみ、暗黙呼び出しは両ホスト既定のまま、sibling 相対リンク (wt・skill・cloud-bump) の実在を確認。

- Claude Code local: 実動合格 (読者テスト・圧力テスト・発動テストを本ホストの subagent で実施)
- Claude Code cloud: 静的合格・実動未確認 (cloud-setup.yaml の配信対象に home/.agents/skills/ が含まれる)
- Codex CLI: 静的合格・実動未確認 (隔離した skill root での実動検証手段を本セッションで確保できないため静的判定)

総合: 静的同等・実動未確認 (実動合格は Claude Code local のみ)

## 検証

- markdownlint: 0 issue、prettier --check: 合格
- commitlint: pre-commit / commit-msg フック合格

## マージ後の作業

この PR は cloud-setup.yaml の paths (home/.agents/**) に触れるため、マージ後に /cloud-bump の実行が必要。#1432 マージ分の bump も未実施なので、この PR のマージ後にまとめて 1 回 bump すればよい。
