### PR TITLE
feat: pre-register github host keys for a prompt-free make repo

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -142,7 +142,7 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    make repo
    ```
 
-   初回の SSH 接続では `Are you sure you want to continue connecting?` と聞かれます。fingerprint を [GitHub 公式のホスト鍵一覧](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)と照合して `yes` と答えてください。これで保存されるのは GitHub 側の公開ホスト鍵（`~/.ssh/known_hosts`）だけで、秘密鍵がマシンに保存されるわけではありません。
+   make repo は GitHub の公開ホスト鍵を [GitHub meta API](https://docs.github.com/en/rest/meta/meta#get-apiversion-meta-information) から取得して `~/.ssh/known_hosts` に事前登録するため、`Are you sure you want to continue connecting?` の確認は表示されません。手動の SSH 接続でこの確認が出た場合は、fingerprint を [GitHub 公式のホスト鍵一覧](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)と照合して `yes` と答えてください。保存されるのは接続先の公開ホスト鍵だけで、秘密鍵がマシンに保存されるわけではありません。
 
 <a id="install-manually"></a>
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ curl -fsSL https://dotfiles.nozo.sh | bash
    make repo
    ```
 
-   The first SSH connection asks `Are you sure you want to continue connecting?`. Verify the fingerprint against [GitHub's SSH key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) and answer `yes`. This only records GitHub's public host key in `~/.ssh/known_hosts` — it does not save any private key on the machine.
+   `make repo` pre-registers GitHub's public host keys in `~/.ssh/known_hosts` (fetched from the [GitHub meta API](https://docs.github.com/en/rest/meta/meta#get-apiversion-meta-information)), so the `Are you sure you want to continue connecting?` prompt does not appear. If a manual SSH connection ever shows it, verify the fingerprint against [GitHub's SSH key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) and answer `yes` — it only records the server's public host key, never a private key.
 
 <a id="install-manually"></a>
 

--- a/scripts/clone_github_repos.sh
+++ b/scripts/clone_github_repos.sh
@@ -10,6 +10,16 @@ set -Ceuo pipefail
 
 echo -e "🦄 Initializing Cloning repositories... \n"
 
+# GitHub のホスト鍵を known_hosts に事前登録し、初回 SSH の対話確認 (yes) を無くす。
+# 鍵は TLS で保護された GitHub API から取得する
+# https://docs.github.com/en/rest/meta/meta#get-apiversion-meta-information
+if ! ssh-keygen -F github.com > /dev/null 2>&1; then
+  echo "🦄 Registering GitHub host keys in ~/.ssh/known_hosts"
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  curl -fsSL https://api.github.com/meta | jq -r '.ssh_keys[] | "github.com \(.)"' >> "$HOME/.ssh/known_hosts"
+fi
+
 repos=(
   nozomiishii/dev
   nozomiishii/nozomiishii


### PR DESCRIPTION
## 概要

`make repo` の初回 SSH 接続で出る `Are you sure you want to continue connecting?`（ホスト鍵確認の yes）を無くす。gh auth login にはホスト鍵を扱うフラグが無い（SSH 接続は gh の管轄外）ため、clone の前に GitHub の公開ホスト鍵を known_hosts に事前登録する方式にした。

## 変更内容

- scripts/clone_github_repos.sh: clone ループの前に、known_hosts に github.com のエントリが無ければ [GitHub meta API](https://docs.github.com/en/rest/meta/meta#get-apiversion-meta-information) からホスト鍵 3 本（ed25519 / ecdsa / rsa）を取得して追記する
  - 取得経路は TLS で保護された API で、fingerprint ページと同じ信頼点。`StrictHostKeyChecking=accept-new`（検証なしの初回自動受け入れ）は採らない
  - 判定は `ssh-keygen -F github.com` なので再実行しても重複追記しない
  - jq と curl は実行時点でインストール済み（make repo は brew 後に実行する手順）
- README.md / README.ja.md: #1451 で入れた注記を「make repo が事前登録するので確認は出ない。手動 SSH で出た場合は fingerprint を照合して yes」に更新

## 検証

- スクラッチの HOME で登録 → `ssh-keygen -F github.com` がヒット → 再実行時は追記スキップ、を確認
- `bash -n` / shellcheck / markdownlint-cli2 で指摘なし