### PR TITLE
chore: explain the ssh host key prompt in setup docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -142,6 +142,8 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    make repo
    ```
 
+   初回の SSH 接続では `Are you sure you want to continue connecting?` と聞かれます。fingerprint を [GitHub 公式のホスト鍵一覧](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)と照合して `yes` と答えてください。これで保存されるのは GitHub 側の公開ホスト鍵（`~/.ssh/known_hosts`）だけで、秘密鍵がマシンに保存されるわけではありません。
+
 <a id="install-manually"></a>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    make repo
    ```
 
+   The first SSH connection asks `Are you sure you want to continue connecting?`. Verify the fingerprint against [GitHub's SSH key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) and answer `yes`. This only records GitHub's public host key in `~/.ssh/known_hosts` — it does not save any private key on the machine.
+
 <a id="install-manually"></a>
 
 <details>


### PR DESCRIPTION
## 概要

新マシンで最初に SSH 接続したとき(`make repo` の clone 時)に出る `Are you sure you want to continue connecting?` の確認について、README に説明を追加する。

このプロンプトを見て「秘密鍵がマシンに保存されるのでは」と迷いが生じたため(実際に迷った)、次を明記する:

- fingerprint を GitHub 公式のホスト鍵一覧と照合して yes と答える
- yes で保存されるのは GitHub 側の公開ホスト鍵(`~/.ssh/known_hosts`)だけで、秘密鍵はマシンに保存されない(「鍵は 1Password 管理でマシンに置かない」方針と矛盾しない)

## 変更内容

- README.md / README.ja.md: 「インストール後の作業」ステップ4のコマンドブロック直後に注記を追加

## 検証

- markdownlint-cli2 で 0 issues、両言語同一構成を維持