### PR TITLE
fix: make install scripts safe to re-run after a partial failure

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -89,3 +89,11 @@ fi
 if command -v rbenv >/dev/null; then
   eval "$(rbenv init -)"
 fi
+
+# Terraform
+# terraform -install-autocomplete は ~/.zshrc へ追記する方式で、symlink 先の repo が
+# dirty になり git pull --rebase と make link が止まるため、補完はここで管理する
+if command -v terraform >/dev/null; then
+  autoload -U +X bashcompinit && bashcompinit
+  complete -o nospace -C terraform terraform
+fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -89,11 +89,3 @@ fi
 if command -v rbenv >/dev/null; then
   eval "$(rbenv init -)"
 fi
-
-# Terraform
-# terraform -install-autocomplete は ~/.zshrc へ追記する方式で、symlink 先の repo が
-# dirty になり git pull --rebase と make link が止まるため、補完はここで管理する
-if command -v terraform >/dev/null; then
-  autoload -U +X bashcompinit && bashcompinit
-  complete -o nospace -C terraform terraform
-fi

--- a/scripts/nix.sh
+++ b/scripts/nix.sh
@@ -9,4 +9,12 @@
 set -Ceuo pipefail
 
 echo "👨🏻‍🚀 Install Nix"
+
+# Determinate installer は既存の /nix があると --no-confirm でも進めず止まるため、
+# 部分実行後の再実行では receipt を見てスキップする
+if [ -e /nix/receipt.json ]; then
+  echo "👨🏻‍🚀 Nix is already installed. Skipping"
+  exit 0
+fi
+
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm

--- a/scripts/toolchains/terraform.sh
+++ b/scripts/toolchains/terraform.sh
@@ -20,7 +20,6 @@ tenv tg install latest-stable
 
 echo "- 🛰️ Terraform $(terraform -version)"
 
-echo '- 🛰️ Install Terraform autocomplete'
-terraform -install-autocomplete
+# 補完は home/.zshrc で管理する (terraform -install-autocomplete は使わない)
 
 echo "🛰️ Terraform setup is complete 🎉"

--- a/scripts/toolchains/terraform.sh
+++ b/scripts/toolchains/terraform.sh
@@ -20,8 +20,5 @@ tenv tg install latest-stable
 
 echo "- 🛰️ Terraform $(terraform -version)"
 
-# terraform -install-autocomplete は使わない。~/.zshrc へ追記する方式で、symlink 先の
-# repo が dirty になり git pull --rebase と make link が止まる。補完自体も OpenTofu へ
-# 移行済みのため入れない
 
 echo "🛰️ Terraform setup is complete 🎉"

--- a/scripts/toolchains/terraform.sh
+++ b/scripts/toolchains/terraform.sh
@@ -20,6 +20,8 @@ tenv tg install latest-stable
 
 echo "- 🛰️ Terraform $(terraform -version)"
 
-# 補完は home/.zshrc で管理する (terraform -install-autocomplete は使わない)
+# terraform -install-autocomplete は使わない。~/.zshrc へ追記する方式で、symlink 先の
+# repo が dirty になり git pull --rebase と make link が止まる。補完自体も OpenTofu へ
+# 移行済みのため入れない
 
 echo "🛰️ Terraform setup is complete 🎉"


### PR DESCRIPTION
## 概要

install.sh が途中で失敗した後の再実行で新たに壊れる箇所を直す。新マシンセットアップの事前調査で発見。

## 修正内容

- scripts/toolchains/terraform.sh: `terraform -install-autocomplete` をやめる
  - このコマンドは `~/.zshrc` へ追記する方式で、`~/.zshrc` は repo への symlink のため repo working tree が dirty になる。その結果、再実行時の `git pull --rebase`（install.sh）と `make link`（symlink.sh の未コミット検出）が両方止まる。2 回目の実行自体も「already installed」エラーで非ゼロ終了する
- home/.zshrc: terraform の補完を repo 管理の 1 行として追加（`complete -o nospace -C terraform terraform`）。terraform 未インストール環境では何もしない
- scripts/nix.sh: `/nix/receipt.json` があればスキップ
  - Determinate installer は既存の /nix が残っていると `--no-confirm` でも進めず止まるため、部分実行後の再実行がここで死んでいた

## 検証

- `bash -n` / shellcheck / `zsh -n` を全変更ファイルで実行し、指摘なし