### PR TITLE
fix: manage routine connectors on the trigger side only

### DIFF
--- a/home/.agents/skills/routine/SKILL.md
+++ b/home/.agents/skills/routine/SKILL.md
@@ -71,7 +71,7 @@ name とファイル名を `<頻度>-<対象>` の形に揃える。頻度語は
 - 実行頻度の妥当性（daily / weekly / monthly、曜日・時刻）
 - model の選定（調査・要約中心なら sonnet、判断・分析が必要なら opus）
 - 既存 routine と責務が被らないか（`.routines/` の一覧を見て確認）
-- connector の要否。既定は無し。prompt の手順が MCP ツールを必要とするときだけ足す
+- connector の要否。既定は無し。prompt の手順が MCP ツールを必要とするときだけ使う。使う connector は prompt 本文の前提に書く。これが merge 後に trigger を設定するときの正本になる
 - エラー時の振る舞い（部分的な結果で続行するか、止めるか）
 
 #### monthly の発火日を決める
@@ -107,7 +107,7 @@ routine を 4 つの型のどれかに分類する。型ごとの雛形が `.rou
 `.routines/_templates/<type>.md` をコピーし、`<...>` の placeholder と各セクションを埋める。
 
 - `repos` には対象 repo と `nozomiishii/brain` の両方を含める
-- `connectors` には使う connector 名だけを書く。使わないなら `[]`
+- `connectors` キーは frontmatter に書かない。schema（`scripts/schemas/claude/routines.ts`）に無いキーは pre-commit の lint で落ちる。使う connector は prompt 本文の前提に書き、merge 後の trigger 登録時に設定する
 - schedule の cron は UTC で書き、コメントに JST を添える（20:00 UTC = 翌日 05:00 JST。日またぎで曜日・日付がずれる点に注意）
 - 雛形にないセクションの追加は自由。雛形の必須セクションを削る場合は理由をユーザーと合意する
 
@@ -147,9 +147,9 @@ cloud trigger を create / update する前に、brain repo で `git fetch origi
 - repos: 対象 repo + nozomiishii/brain
 - schedule: frontmatter と同じ cron
 - model: frontmatter と同じ model
-- connectors: frontmatter と同じ connector
+- connectors: prompt 本文の前提に書いた connector
 
-trigger を新規作成すると、アカウントで有効な connector がすべて自動で付く。connector が付いた routine は実行中にその全ツールを無確認で使えるため、作成直後に [Routine 管理画面](https://claude.ai/code/routines) の Edit を開き、frontmatter の `connectors` と一致させる。API では connector を変更・削除できない。
+trigger を新規作成すると、アカウントで有効な connector がすべて自動で付く。connector が付いた routine は実行中にその全ツールを無確認で使えるため、作成直後に [Routine 管理画面](https://claude.ai/code/routines) の Edit を開き、prompt 本文の前提に書いた connector だけに絞る。API では connector を変更・削除できない。
 
 ### 発火時刻の確認
 
@@ -173,8 +173,9 @@ diff がない場合（直接 frontmatter を変更する依頼の場合）は�
 
 - `model` → `job_config.ccr.session_context.model`（frontmatter 値に `claude-` を prefix）
 - `schedule` → `cron_expression`
-- `connectors` → `mcp_connections`。API では変更できないため [Routine 管理画面](https://claude.ai/code/routines) の Edit で操作する
 - `type` → 同期しない（`.routines/` ローカル専用のフィールド）
+
+connector は frontmatter に無いため、この同期の対象外。変更するときは [Routine 管理画面](https://claude.ai/code/routines) の Edit で操作する。API では変更できない。
 
 update 時は `environment_id` を既存 trigger から取得して含める（API が要求するため）。照合できない routine はスキップし、ユーザーに報告する。
 
@@ -186,7 +187,7 @@ schedule を update した場合は、レスポンスの `next_run_at` を JST �
 
 新規追加・変更・同期のどの経路でも、終了前に必ず実行する。結果は差分ゼロでも表で提示する。表を出さずに終了していたらチェック漏れ。
 
-「trigger 操作の選択」で選んだ手段で全 trigger を list し、`.routines/` の全 frontmatter と突き合わせる。
+「trigger 操作の選択」で選んだ手段で全 trigger を list し、`.routines/` の全ファイルと突き合わせる。
 
 検証項目:
 
@@ -194,7 +195,7 @@ schedule を update した場合は、レスポンスの `next_run_at` を JST �
 - `schedule`: frontmatter の cron と trigger の `cron_expression` が一致するか
 - `model`: frontmatter の model と trigger の `session_context.model` が一致するか（`claude-` prefix を考慮）
 - `repos`: frontmatter の repos と trigger の `sources` が一致するか
-- `connectors`: frontmatter の connectors と trigger の `mcp_connections` が一致するか
+- `connectors`: trigger の `mcp_connections` が prompt 本文の前提に書いた connector だけになっているか。新規作成時に全 connector が自動で付くため、余分が残りやすい
 - `prompt`: trigger の events に `.routines/<name>.md を Read し、その指示に従って実行お願い。` が設定されているか
 
 trigger 側で値が未設定の場合も差分として扱う。
@@ -205,7 +206,7 @@ trigger 側で値が未設定の場合も差分として扱う。
 
 - routine prompt は brain repo `.routines/` が正本。cloud trigger に prompt 本文を直接書かない
 - frontmatter の `repos` に `nozomiishii/brain` を必ず含める
-- trigger の connector は frontmatter の `connectors` に揃える。新規作成では自動で付くため必ず確認する
+- connector は frontmatter に書かず、trigger 側でだけ設定する。使う connector の正本は prompt 本文の前提。新規作成では全 connector が自動で付くため必ず絞る
 - monthly の発火日は JST 2〜28 日から空き日を選び、name とファイル名の 2 桁に入れる
 - cron は UTC で記述し、JST をコメントで添える
 - frontmatter を変更したら main への merge 後に skill を再実行し、cloud trigger も必ず同期する


### PR DESCRIPTION
## 問題

routine スキル ([home/.agents/skills/routine/SKILL.md](https://github.com/nozomiishii/dotfiles/blob/main/home/.agents/skills/routine/SKILL.md)) が「`connectors` には使う connector 名だけを書く。使わないなら `[]`」と frontmatter への記載を指示していたが、brain repo の [scripts/schemas/claude/routines.ts](https://github.com/nozomiishii/brain/blob/main/scripts/schemas/claude/routines.ts) は `z.strictObject({ model, name, repos, schedule, type })` で未知キーを弾くため、指示どおりに書くと pre-commit の lint-frontmatter で落ちる。既存 routine 18 本と雛形 4 本のいずれにも `connectors` キーは無い。#1428 で追加された記述が schema と不整合のまま入っていた。

## 対応

運用実態 (connector は cloud trigger 側でのみ管理) に合わせて SKILL.md 側を修正。connectors への言及 6 箇所を一貫して書き換えた。

- frontmatter に `connectors` キーを書かせる指示を削除。schema に無いキーは lint で落ちることを明記
- 使う connector の正本は routine prompt 本文の「前提」に置く (repo 側に残る唯一の記録で、merge 後の別セッションから trigger 設定時に参照できる)
- trigger 登録・同期・整合性チェック・制約の各セクションを frontmatter 前提から trigger 側管理へ書き換え。新規作成時に全 connector が自動で付くため Edit で絞る運用は維持

schema に `connectors` を足す案は、既存 18 routine の運用実態 (frontmatter に無い) と brain 側の変更が必要になる点から不採用。

## テスト記録 (/skill のドキュメント TDD)

### RED (現行版で失敗を再現)

使い捨て環境 (現行 SKILL.md の作業コピー + brain repo の一時コピー、git init + local bare remote) で、subagent に現実の依頼として「Linear MCP connector を使う weekly routine の追加」を投げた。

- 観察された失敗: 指示どおり frontmatter に書くと lint が落ちることに行き当たり、手順書から逸脱して自力のワークアラウンド (prompt 本文へ記載) を取った上で「`connectors` の扱い (frontmatter に書かない / schema に足す) を決めてから進めるのがよいです」とユーザーへのエスカレーションでフローが停止した
- 指示を文字どおり実行した場合の実証: `connectors: [linear]` を frontmatter に足して lint を実行 → `(root): Unrecognized key: "connectors"` で exit 1

### GREEN → REFACTOR (編集版で読者テスト)

編集後の SKILL.md で同一の依頼を別 subagent に実行。

- frontmatter に `connectors` キーを書かず、lint 一発通過 (`ok: 1 file(s) checked`。親側でも再実行して確認)
- エスカレーションなしで完走。Linear connector の必要性を prompt 本文の前提に記載
- merge 後の手順として「trigger 作成 → 管理画面 Edit で prompt 前提の connector だけに絞る → 整合性チェックの connectors 行で検証」を正しく説明
- 読んだファイルは全て作業コピー配下。報告内容が編集版にしかない記述に沿っており、旧版 (インストール済み) の混入なし

### 発動テスト

description は未変更。回帰確認として、description 一覧だけを見せた subagent に 8 発話を判定させた。

- 発動すべき 4 件 (「routine を追加したい」「/routine <name> sync」「定期実行つくりたい」「.routines/ の schedule を変えたい」) → すべて routine
- 発動すべきでない 4 件 (shell cron スクリプト作成、Codex automation 設定、5 分ごとのポーリング、学びのメモ) → なし / loop / note へ正しく分岐

### 最終検証 (Claude Code / Codex 同等性)

参照した公式情報 (いずれも 2026-08-05 に取得):

- Agent Skills 標準: <https://agentskills.io/specification> (frontmatter 必須キーは name / description)
- Claude Code: <https://code.claude.com/docs/en/skills> (frontmatter reference に name / description / argument-hint を確認)
- Codex: <https://learn.chatgpt.com/docs/build-skills> (frontmatter 必須は name / description、追加 metadata は agents/openai.yaml 側)

| 項目 | Claude Code | Codex |
| --- | --- | --- |
| frontmatter (name / description / argument-hint) | 変更なし。実動合格 (本セッションで skill 一覧に正しく載っている) | 変更なし。静的合格 (name / description は仕様内。argument-hint は Claude Code 拡張で従来から配置済み・今回の変更対象外) |
| 本文の編集箇所 (connector の管理手順) | 実動合格 (REFACTOR 読者テスト) | 静的合格・実動未確認 (編集文はホスト中立。Routine 管理画面の操作は既存の「trigger 操作の選択」の Codex 分岐に従う。今回未変更) |
| 発動 (description) | 実動合格 (発動テスト 8/8) | 静的合格 ($routine 明示時のみの記述は未変更) |

判定: 静的同等・Codex は実動未確認。Claude Code surface のみ実動合格。

## merge 後

- この PR は [cloud-setup.yaml](https://github.com/nozomiishii/dotfiles/blob/main/.github/workflows/cloud-setup.yaml) の paths (`home/.agents/**`) に該当するため、merge 後に `/cloud-bump` の実行が必要
