### PR TITLE
feat: define provisional app id prefix

### DIFF
--- a/home/.agents/skills/release-check/SKILL.md
+++ b/home/.agents/skills/release-check/SKILL.md
@@ -14,12 +14,13 @@ Web サービス・モバイルアプリを一般公開する前の共通チェ�
 
 ## 公開準備の開始ゲート
 
-公開準備の最初に、次の 2 項目を確認して issue の先頭に置く。
+公開準備の最初に、次の項目を確認して issue の先頭に置く。
 
 - [ ] アプリ／サービスの正式名を決定する。候補ごとに多言語で不適切な意味にならないか、対応するドメインを取得できるか確認する
 - [ ] 本番ドメインを取得する
+- [ ] ストア向け app ID / Bundle ID を確認する。正式名が未決定の仮置きは `dev.nozomiishii.<repo 名>` とし、dance なら `dev.nozomiishii.dance` を使う。`dev` は `nozomiishii.dev` 由来の固定 prefix で、開発環境を表す末尾 suffix ではない
 
-どちらかが未決定なら、全項目の調査と issue 本文の作成は続けるが、ゲートは未通過と明記する。ブランド、app ID、OAuth callback、メール送信ドメイン、公開 URL、本番 routing の作業を後続に置き、ゲートを通過するまで着手しない。実装済みの機能が多いことを、名称とドメインを後回しにする理由にしない。
+正式名か本番ドメインが未決定なら、全項目の調査と issue 本文の作成は続けるが、ゲートは未通過と明記する。ブランド、OAuth callback、メール送信ドメイン、公開 URL、本番 routing の作業を後続に置き、ゲートを通過するまで着手しない。app ID / Bundle ID は上の規則で仮置きしてローカル build と検証を進めてよい。App Store Connect へ最初の build を upload した後は変更できず、app record を削除しても再利用できないため、upload 前に現在値をユーザーへ提示して確定する。[Apple の変更手順](https://developer.apple.com/documentation/xcode/changing-the-bundle-identifier)を参照する。実装済みの機能が多いことを、名称とドメインを後回しにする理由にしない。
 
 ## 進め方
 


### PR DESCRIPTION
## 変更内容

- 正式名が未決定の app ID / Bundle ID は `dev.nozomiishii.<repo 名>` で仮置きする規則を追加
- `dev` は `nozomiishii.dev` 由来の固定 prefix であり、開発環境を示す末尾 suffix ではないことを明記
- 名称と本番ドメインが未決定でも、仮 ID でローカル build と検証を進められるよう開始ゲートを整理
- App Store Connect へ最初の build を upload する前に、現在の ID をユーザーへ提示して確定する停止条件を追加

## 背景

release-check には正式名と本番ドメインの開始ゲートがありましたが、名称決定前にネイティブ build を進める場合の仮 ID 規則がありませんでした。そのため、一般的な逆ドメイン形式や環境 suffix を推測し、意図しない ID を提案する余地がありました。

この変更により、dance では `dev.nozomiishii.dance` を使い、今後の仮置きも同じ prefix に統一できます。

Bundle ID を変更できる時点の根拠は [Apple の変更手順](https://developer.apple.com/documentation/xcode/changing-the-bundle-identifier) を参照しています。

## スキルのテスト記録

### RED

シナリオ: 仮称 dance のままローカル iOS build を進めるため、仮の Bundle ID を決める。

変更前の読者は `com.nozomiishii.dance.dev` を提案し、仮 ID と本番 ID を別の規則として扱いました。期待する `dev.nozomiishii.dance` と一致しないため失敗と判定しました。

### GREEN / REFACTOR

変更後の作業コピーを読ませた同じシナリオでは、次を満たしました。

- `dev.nozomiishii.dance` を提案
- `dev` を `nozomiishii.dev` 由来の固定 prefix と認識
- ローカル build は進める
- 最初の App Store Connect upload 前にユーザー確認で停止

### 発動テスト

description は変更していません。次の発話で選択結果を確認しました。

- 「dance を App Store へ出す準備を始めたい」→ release-check
- 「公開準備のチェック項目を Issue にしたい」→ release-check
- 「release-check スキルの Bundle ID 規則を変えたい」→ skill
- 「Bundle ID とは何？」→ 該当なし
- 「README を GitHub で公開したい」→ 該当なし
- 「ストア審査に向けて準備状況を棚卸ししたい」→ release-check

### Claude Code / Codex 互換性

2026-07-30 JST に [Agent Skills specification](https://agentskills.io/specification)、[Claude Code skills](https://code.claude.com/docs/en/slash-commands)、[Codex skills](https://learn.chatgpt.com/docs/build-skills) の現行文書を確認しました。

- Claude Code 2.1.215: 配置・frontmatter・暗黙呼び出しは静的合格。隔離した実動テストは未確認
- Codex CLI 0.145.0 / Codex App: 配置・frontmatter・暗黙呼び出しは静的合格。Codex subagent の読者テストは合格したものの、host trace による読み込み元の確認を記録していないため、ホスト全体の実動合格とは扱わない
- ホスト固有のツール、metadata、引数展開は今回の変更では使用しない

## 検証

- `pnpm exec markdownlint-cli2 'home/.agents/skills/release-check/SKILL.md'`
- `pnpm exec prettier --ignore-unknown --check home/.agents/skills/release-check/SKILL.md`
- `pnpm test`
- YAML frontmatter の parse
- pre-commit の `lint-docs`
- commitlint

`pnpm format` の全体実行は、今回変更していない既存21ファイルの format 差分により失敗しました。対象ファイルの format 検証は成功しています。

## マージ後

このファイルは `.github/workflows/cloud-setup.yaml` の配信対象 `home/.agents/**` に含まれます。マージ後、新しい cloud セッションへ反映するため `$cloud-bump` の実行が必要です。