### PR TITLE
chore: pin keyless gh auth login flags in setup docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,10 +135,10 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 4. プライベートリポジトリのクローン  
    再起動が終わったら GitHub で認証して、プライベートリポジトリをクローンしましょう。
-   make repo は SSH URL で clone するため、`gh auth login` では認証方式に SSH を選んでください：
+   フラグで SSH プロトコルを固定し（make repo は SSH URL で clone）、SSH 鍵の生成をスキップし（鍵は 1Password SSH agent 管理）、watch スキルが使う notifications スコープを追加しています。トークンはブラウザ認証で発行され macOS の Keychain に保存されます：
 
    ```shell
-   gh auth login
+   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications
    make repo
    ```
 
@@ -540,7 +540,8 @@ for x in {1..10}; do time zsh -i -c exit; done
 
 2: 後片付け
 
-- GitHub / GitLab に登録した SSH キーを削除してください
+- SSH 鍵は 1Password SSH agent 管理でこのマシンには置いていないため、削除する鍵はありません
+- （任意）[GitHub Settings > Applications](https://github.com/settings/apps/authorizations) で GitHub CLI の認可を失効できます。全マシンの gh トークンが無効になる点に注意してください
 
 3: iCloud からサインアウト
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 4. **Clone private repositories after reboot**  
    After authenticating with GitHub, clone your private repos.
-   Choose SSH as the protocol in `gh auth login` — `make repo` clones over SSH:
+   The flags pin the SSH protocol (`make repo` clones over SSH), skip SSH key generation (keys live in the 1Password SSH agent), and add the `notifications` scope used by the watch skill. The token is issued via the browser and stored in the macOS Keychain:
 
    ```shell
-   gh auth login
+   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications
    make repo
    ```
 
@@ -542,7 +542,8 @@ for x in {1..10}; do time zsh -i -c exit; done
 
 2: Clean up
 
-- Delete SSH keys on GitHub, GitLab
+- SSH keys live in the 1Password SSH agent (nothing is stored on this machine), so there are no keys to delete
+- (Optional) Revoke the GitHub CLI authorization in [GitHub Settings > Applications](https://github.com/settings/apps/authorizations) — note this invalidates gh tokens on every machine
 
 3: Sign out your iCloud.
 

--- a/install.sh
+++ b/install.sh
@@ -183,7 +183,7 @@ printf '%s\n' \
   "" \
   "📦 After restarting, clone your private repositories:" \
   "" \
-  "    1. gh auth login" \
+  "    1. gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications" \
   "    2. make repo" \
   "" \
   ""


### PR DESCRIPTION
## 概要

新マシンの `gh auth login` を対話プロンプト無しで固定し、誤って SSH 鍵をローカル生成する余地をなくす。秘密鍵は 1Password SSH agent のみで管理する方針（[home/.ssh/config](home/.ssh/config) が全ホストで IdentityAgent 指定済み）の総仕上げ。

```shell
gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications
```

- `--git-protocol ssh`: プロトコル選択の質問を固定（make repo は SSH URL で clone）
- `--skip-ssh-key`: 「SSH 鍵を生成/アップロードする?」のプロンプトを出さない（鍵は 1Password 管理）
- `--web`: ブラウザ OAuth に固定。トークンは macOS Keychain に保存される（gh のデフォルト。`--insecure-storage` が平文保存のオプトアウトとして存在する）
- `--scopes notifications`: watch スキルの Issue サブスクライブ（GraphQL `updateSubscription`）に必要。手持ちのスキル・スクリプト・routines を全部洗い、デフォルトスコープ（repo / read:org / gist / workflow）に追加が必要なのはこれだけと確認済み

## 変更内容

- README.md / README.ja.md: 「インストール後の作業」の `gh auth login` をフラグ付きコマンドに置き換え、理由を注記
- install.sh: 完了バナーの案内コマンドも同じものに更新
- README.md / README.ja.md: Reinstall macOS の「Delete SSH keys on GitHub, GitLab」を削除し、鍵はマシンに無い旨と、（任意の）GitHub CLI 認可の失効手順に置き換え（失効は全マシンの gh トークンに効く点を注記）

## 検証

- `bash -n` / shellcheck / markdownlint-cli2 で指摘なし
- フラグは gh 2.96.0 のヘルプで実在を確認済み