### PR TITLE
feat: add cloud-to-local handoff flow to wt skill

### DIFF
--- a/home/.agents/skills/wt/SKILL.md
+++ b/home/.agents/skills/wt/SKILL.md
@@ -28,6 +28,14 @@ repo をまたぐタスクは、同一セッションで worktree を切るよ�
 - 続きは同じブランチ・同じ worktree と会話履歴を開き直す: Claude Code デスクトップは worktree 選択で既存を選ぶ、CLI は `claude --resume <session-id>` を使う。`claude --worktree <名前>` は新しい session を作る操作なので会話再開には使わない。Codex App は元の task を再開し、Codex CLI は `codex resume -C <worktree のパス> <session-id>` を使う。`codex -C` だけでは新規 session になり履歴を引き継がない
 - 背景・残作業・ブランチ名は新セッションの最初のメッセージに書いて渡す
 
+## cloud セッションからローカルへ引き継ぐ
+
+cloud セッションからは、ブラウザ操作・ローカル認証・host 固有ツールなどローカルの capability に到達できない。ローカルでしか実行できないと分かった時点で、代替手段を探さず引き継ぎ prompt を出して停止する。
+
+- 作業途中の変更は commit して push してから引き継ぐ。cloud のコンテナは回収されるため、push していない作業は引き継げない
+- 引き継ぎ prompt は sibling の [task SKILL.md](../task/SKILL.md) の「切り出す内容」に従って自己完結で書き、そのまま貼れる 1 つのコードブロックで出す
+- ローカルで実行するスキルやコマンド、実行する surface (Claude Code デスクトップ / CLI)、対象 repo と branch を明記する
+
 ## 同一セッションで worktree を切る
 
 REPO は対象 repo のルート。SLUG はブランチ名で、呼び出し元の規約に従う (無ければ作業内容の kebab-case)。

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -30,6 +30,7 @@ Claude Code on the web など、ローカルの clone や gh が無いリモー�
 - add_repo の実行は、承認プロンプトへのユーザーの承認をもって同意とする。承認を得られなければその repo の作業を中断して報告し、一時ディレクトリなど代替の置き場へ進まない。
 - subagent からは add_repo の承認を得られない。repo は親セッションで揃えてから dispatch する。
 - gh が無ければ GitHub 操作は GitHub MCP の同等ツールに読み替え、gh コマンドの引数をそのままパラメータに写す。gh が省略時に default branch へ解決する base などは、対象 repo の実際の default branch を指定する。
+- ローカルでしか実行できない作業 (ブラウザ操作、ローカル認証、host 固有ツール) に当たったら、口頭の案内で終わらせず /wt スキルの手順で引き継ぎ prompt を出して停止する。
 
 ## dotfiles の実体パス
 `~/.claude/` 配下の設定はシンボリックリンクで、実体は `~/Code/nozomiishii/dotfiles/home/` 配下にある。編集は実体パスで行う。


### PR DESCRIPTION
## 概要

cloud セッションでローカルでしか実行できない作業に当たったとき、口頭の案内で終わらせず引き継ぎ prompt を出して停止するフローを追加する。

- `home/AGENTS.md`「cloud セッション」: 発火条件を 1 行追加。発動条件は常時ロードされる場所に無いと機能しないため、スキル本文ではなくここに置く
- `home/.agents/skills/wt/SKILL.md`: 「cloud セッションからローカルへ引き継ぐ」節を追加。prompt に含める項目は [task SKILL.md](https://github.com/nozomiishii/dotfiles/blob/main/home/.agents/skills/task/SKILL.md) の「切り出す内容」を正本として参照し、二重管理にしない

## テスト記録 (/skill のドキュメント TDD)

- RED (観察された失敗): cloud セッションの実挙動。PR #1483 マージ後に /cloud-bump が実行不能と判明した際、引き継ぎ prompt を出さず「デスクトップまたは CLI のローカルセッションで /cloud-bump を実行してください」という口頭案内で終えた
- GREEN: 観察された失敗のみに対処する 2 箇所の追記 (9 行)
- REFACTOR (読者テスト): 更新版の作業コピー (AGENTS.md + wt/task/oss スキル) だけを参照させた subagent に、同じ状況を現実の依頼として提示。AGENTS.md → wt → task の順に参照し、「切り出す内容」の項目 (達成する結果・対象 repo/PR・制約と完了条件・commit/PR の要否) を満たす自己完結 prompt を 1 つのコードブロックで出力、surface (Claude Code デスクトップ) を明記して停止した。代替手段の探索なし、新しい言い訳・抜け穴なし
- 発動テスト: wt の description は未変更。発火経路は AGENTS.md の追記行で、読者テストで /wt 本文への到達を確認
- surface 別: Claude Code cloud = 実動合格。Claude Code local / Codex = 静的合格 (実動未確認)。追加節は prose と sibling 相対リンクのみで、同ファイル既存の oss 参照と同じパターン。frontmatter・ツール・引数の変更なし

## 検証

- prettier: pass (変更 2 ファイル)
- markdownlint: 追加行への新規指摘なし (`home/AGENTS.md` の既存 17 件は main と同一でスコープ外)

## マージ後

`home/AGENTS.md` と `home/.agents/skills/**` は [cloud-setup.yaml](https://github.com/nozomiishii/dotfiles/blob/main/.github/workflows/cloud-setup.yaml) の `paths` に含まれるため、マージ後に /cloud-bump の実行が必要。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdRsL54uGjedGEiuELy7r8)_