### PR TITLE
chore: request the workflow scope in gh auth login

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,10 +135,10 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 4. プライベートリポジトリのクローン  
    再起動が終わったら GitHub で認証して、プライベートリポジトリをクローンしましょう。
-   フラグで SSH プロトコルを固定し（make repo は SSH URL で clone）、SSH 鍵の生成をスキップし（鍵は 1Password SSH agent 管理）、watch スキルが使う notifications スコープを追加しています。トークンはブラウザ認証で発行され macOS の Keychain に保存されます：
+   フラグで SSH プロトコルを固定し（make repo は SSH URL で clone）、SSH 鍵の生成をスキップし（鍵は 1Password SSH agent 管理）、watch スキルが使う notifications と GitHub Actions の workflow ファイル更新に要る workflow のスコープを追加しています（どちらも gh のデフォルトスコープに含まれません）。トークンはブラウザ認証で発行され macOS の Keychain に保存されます：
 
    ```shell
-   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications
+   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications,workflow
    make repo
    ```
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ curl -fsSL https://dotfiles.nozo.sh | bash
 
 4. **Clone private repositories after reboot**  
    After authenticating with GitHub, clone your private repos.
-   The flags pin the SSH protocol (`make repo` clones over SSH), skip SSH key generation (keys live in the 1Password SSH agent), and add the `notifications` scope used by the watch skill. The token is issued via the browser and stored in the macOS Keychain:
+   The flags pin the SSH protocol (`make repo` clones over SSH), skip SSH key generation (keys live in the 1Password SSH agent), and add the `notifications` scope used by the watch skill plus the `workflow` scope for updating GitHub Actions workflow files (neither is in gh's default scopes). The token is issued via the browser and stored in the macOS Keychain:
 
    ```shell
-   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications
+   gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications,workflow
    make repo
    ```
 

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ printf '%s\n' \
   "" \
   "📦 After restarting, clone your private repositories:" \
   "" \
-  "    1. gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications" \
+  "    1. gh auth login --hostname github.com --git-protocol ssh --skip-ssh-key --web --scopes notifications,workflow" \
   "    2. make repo" \
   "" \
   ""


### PR DESCRIPTION
## 概要

セットアップ手順の `gh auth login` に `workflow` スコープを明示追加する。

`gh auth login --help` で確認したところ、gh のデフォルト最小スコープは `repo` / `read:org` / `gist` のみで、workflow は含まれない。現状のコマンド（`--scopes notifications`）のままだと、新マシンのトークンには workflow スコープが付かず、GitHub Actions の workflow ファイルを gh / HTTPS 経由で更新する操作が失敗する。実際にこのマシンでも `gh auth refresh --scopes notifications` の実行で既存の workflow スコープが落ちた（refresh は追加スコープ集合を置き換えるため）。

## 変更内容

- README.md / README.ja.md: 「インストール後の作業」のコマンドを `--scopes notifications,workflow` に変更し、注記に workflow の理由（どちらもデフォルトスコープ外であること）を追記
- install.sh: 完了バナーの案内コマンドも同じものに更新

## 検証

- `gh auth login --help` でデフォルト最小スコープ（repo / read:org / gist）を確認
- `bash -n` / shellcheck / markdownlint-cli2 で指摘なし

## 補足

#1452（ホスト鍵の事前登録）と同じ段落の近接領域を触るため、マージ順によっては軽微な競合が出る可能性がある（どちらが先でも解消は自明）