### PR TITLE
fix: replace defaults keys that no longer work on current macOS

### DIFF
--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -86,14 +86,19 @@ defaults write com.apple.WindowManager EnableStandardClickToShowDesktop -bool fa
 # ----------------------------------------------------------------
 echo "- 🕹 Menu bar" # killall SystemUIServer
 
-# This setting configures the time and date format for the menubar digital clock
-defaults write com.apple.menuextra.clock DateFormat -string "EEE d MMM  h:mm a"
+# Menu bar clock: 曜日 + AM/PM を表示、日付はスペースに余裕がある時だけ
+# (旧 DateFormat キーは現行 macOS では読まれない)
+defaults write com.apple.menuextra.clock ShowDayOfWeek -bool true
+defaults write com.apple.menuextra.clock ShowAMPM -bool true
+defaults write com.apple.menuextra.clock ShowDate -int 0
 
 # Time format 12 hour time: AM/PM
 defaults write NSGlobalDomain AppleICUForce12HourTime -bool true
 
-# Configure the menu bar Items
-defaults write com.apple.systemuiserver menuExtras -array "/System/Library/CoreServices/Menu Extras/TimeMachine.menu"
+# Show Time Machine in the menu bar
+# (System Settings > Control Center の Show in Menu Bar トグルが書くキー。
+#  旧 menuExtras 配列は現行 macOS では読まれない)
+defaults write com.apple.systemuiserver "NSStatusItem VisibleCC com.apple.menuextra.TimeMachine" -bool true
 
 # Not Share Do Not Disturb status across devicess
 defaults write com.apple.donotdisturbd disableCloudSync -bool true
@@ -210,7 +215,9 @@ defaults write com.apple.dock expose-group-apps -bool true
 echo "- 👮 Security & Privacy"
 
 # Turn on Firewall
-sudo defaults write /Library/Preferences/com.apple.alf globalstate -int 1
+# (alf plist への直接書き込みは現行 macOS では反映されず、実際には無効のままだった。
+#  socketfilterfw が現行のインターフェース)
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
 
 # ----------------------------------------------------------------
 # Keyboard
@@ -403,7 +410,8 @@ killall Dock
 killall Finder
 killall SystemUIServer
 # cfprefsd helps an app or the system to read or write to preference files.
-sudo killall cfprefsd
-sudo killall corebrightnessd
+# killall は対象プロセスが居ないと exit 1 になり set -e で終盤に死ぬため握りつぶす
+sudo killall cfprefsd || true
+sudo killall corebrightnessd || true
 
 echo "💻 MacOS setup is complete 🎉"


### PR DESCRIPTION
## 概要

scripts/darwin/macos.sh に、現行 macOS では読まれず黙って無効になっている defaults キーが 3 箇所あった。macOS 26.5 のこのマシンで実際に System Settings が書くキーを確認し、現行の手段に置き換える。あわせて終盤の killall が `set -e` でスクリプトを殺し得る問題を直す。

## 変更内容

- メニューバー時計: `com.apple.menuextra.clock DateFormat` は現行 macOS の plist に存在せず無効。実機で確認した現行キー `ShowDayOfWeek` / `ShowAMPM` / `ShowDate` に置き換え（曜日 + AM/PM 表示、日付はスペースに余裕がある時だけ = 現状の実機状態と同じ）
- Time Machine のメニューバー表示: `com.apple.systemuiserver menuExtras` 配列は旧機構。System Settings > Control Center のトグルが実際に書く `NSStatusItem VisibleCC com.apple.menuextra.TimeMachine` に置き換え（実機の設定値で確認）
- ファイアウォール: `/Library/Preferences/com.apple.alf globalstate` への直接書き込みは反映されておらず、このマシンのファイアウォールは実際には無効のままだった（`socketfilterfw --getglobalstate` で State = 0 を確認）。現行インターフェースの `socketfilterfw --setglobalstate on` に置き換え
- `sudo killall cfprefsd` / `corebrightnessd` に `|| true` を追加。対象プロセスが居ないと exit 1 で終盤に全体が死ぬため

## 変更しなかったもの

- Remote Login の `launchctl load -w ssh.plist` は deprecated だが現行 macOS でも機能しており（CI の macOS runner でも通過）、現行手段の `systemsetup -setremotelogin on` は Full Disk Access を要求するため無人のフレッシュインストールでは逆に止まる。現状維持とした

## 検証

- `bash -n` / shellcheck で指摘なし
- 各置き換えキーは macOS 26.5 の実機で System Settings が書いた値と突き合わせて確認

## 補足

マージ後に `make macos` を実行すると、これまで無効だったファイアウォールが実際に有効化される（挙動変化として認識しておく）