### PR TITLE
feat: set up pm on fresh machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ toolchains: ## Set up language toolchains
 	bash ./scripts/toolchains/python.sh
 	bash ./scripts/toolchains/ruby.sh
 	bash ./scripts/toolchains/rust.sh
+	bash ./scripts/toolchains/pm.sh
 
 .PHONY: repo
 repo: ## Clone GitHub repositories

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -68,9 +68,14 @@ if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
 fi
 
 # pm - VS Code Project Manager CLI
+# pm は dotfiles 管理外のため、未導入のマシン (セットアップ直後) でも zsh が
+# 起動できるようガードする
 export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
-source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
+pm_zsh_path="${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
+# shellcheck source=/dev/null
+[[ -r "$pm_zsh_path" ]] && source "$pm_zsh_path"
+unset pm_zsh_path
 # Option+j (ESC+j / ∆)
 bindkey -s '^[j' 'pm^M'
 bindkey -s '∆' 'pm^M'

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -68,14 +68,15 @@ if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
 fi
 
 # pm - VS Code Project Manager CLI
-# pm は dotfiles 管理外のため、未導入のマシン (セットアップ直後) でも zsh が
-# 起動できるようガードする
+# 未導入のマシンでも zsh が起動できるようガードする。source の行は pm installer が
+# 追記済み判定に使うマーカーなので、この文字列のまま変えない
+# https://github.com/nozomiishii/pm/blob/main/install.sh
 export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
-pm_zsh_path="${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
-# shellcheck source=/dev/null
-[[ -r "$pm_zsh_path" ]] && source "$pm_zsh_path"
-unset pm_zsh_path
+if [[ -r "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh" ]]; then
+  # shellcheck source=/dev/null
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"
+fi
 # Option+j (ESC+j / ∆)
 bindkey -s '^[j' 'pm^M'
 bindkey -s '∆' 'pm^M'

--- a/install.sh
+++ b/install.sh
@@ -104,6 +104,7 @@ if [[ "$OS_NAME" == "Darwin" ]]; then
   bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
   bash "$SCRIPT_DIR/scripts/nvim.sh"
   bash "$SCRIPT_DIR/scripts/default_apps.sh"
   bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
@@ -122,6 +123,7 @@ if [[ "$OS_NAME" == "Linux" ]]; then
   bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
   bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
 fi
 
 echo -e "${yellow}"

--- a/scripts/toolchains/pm.sh
+++ b/scripts/toolchains/pm.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# -C          : Prevent overwriting files with output redirection
+# -e          : Exit the script if any command returns a non-zero status
+# -u          : Exit the script if an undefined variable is used
+# -o pipefail : Change pipeline exit status to the last non-zero exit
+#               code in the pipeline, or zero if all commands succeed
+# -x          : (Optional) Enable command tracing for easier debugging
+set -Ceuo pipefail
+
+echo '📁 pm'
+
+# https://github.com/nozomiishii/pm
+# インストーラは binary を ~/.local/bin、pm.zsh を ~/.config/pm に置く。
+# ~/.zshrc への追記は source 行のマーカーがあればスキップされる (home/.zshrc に記載済み)
+echo '- 📁 Install pm'
+curl -fsSL https://raw.githubusercontent.com/nozomiishii/pm/main/install.sh | bash
+
+# インストーラの導入先 ~/.local/bin は非対話 shell の PATH に無い
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "- 📁 pm $(pm --version)"
+
+echo "📁 pm setup is complete 🎉"


### PR DESCRIPTION
## 概要

managed な `home/.zshrc` が pm(dotfiles 管理外)の `~/.config/pm/pm.zsh` を無条件に `source` しており、pm 未導入の新マシンでは zsh の起動がここでエラーになる。レビュー指摘を受けて、ガードだけでなく pm 自体を install フローに組み込む。

## 変更内容

- home/.zshrc: pm.zsh が読めるときだけ source するガードを追加
  - `source "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh"` の行は [pm installer の追記済み判定マーカー](https://github.com/nozomiishii/pm/blob/main/install.sh)なので、この文字列を保つ if 形式にしている（変数化するとマーカーが消え、installer が symlink 先の repo zshrc に追記して dirty にする）
- scripts/toolchains/pm.sh: [nozomiishii/pm](https://github.com/nozomiishii/pm) の公式インストーラを呼ぶスクリプトを追加（binary → `~/.local/bin`、pm.zsh → `~/.config/pm`）。pm.zsh は pm repo が正本のため、dotfiles への vendoring はしない
- install.sh(Darwin / Linux)と `make toolchains` に pm.sh を追加。symlink.sh の後に走るため、installer の zshrc 追記はマーカー検出でスキップされる

## 検証

- `zsh -n` / `bash -n` / shellcheck で指摘なし
- `grep -qF` でマーカー文字列が home/.zshrc に残ることを確認（installer と同じ判定）