### PR TITLE
feat: add user profile reference to global AGENTS.md

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -26,6 +26,10 @@
 ## Agents設定
 - 必ずclaude code、codexどちらでも同じ挙動になるように作る。
 
+## ユーザープロフィール
+
+ユーザー本人や開発環境の情報が必要なときは `~/Code/nozomiishii/brain/brain/PROFILE.md` を参照する。
+
 ## 外部リポジトリ
 - 外部リポジトリを変更する操作は /oss スキルを使用する
 


### PR DESCRIPTION
## 概要

グローバル指示ファイル `home/AGENTS.md` (`~/.claude/CLAUDE.md` の実体) に、ユーザープロフィールを参照するセクションを追記する。

- プロフィール本体はユーザープロフィール `brain/PROFILE.md` として private の brain リポジトリに新設: nozomiishii/brain#402
- dotfiles は public リポジトリのため、個人情報はプロフィール本体 (brain) に置き、ここには参照指示のみを追記する
- 毎セッション必読にはせず、「必要なときに参照する」形にする
- Codex は AGENTS.md 内の `@path` import 記法をサポートしないため、プレーンパスのテキスト指示にする

## 追記位置

当初の指定は「`## dotfiles の実体パス` セクションの直後」だったが、同セクションは #1493 で削除済み。さらに #1495 の全面改稿を取り込んだため、現構成で参照系セクションの並びとなる「## Agents設定」の直後・「## 外部リポジトリ」の直前に置いた。

## マージ後の作業

`home/AGENTS.md` は cloud 配信対象 (`.github/workflows/cloud-setup.yaml` の `paths` に含まれる) のため、**マージ後に `/cloud-bump` の実行が必要**。bump しない限り、cloud の新規セッションは最大 7 日前のスナップショットで起動する。