### PR TITLE
feat: fall back to gh cli when the github connector is unavailable

### DIFF
--- a/home/.agents/skills/pr/SKILL.md
+++ b/home/.agents/skills/pr/SKILL.md
@@ -17,15 +17,15 @@ pr — Pull Request 当番。CI が落ちていたり、main が進んでいた�
 ## 絶対制約
 
 - マージは実行しない。merge 系の tool / capability を呼ばず、local で base branch へ merge して push するなど他の手段でもマージしない。マージはユーザーが手動で行う
-- GitHub の読み書きは「GitHub へのアクセス」の connector に限る。gh CLI が使える環境でも GitHub 操作に gh を使わない
+- GitHub の読み書きは「GitHub へのアクセス」の backend 選択（connector 優先、不通時は gh CLI fallback）に一元化する
 - PR の状態取得は「状態の収集」の同一 iteration 一括取得に一元化する。トラブルシューティング中でも同じ iteration 内で個別に再取得しない。分割再取得による snapshot ズレを防ぐため
 - force-push は `--force-with-lease` のみ。`--force` は禁止
 
 ## GitHub へのアクセス
 
-GitHub の読み書き（PR の特定・状態取得・CI ログ・レビュー返信・PR 本文更新）は、利用可能な GitHub connector / app を自分で検索して行う。Claude Code の GitHub MCP 名や Codex の GitHub app 名を固定しない。gh CLI が導入・認証済みでも GitHub 操作には使わない。connector 側の tool 単位の無効化（merge 禁止など）を唯一の適用点にするための一元化なので、gh への迂回はこの前提を壊す。
+GitHub の読み書き（PR の特定・状態取得・CI ログ・レビュー返信・PR 本文更新）は、利用可能な GitHub connector / app を自分で検索して行う。Claude Code の GitHub MCP 名や Codex の GitHub app 名を固定しない。connector が使える間は、gh CLI が導入・認証済みでも GitHub 操作には使わない。
 
-connector が見つからない場合は GitHub 操作を始めず、GitHub connector / MCP の設定が必要なことをユーザーに伝えて停止する。gh CLI での代替や、gh の導入・再認証を代替案にしない。
+connector が見つからない・認証切れ・接続失敗の場合は、認証済みの gh CLI に fallback して同じ操作を行う。fallback したことと理由を報告に含める。fallback 中も絶対制約の merge 禁止はそのまま適用される（`gh pr merge`、merge endpoint への `gh api` は実行しない。Claude Code では gh 側の permissions deny でも封じられている）。gh も未認証なら GitHub 操作を始めず、必要な設定をユーザーに伝えて停止する。
 
 local repo の操作（branch 作成、stage、commit、fetch、rebase、push）は引き続き git で行い、connector に置き換えない。
 

--- a/home/.agents/skills/tha/SKILL.md
+++ b/home/.agents/skills/tha/SKILL.md
@@ -13,15 +13,15 @@ model: sonnet
 
 ## GitHub へのアクセス
 
-base branch の解決、ブランチ判定での PR 検索、既存 PR の状態・head 情報の取得、新規 PR 作成、draft 判定、pr skill への引き継ぎ後の状態取得は、利用可能な GitHub connector / app を自分で検索して行う。connector の機能名は固定しない。gh CLI が導入・認証済みでも GitHub 操作には使わない。connector 側の tool 単位の無効化（merge 禁止など）を唯一の適用点にするための一元化なので、gh への迂回はこの前提を壊す。
+base branch の解決、ブランチ判定での PR 検索、既存 PR の状態・head 情報の取得、新規 PR 作成、draft 判定、pr skill への引き継ぎ後の状態取得は、利用可能な GitHub connector / app を自分で検索して行う。connector の機能名は固定しない。connector が使える間は、gh CLI が導入・認証済みでも GitHub 操作には使わない。
 
-connector が見つからない場合は GitHub 操作を始めず、GitHub connector / MCP の設定が必要なことをユーザーに伝えて停止する。gh CLI での代替や、gh の導入・再認証を代替案にしない。
+connector が見つからない・認証切れ・接続失敗の場合は、認証済みの gh CLI に fallback して同じ操作を行う（default branch は `gh repo view --json defaultBranchRef`、PR の検索・作成は `gh pr list` / `gh pr create`）。fallback したことと理由を最後の報告に含める。fallback 中も merge 系（`gh pr merge`、merge endpoint への `gh api`）は実行しない。merge 禁止は backend に依らずこの skill の制約として適用される（Claude Code では gh 側の permissions deny でも封じられている）。gh も未認証なら GitHub 操作を始めず、必要な設定をユーザーに伝えて停止する。
 
-connector が対象 PR に必要な head repository identity または write capability を返せない場合は、fork かを推測せず停止する。local branch の作成、stage、commit、push は引き続き git で行い、connector に置き換えない。
+利用中の backend（connector または gh）が対象 PR に必要な head repository identity または write capability を返せない場合は、fork かを推測せず停止する。local branch の作成、stage、commit、push は引き続き git で行い、connector に置き換えない。
 
 ## base branch の解決
 
-branch 判定より先に、connector の repository metadata capability から default branch 名を `BASE_REF` として取得する。`BASE_REF` が空、または `git check-ref-format --branch "$BASE_REF"` に失敗したら fetch や branch 作成へ進まない。
+branch 判定より先に、利用中の backend の repository metadata capability から default branch 名を `BASE_REF` として取得する。`BASE_REF` が空、または `git check-ref-format --branch "$BASE_REF"` に失敗したら fetch や branch 作成へ進まない。
 
 ## ブランチ判定
 
@@ -48,6 +48,6 @@ base または head が外部 repo、もしくは所有者を判定できない�
 
 ## PR の監視（pr skill へ引き継ぐ）
 
-PR 作成 / push 完了後、sibling の [pr SKILL.md](../pr/SKILL.md) を明示的に読み、その手順で CI 失敗・レビュー指摘・base branch との conflict を修復して mergeable まで持っていく。PR 番号または URL と利用中の connector を引き継ぎ、pr skill の「GitHub へのアクセス」と同じ connector 手順を使う。pr skill は explicit-only のため、catalog から暗黙に選ばせない。
+PR 作成 / push 完了後、sibling の [pr SKILL.md](../pr/SKILL.md) を明示的に読み、その手順で CI 失敗・レビュー指摘・base branch との conflict を修復して mergeable まで持っていく。PR 番号または URL と利用中の backend（connector または gh fallback）を引き継ぎ、pr skill の「GitHub へのアクセス」と同じ backend 選択手順を使う。pr skill は explicit-only のため、catalog から暗黙に選ばせない。
 
 ただし connector が返す PR metadata で draft の場合はスキップする。draft は修正途中である前提なので、CI の失敗を勝手に直さない。


### PR DESCRIPTION
## 概要

tha / pr スキルは GitHub 操作を GitHub connector / MCP に一元化し、gh CLI への迂回を禁止していた。しかし GitHub MCP server (api.githubcopilot.com) は認可サーバーが github.com/login/oauth で Dynamic Client Registration 非対応、Claude Code 側は DCR 必須 ([anthropics/claude-code#26675](https://github.com/anthropics/claude-code/issues/26675)) のため、OAuth トークンが切れた現在は再認証経路が構造的に塞がっており、両スキルは connector 不通で必ず停止する。

connector 優先は維持しつつ、不通時に認証済み gh CLI へ fallback する条項を追加する。旧文面の「connector を唯一の適用点にする」根拠は、merge 禁止が connector の tool 無効化と gh 側の permissions deny (settings.json) の両輪で担保されている現状に合わせて更新した。fallback 中も merge 系の実行禁止は変わらない。

## テスト記録 (skill スキルのドキュメント TDD)

シナリオ: ローカル bare remote を origin に持つ使い捨て repo で「変更をコミットして PR にして」を、作業コピーの SKILL.md とともに subagent へ依頼 (GitHub MCC は実際に不通の実環境)。

- RED (現行版): connector 検索 0 件 →「connector が見つからない場合は GitHub 操作を始めず…gh CLI での代替や、gh の導入・再認証を代替案にしない」を逐語引用してコミットすら行わず停止。実世界の失敗と同型
- GREEN: 上記の停止条項を fallback 条項に置換 (最小変更、両スキル)
- REFACTOR (改訂版): connector 検索 0 件 → `gh auth status` で認証確認 → fallback を採用し理由を報告 → 手順書指定の `gh repo view --json defaultBranchRef` まで実行。停止は fixture の origin が GitHub 実体を持たないことの正しい診断によるもので、本物の push・PR 作成は検証では実行しない方針の範囲内。新しい言い訳・抜け穴なし
- 発動テスト: 両スキルとも description 変更なしのためスキップ
- surface 別: Claude Code local は上記で実動合格 (fallback 分岐まで)。Codex は本文プロースのみの変更で host 固有機能に触れず、host 固有の主張は「Claude Code では gh 側の permissions deny でも封じられている」と明示スコープ済み — 静的合格 (実動未確認)。Codex の merge 抑止は skill 本文と ~/.codex/config.toml の merge tool 無効化が担う

## マージ後の作業

- `home/.agents/**` は cloud 配信対象のため /cloud-bump が必要
- 上流の DCR 問題は #26675 を watch で追跡し、解消したら fallback 条項の要否を見直す (別途追跡 issue を作成)

## 検証

- markdownlint-cli2 で 0 issues