### PR TITLE
chore: fix stale docs references and document post-install steps

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,14 +35,6 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 curl -fsSL https://dotfiles.nozo.sh | bash -s -- --full
 ``` -->
 
-<!-- これにするのが目標
-
-```shell
-curl -L dot.nozomiishii.dev | sh
-``` -->
-
-</details>
-
 ## 開発
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nozomiishii/dotfiles)
@@ -142,7 +134,8 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    ```
 
 4. プライベートリポジトリのクローン  
-   再起動が終わったら GitHub で認証して、プライベートリポジトリをクローンしましょう：
+   再起動が終わったら GitHub で認証して、プライベートリポジトリをクローンしましょう。
+   make repo は SSH URL で clone するため、`gh auth login` では認証方式に SSH を選んでください：
 
    ```shell
    gh auth login
@@ -489,6 +482,18 @@ fork して自分用に使う場合、書き換えが必要な箇所を [docs/fo
 
 ```shell
 make homebrew
+```
+
+`home/` 配下のファイルを編集したら symlink を張り直しましょう
+
+```shell
+make link
+```
+
+macOS のシステム設定を再適用するには
+
+```shell
+make macos
 ```
 
 ### 開発

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 curl -fsSL https://dotfiles.nozo.sh | bash -s -- --full
 ``` -->
 
-</details>
-
 ## Development
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nozomiishii/dotfiles)
@@ -136,7 +134,8 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    ```
 
 4. **Clone private repositories after reboot**  
-   After authenticating with GitHub, clone your private repos:
+   After authenticating with GitHub, clone your private repos.
+   Choose SSH as the protocol in `gh auth login` — `make repo` clones over SSH:
 
    ```shell
    gh auth login
@@ -484,6 +483,18 @@ Clean unused homebrew dependencies up, and upgrade them
 
 ```shell
 make homebrew
+```
+
+Relink dotfiles after editing files under `home/`
+
+```shell
+make link
+```
+
+Reapply macOS system settings
+
+```shell
+make macos
 ```
 
 ### Dev

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -9,24 +9,25 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 ### アカウント
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`home/.gitconfig`](../home/.gitconfig) | `name`, `email` |
 
 ### リポジトリ・bootstrap
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`install.sh`](../install.sh) | `DOTFILES_REPO` を自分の fork URL に。`DOTFILES_DIR` は env override 可能なので、`DOTFILES_DIR=... curl ... \| bash` で別パスにも置ける |
 | [`scripts/clone_github_repos.sh`](../scripts/clone_github_repos.sh) | `make repo` で clone される個人 repo リスト |
 | [`.github/CODEOWNERS`](../.github/CODEOWNERS) | `@nozomiishii` |
 | [`Brewfile`](../Brewfile) | `tap "nozomiishii/tap"` と `cask "nozomiishii/tap/brooklyn"` の個人 tap / cask |
+| [`scripts/homebrew.sh`](../scripts/homebrew.sh) | `trust_brew_bundle_formulae` が `brew trust` する tap 一覧（`nozomiishii/tap/brooklyn` を含む） |
 
 ### npm scoped packages
 
 [lint・format・commit hook の設定を `@nozomiishii/*` 系の scoped package から取っている](https://www.npmjs.com/search?q=%40nozomiishii)。自分用 scoped package を作るか、公開版に差し替える。
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`commitlint.config.ts`](../commitlint.config.ts) | `@nozomiishii/commitlint-config` |
 | [`lefthook.yaml`](../lefthook.yaml) | `@nozomiishii/lefthook-config` |
 | [`prettier.config.ts`](../prettier.config.ts) | `@nozomiishii/prettier-config` |
@@ -36,11 +37,10 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 ### 固定パス（個人 layout 前提）
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`home/.zshrc`](../home/.zshrc) | `PM_CONFIG`（projects.json のパス） |
 | [`home/.config/zellij/layouts/code.kdl`](../home/.config/zellij/layouts/code.kdl) | 各 tab の `cwd="Code/nozomiishii/<name>"` |
 | [`home/Library/Application Support/Code/User/settings.json`](../home/Library/Application%20Support/Code/User/settings.json) | `dotfiles.repository` / `dotfiles.targetPath` / `projectManager.projectsLocation` / `vscode-kubernetes.minikube-path.mac` / `vscode-kubernetes.kubectl-path.mac` / `rufo.exe` |
-| [`home/.agents/skills/backlog/SKILL.md`](../home/.agents/skills/backlog/SKILL.md) | `BRAIN`（brain vault のパス） |
 | [`home/.agents/skills/broadcast/SKILL.md`](../home/.agents/skills/broadcast/SKILL.md) | projects / repos のパス |
 
 ## 任意（個人色、動くが書き換え推奨）
@@ -48,7 +48,7 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 ### 自分の情報
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`home/.npmrc`](../home/.npmrc) | `init-author-name` |
 | [`LICENSE`](../LICENSE) / [`package.json`](../package.json) | 著作権表示・`author` |
 | [`README.ja.md`](../README.ja.md) / [`README.md`](../README.md) | Apple ID セットアップ例の `Full Name`, `Account name` |
@@ -56,9 +56,9 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 ### SNS・bootstrap URL
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | `README.*` | Twitter handle `nozomiishii_dev` |
-| `README.*` | `curl -L https://nozomiishii.dev/dotfiles/install \| bash` の bootstrap URL。独自ドメインを立てないなら `curl -L https://raw.githubusercontent.com/<you>/dotfiles/main/install.sh \| bash` で代用可能 |
+| `README.*` | `curl -fsSL https://dotfiles.nozo.sh \| bash` の bootstrap URL。独自ドメインを立てないなら `curl -fsSL https://raw.githubusercontent.com/<you>/dotfiles/main/install.sh \| bash` で代用可能 |
 | [`home/.config/raycast/scripts/*`](../home/.config/raycast/scripts/) | Raycast script の `@raycast.author` / `@raycast.authorURL` |
 | [`home/.config/tampermonkey/*`](../home/.config/tampermonkey/) | userscript の `@author` / `@namespace` |
 | [`home/Library/Application Support/Code/User/snippets/global.code-snippets`](../home/Library/Application%20Support/Code/User/snippets/global.code-snippets) | TODO snippet の `@nozomiishii`、`cSpell.userWords` |
@@ -66,7 +66,7 @@ repo の置き場所自体は配置非依存にしてあるので([#1057](https:
 ### メタデータ
 
 | ファイル | 内容 |
-|---|---|
+| --- | --- |
 | [`package.json`](../package.json) | `homepage`, `repository.url`, `bugs.url` |
 | [`.devcontainer/Dockerfile`](../.devcontainer/Dockerfile) | `org.opencontainers.image.source` |
 


### PR DESCRIPTION
## 概要

新マシンセットアップの事前調査で見つかったドキュメントの古い記述・不足を修正する。

## 変更内容

- docs/forking.md
  - bootstrap URL を実際の一発コマンド `curl -fsSL https://dotfiles.nozo.sh | bash` に更新（旧 `nozomiishii.dev/dotfiles/install` は現存しない経路）
  - 削除済みの `home/.agents/skills/backlog/SKILL.md` への参照行を削除
  - fork 時に書き換えが必要な箇所として scripts/homebrew.sh の `brew trust` 対象 tap を追記
  - 表の区切り行を `| --- | --- |` に統一（markdownlint MD060 が main の既存記述で 28 件失敗しており、pre-commit の lint-docs が通らないため同時に修正）
- README.md / README.ja.md
  - `make repo` は SSH URL で clone するため、`gh auth login` で SSH を選ぶ前提を「インストール後の作業」に追記
  - Maintenance セクションに `make link`（home/ 編集後の再リンク）と `make macos`（システム設定の再適用）を追記
  - コメントアウトされた details ブロックの残骸である閉じタグ `</details>` を両言語から削除。日本語版のみにあった旧ドメインの目標コメントも削除（dotfiles.nozo.sh で達成済み）

## 検証

- markdownlint-cli2 で 3 ファイルとも 0 issues
- README.md / README.ja.md は同一構成を維持（pre-commit の readme-sync-check 通過）