### PR TITLE
chore: point projects.json references to the infra repo

### DIFF
--- a/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
+++ b/docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md
@@ -10,7 +10,7 @@ Date: 2026-07-24
 ## Decision — 決めたこと
 
 - 新しいリポジトリ作成のフローの正本を new-repo スキルに置く
-- 役割分担: リポジトリの作成・設定・保護は nozomiishii/infra の `locals.repositories`、ローカル登録は nozomiishii/workspaces の `projects.json`、初期セットアップは configs 一式 + nozomiishii/workflows を呼ぶ標準 workflow
+- 役割分担: リポジトリの作成・設定・保護は nozomiishii/infra の `locals.repositories`、ローカル登録は nozomiishii/infra の `projects.json`、初期セットアップは configs 一式 + nozomiishii/workflows を呼ぶ標準 workflow
 - GitHub を直接操作する作成・設定変更(`gh repo create` / `gh repo edit` / ruleset API)は禁止として明文化する
 - ブートストラップは `auto_init` 前提(判断は [infra の ADR](https://github.com/nozomiishii/infra/blob/main/docs/decisions/リポジトリ作成時に%20auto_init%20で%20initial%20commit%20を作る.md))
 - `@nozomiishii/cspell-config` と `@nozomiishii/markdownlint-cli2-config` は非推奨のため新規リポジトリに導入しない

--- a/home/.agents/skills/broadcast/SKILL.md
+++ b/home/.agents/skills/broadcast/SKILL.md
@@ -3,7 +3,7 @@ name: broadcast
 description: >-
   projects.json で管理されている複数の独立 repo に、同じ変更を横断適用（broadcast）する。
   「workspaces のプロジェクト全部に〜したい」「横断で〜入れたい」と言ったときに使用する。
-  第 1 引数が既存ディレクトリならその配下の projects.json を、それ以外は nozomiishii/workspaces clone の projects.json を対象にする。
+  第 1 引数が既存ディレクトリならその配下の projects.json を、それ以外は nozomiishii/infra clone の projects.json を対象にする。
   Claude Code bundled の /batch（1 つの repo を複数ユニットに分解して worktree 並列実行）とは別物。こちらは N 個の repo への同一変更 broadcast。
 ---
 
@@ -20,7 +20,7 @@ projects.json に列挙された `enabled: true` の全プロジェクト（そ�
 ```
 
 - 第 1 引数が既存ディレクトリ → そこを `<projects-json-dir>` として `<dir>/projects.json` を読む
-- 第 1 引数がディレクトリでない → 全引数を指示として扱い、git remote が `nozomiishii/workspaces` を指す clone を現在の task、ホストの project 一覧、既存の local clone の順で探して `<projects-json-dir>` にする
+- 第 1 引数がディレクトリでない → 全引数を指示として扱い、git remote が `nozomiishii/infra` を指す clone を現在の task、ホストの project 一覧、既存の local clone の順で探して `<projects-json-dir>` にする
 - 第 1 引数がパスの形なのにローカルに無い場合（cloud セッション等）→ デフォルトに切り替えず、どの projects.json を使うかユーザーに確認して止まる
 - 指示部分が空のとき → ユーザーに「何を適用するか」を聞いて止まる（projects.json の一覧だけ読み込んで提示してよい）
 
@@ -35,7 +35,7 @@ jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSO
 - `rootPath` は文字列型に限定し、NUL・改行などの control character を拒否する。先頭の `~/` だけを literal に `$HOME/` へ置換する。`eval`、`source`、`bash -c`、shell の再評価は禁止。置換後が絶対 path でなければ除外する
 - `rootPath` は projects.json 由来の信頼できない入力として扱う。展開後に `realpath` で正規化し、symlink を含む path、存在しない directory、`git -C <path> rev-parse --show-toplevel` が同じ realpath を返さない entry を除外する。`home` のような repo 内 subdirectory と `Desktop` のような非 repo は変更対象にせず、skip 理由を報告する
 - 各 repo の `remote.origin.url` から owner / repo を取り、`nozomiishii/<正規化した rootPath の basename>` と一致することを確認する。`name` は絵文字を含む表示名なので identity 判定に使わない。projects.json だけを信頼して command を実行しない
-- デフォルトの projects.json が無い cloud セッションでは、ホストに repo 追加機能があれば nozomiishii/workspaces を追加し、PROJECTS_JSON を clone 先のパスに読み替える。機能が無ければ対象を推測せず停止する。読めるのは push 済みの版である旨を対象リストの提示に添える
+- デフォルトの projects.json が無い cloud セッションでは、ホストに repo 追加機能があれば nozomiishii/infra を追加し、PROJECTS_JSON を clone 先のパスに読み替える。機能が無ければ対象を推測せず停止する。読めるのは push 済みの版である旨を対象リストの提示に添える
 
 ## 対象リストを提示する
 
@@ -99,7 +99,7 @@ jq -r '.[] | select(.enabled == true) | "\(.name)\t\(.rootPath)"' "$PROJECTS_JSO
 
 ## 制約
 
-- `projects.json` を編集しないこと。skill の責務は projects.json を「読む」ことだけで、プロジェクト一覧の追加/削除はユーザーが `nozomiishii/workspaces` repo で行う
+- `projects.json` を編集しないこと。skill の責務は projects.json を「読む」ことだけで、プロジェクト一覧の追加/削除はユーザーが `nozomiishii/infra` repo で行う
 - PR のマージは絶対に実行しない（tha・pr skill の制約と同じ）
 - git 操作は `cd <path> && git` でなく `git -C <path>` を使う（bare repository attack 防止の sandbox 制約）
 - worktree では main や別 branch に切り替えず、切り出し時に作成した task branch を使う

--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -33,9 +33,9 @@ clone して次を揃え、1 つの PR にする。完成形の実例は直近�
 - SessionStart hook: `.claude/settings.json` と `.hooks/setup.sh` (`pnpm install`)。
 - README.md と README.ja.md を同じ構成で作る。
 
-## 登録 (workspaces)
+## 登録 (infra)
 
-- nozomiishii/workspaces の `projects.json` にエントリを追加する PR を作る。別 repo の変更なので /wt の切り出しに従う。
+- ローカル登録も infra が正本。`stacks/github/main.tf` の `locals.repositories` と repo 直下の `projects.json` は、リポジトリ作成と同じ 1 つの PR で両方更新する。
 
 ## リリースフロー
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -69,7 +69,7 @@ fi
 # 未導入のマシンでも zsh が起動できるようガードする。source の行は pm installer が
 # 追記済み判定に使うマーカーなので、この文字列のまま変えない
 # https://github.com/nozomiishii/pm/blob/main/install.sh
-export PM_CONFIG="$HOME/Code/nozomiishii/workspaces/projects.json"
+export PM_CONFIG="$HOME/Code/nozomiishii/infra/projects.json"
 export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
 if [[ -r "${XDG_CONFIG_HOME:-$HOME/.config}/pm/pm.zsh" ]]; then
   # shellcheck source=/dev/null

--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -22,7 +22,7 @@
   // ----------------------------------------------------------------
   // vscode project manager
   // ----------------------------------------------------------------
-  "projectManager.projectsLocation": "~/Code/nozomiishii/workspaces",
+  "projectManager.projectsLocation": "~/Code/nozomiishii/infra",
   "projectManager.sortList": "Saved",
 
   // ----------------------------------------------------------------


### PR DESCRIPTION
## 概要

`projects.json` を nozomiishii/workspaces から nozomiishii/infra 直下に移設した (https://github.com/nozomiishii/infra/pull/164) のに合わせ、dotfiles 側の参照先を切り替える。workspaces repo は archive する。

`projectsLocation` = repo root という前提は変わらないため、向き先の差し替えだけで済む。

## 変更

| ファイル | 内容 |
| --- | --- |
| `home/.zshrc` | `PM_CONFIG` を `$HOME/Code/nozomiishii/infra/projects.json` に |
| `home/Library/Application Support/Code/User/settings.json` | `projectManager.projectsLocation` を `~/Code/nozomiishii/infra` に |
| `home/.agents/skills/broadcast/SKILL.md` | デフォルトの projects.json 探索先と、一覧の追加/削除を行う repo を infra に |
| `home/.agents/skills/new-repo/SKILL.md` | 「登録 (workspaces)」→「登録 (infra)」。`stacks/github/main.tf` の `locals.repositories` と repo 直下の `projects.json` を infra の同一 PR で両方更新する内容に変更。別 repo ではなくなったので /wt の切り出し指示を削除 |
| `docs/decisions/新しいリポジトリ作成のフローは new-repo スキルを正本にする.md` | 役割分担のローカル登録先を infra に |

## マージ順序

**infra の https://github.com/nozomiishii/infra/pull/164 が merge された後に merge する。**

先に merge すると `~/Code/nozomiishii/infra/projects.json` が main の checkout に存在せず、`pm` と VS Code Project Manager 拡張が壊れる。`~/.zshrc` と VS Code の `settings.json` は dotfiles 作業ツリーへの symlink なので、merge した時点で即反映される。

## 対象外

- `docs/forking.md` の固定パス表 (41, 43, 44 行): どのファイルに個人パスがあるかを示すだけで値そのものを書いていないため、変更不要
- `scripts/darwin/macos.sh` の `Code/User/projects.json` symlink: リンク先の実体が存在しない dead code で、今回の変更とは独立した別件
- `home/.agents/skills/broadcast/SKILL.md` の description にあるトリガー発話「workspaces のプロジェクト全部に〜したい」: repo 参照ではなくユーザーの発話例のため据え置き。変更するなら発動テストが要るので別途判断したい

## テスト記録

skill スキルが要求する RED / REFACTOR / 発動テストは未実施。作成セッションが subagent の利用を禁止されているため実行できなかった。

変更の大半は repo 名とパスの差し替えだが、`new-repo` の「登録」節だけは手順自体が変わっている (別 repo の PR → infra の同一 PR、/wt の切り出し不要)。この節の読者テストは別セッションで実施したい。

## cloud-bump

`home/.agents/**` に触れるため、merge 後に `/cloud-bump` が必要。
