### PR TITLE
fix: pre-create runtime dirs so stow does not fold them into the repo

### DIFF
--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -27,10 +27,24 @@ if ! git diff --quiet -- home || ! git diff --quiet --cached -- home; then
   exit 1
 fi
 
-# ~/.local/bin を実 dir として先に用意してから stow を走らせる。tree folding で
-# ~/.local/bin が repo 配下への folder-symlink に畳まれると、あとで張る ln -sfn の
-# 書き込み先が repo working tree に入って次回 make link が止まる。
-mkdir -p "$HOME/.local/bin"
+# 外部ツールが実行時に書き込むディレクトリは、実 dir として先に用意してから
+# stow を走らせる。まっさらなアカウントでは tree folding で repo 配下への
+# folder-symlink に畳まれ、ssh-keygen の秘密鍵・Claude Code / Codex / VS Code の
+# ランタイム状態・サードパーティの LaunchAgent が repo working tree に書き込まれて
+# しまう。~/.local/bin は、あとで張る ln -sfn の書き込み先になるため同様。
+runtime_dirs=(
+  "$HOME/.claude"
+  "$HOME/.codex"
+  "$HOME/.config"
+  "$HOME/.local/bin"
+  "$HOME/.ssh"
+  "$HOME/Documents/superwhisper/modes"
+  "$HOME/Library/Application Support/Code/User"
+  "$HOME/Library/Developer/Xcode/UserData"
+  "$HOME/Library/LaunchAgents"
+)
+mkdir -p "${runtime_dirs[@]}"
+chmod 700 "$HOME/.ssh"
 
 # repo を常に正とする。衝突する実体ファイルは --adopt で stow が吸収し（削除しない）、
 # 直後に git restore で repo 版へ戻す。home/ は上のチェックでクリーンなので、


### PR DESCRIPTION
## 概要

まっさらなアカウントで `scripts/symlink.sh` を実行すると、`~/.ssh` や `~/Library/LaunchAgents` などがまだ存在しないため、stow の tree folding でディレクトリごと repo 配下への folder-symlink に畳まれる。その状態で暮らし始めると、外部ツールの書き込みがそのまま repo working tree に入ってしまう。

- `ssh-keygen` の秘密鍵や known_hosts が `home/.ssh/` に書き込まれる（.gitignore は無いので commit 事故に直結）
- Claude Code のセッション履歴・todos、Codex の sessions/config、VS Code の globalStorage が repo に溜まる
- `~/.config` が畳まれると gh / gcloud / op（1Password CLI）の認証情報まで repo 配下に入る
- サードパーティアプリの LaunchAgent plist が repo に落ちる

## 変更内容

既存の `~/.local/bin` の事前 mkdir と同じ方式で、外部ツールが実行時に書き込むディレクトリを stow 実行前に実ディレクトリとして用意する。`~/.ssh` は 700 に chmod する。

既存マシンでは各ディレクトリは実在するため no-op。すでに folder-symlink になっている場合も `mkdir -p` は既存パスとして解決されるだけで無害（fold の解消は行わない。新規セットアップでの発生だけを防ぐ）。

## 検証

- `bash -n` と shellcheck を実行し、指摘なし