### PR TITLE
chore: capture machine-local settings drift into repo

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -118,13 +118,21 @@
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "sentry-mcp@sentry-mcp": true
+    "sentry-mcp@sentry-mcp": true,
+    "codex@openai-codex": true,
+    "frontend-design@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "sentry-mcp": {
       "source": {
         "source": "github",
         "repo": "getsentry/sentry-mcp"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     }
   },

--- a/home/.claude/settings.md
+++ b/home/.claude/settings.md
@@ -1,6 +1,6 @@
 # ~/.claude/settings.json リファレンス
 
-最終更新: 2026-07-17
+最終更新: 2026-07-30
 
 ## 背景
 
@@ -181,7 +181,9 @@ Auto mode の利用可能条件: Max / Team / Enterprise / API プラン + 対�
 "enabledPlugins": {
   "swift-lsp@claude-plugins-official": true,
   "typescript-lsp@claude-plugins-official": true,
-  "sentry-mcp@sentry-mcp": true
+  "sentry-mcp@sentry-mcp": true,
+  "codex@openai-codex": true,
+  "frontend-design@claude-plugins-official": true
 }
 ```
 
@@ -192,12 +194,15 @@ Auto mode の利用可能条件: Max / Team / Enterprise / API プラン + 対�
 - swift-lsp — Swift 用 LSP プラグイン。`/usr/bin/sourcekit-lsp`（Xcode CLT 同梱）を Claude Code に配線し、Brooklyn 等の Swift プロジェクトで go-to-definition / references / diagnostics を有効化する。
 - typescript-lsp — TypeScript / JavaScript 用 LSP プラグイン。`typescript-language-server` バイナリ（`scripts/toolchains/node.sh` で npm global インストール）を Claude Code に配線し、`.ts/.tsx/.js/.jsx/.mts/.cts/.mjs/.cjs` で go-to-definition / references / diagnostics を有効化する。
 - sentry-mcp — Sentry 公式の MCP プラグイン。Claude Code から Sentry の issue・エラーイベントを参照できる。取得元は下の extraKnownMarketplaces で解決する。
+- codex — OpenAI 公式の Codex プラグイン。/codex:* スキルでレビュー・診断・タスク委譲を Codex に投げられる。取得元は下の extraKnownMarketplaces で解決する。
+- frontend-design — Anthropic 公式のフロントエンドデザインプラグイン。新規 UI 構築時にテンプレ的でない見た目を作るための指針スキルを提供する。
 
 ### extraKnownMarketplaces
 
 ```jsonc
 "extraKnownMarketplaces": {
-  "sentry-mcp": { "source": { "source": "github", "repo": "getsentry/sentry-mcp" } }  // sentry-mcp プラグインの取得元
+  "sentry-mcp": { "source": { "source": "github", "repo": "getsentry/sentry-mcp" } },  // sentry-mcp プラグインの取得元
+  "openai-codex": { "source": { "source": "github", "repo": "openai/codex-plugin-cc" } }  // codex プラグインの取得元
 }
 ```
 

--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -604,15 +604,7 @@
     "**/.gitea/workflows/*.yml",
     "**/.gitea/workflows/*.yaml",
     "**/.forgejo/workflows/*.yml",
-    "**/.forgejo/workflows/*.yaml",
-    "**/docker-compose.yml",
-    "**/docker-compose.yaml",
-    "**/docker-compose.*.yml",
-    "**/docker-compose.*.yaml",
-    "**/compose.yml",
-    "**/compose.yaml",
-    "**/compose.*.yml",
-    "**/compose.*.yaml"
+    "**/.forgejo/workflows/*.yaml"
   ],
   "workbench.preferredDarkColorTheme": "Monokai Pro"
 


### PR DESCRIPTION
## 概要

新マシンへの dotfiles インストール準備の事前調査で見つかった、このマシン上の実設定と repo の乖離を repo に回収する。

## 変更内容

- home/.claude/settings.json
  - enabledPlugins に `codex@openai-codex` と `frontend-design@claude-plugins-official` を追加（/plugin で有効化済みだが、settings.json が実ファイル化して stow から外れていたため repo に未反映だった）
  - extraKnownMarketplaces に `openai-codex`（github: openai/codex-plugin-cc）を追加。CLI 登録の marketplace は dotfiles 管理外のため、新マシンでも解決できるよう source を明記する（sentry-mcp と同じ方針）
- home/.claude/settings.md
  - 上記に合わせて enabledPlugins / extraKnownMarketplaces のセクションを同期
- home/Library/Application Support/Code/User/settings.json
  - yaml.schemas から docker-compose 系 glob 8 件を削除。現用 clone の working tree に未コミットで残っていた編集の回収

## repo に回収しなかったもの

- Orca アプリが live 設定に書き込んだ hooks（`/Users/nozomiishii/.orca/...` とユーザー名ハードコードのマシンローカル設定）
- `bash ~/.hooks/block-op-cli.sh` の PreToolUse フック（`~/.hooks` は repo から削除済みで壊れた参照。マシン側の後掃除で除去予定）

## マージ後の作業

- `home/.claude/**` は cloud 配信対象のため、マージ後に /cloud-bump の実行が必要
- マシン側で make link を再実行し、実ファイル化した `~/.claude/settings.json` を symlink に戻す