### PR TITLE
fix: state the new-repo registration target as the infra repo root

### DIFF
--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -35,7 +35,7 @@ clone して次を揃え、1 つの PR にする。完成形の実例は直近�
 
 ## 登録 (infra)
 
-- ローカル登録も infra が正本。`stacks/github/main.tf` の `locals.repositories` と repo 直下の `projects.json` は、リポジトリ作成と同じ 1 つの PR で両方更新する。
+- ローカル登録も infra が正本。infra の `stacks/github/main.tf` の `locals.repositories` と、infra 直下の `projects.json` を、リポジトリ作成と同じ 1 つの PR で両方更新する。新しく作る repo 側には `projects.json` を置かない。
 
 ## リリースフロー
 


### PR DESCRIPTION
## 概要

#1508 で書いた `new-repo` スキルの「登録 (infra)」節に曖昧さがあったので直す。読者テスト (skill スキルの REFACTOR) で検出した。

`repo 直下の projects.json` の "repo" が、infra なのか新規作成する repo なのか一意に読めていなかった。

```diff
-- ローカル登録も infra が正本。`stacks/github/main.tf` の `locals.repositories` と repo 直下の `projects.json` は、リポジトリ作成と同じ 1 つの PR で両方更新する。
+- ローカル登録も infra が正本。infra の `stacks/github/main.tf` の `locals.repositories` と、infra 直下の `projects.json` を、リポジトリ作成と同じ 1 つの PR で両方更新する。新しく作る repo 側には `projects.json` を置かない。
```

## テスト記録

#1508 が未実施のまま merge した RED / REFACTOR / 発動テストを、この PR で実施した。

### シナリオ

「新しいリポジトリ `nozomiishii/palette` (private、CLI ツール用) を作りたい。作成から、普段使っている VS Code / ターミナルのプロジェクト一覧に出るようにするところまでの手順を示して」

作業コピーを一時ディレクトリに置き、subagent にはそのパスのファイルだけを読ませた。実際の repo 作成・PR 作成・`gh` / `tofu` の実行は禁止し、計画のみ出させた。

### RED (#1508 適用前の SKILL.md)

意図した失敗を再現した。

- 「`nozomiishii/workspaces` の `projects.json` にエントリを追加する PR を作る」「別 repo の変更なので `/wt` の切り出しに従う」と計画
- archive 予定の repo を 3 つ目の PR 対象に据えた

### REFACTOR (#1508 適用後の SKILL.md)

infra の同一 PR という結論には到達したが、次の指摘が出た。

> 「repo 直下の `projects.json`」の repo が特定できない。「ローカル登録も infra が正本」という文脈から infra リポジトリ自身の直下と解釈しましたが、palette リポジトリ自身の直下を指す可能性、あるいは infra でも palette でもない第三のリポジトリ (プロジェクト一覧を集約する別リポジトリ) を指す可能性も文面上排除できません。

これが本 PR で直した欠陥。

### 再テスト (本 PR 適用後)

同じシナリオで、曖昧さの指摘は消えた。

- `projects.json` の場所を「`nozomiishii/infra` リポジトリ直下 (root)」と一意に特定し、本文を根拠として引用した
- 「リポジトリ作成の PR と同じ PR」と正しく回答した

### 発動テスト (broadcast の description)

#1508 で broadcast の description 本文を変更した (`nozomiishii/workspaces clone` → `nozomiishii/infra clone`) ため実施。本文は見せず、インストール済みスキルの description 一覧に混ぜて判定させた。

| 発話 | 期待 | 結果 |
| --- | --- | --- |
| infra の projects.json に載ってる repo 全部に CODEOWNERS 入れたい | broadcast | broadcast |
| workspaces のプロジェクト全部に renovate 設定入れて | broadcast | broadcast |
| 横断で lefthook のバージョン揃えたい | broadcast | broadcast |
| プロジェクト一覧の repo 全部に同じ workflow 配りたい | broadcast | broadcast |
| infra の projects.json に新しいエントリ追加して | broadcast 以外 | wt (broadcast の誤発動なし) |
| infra repo の terraform を直したい | broadcast 以外 | wt (broadcast の誤発動なし) |
| 新しい repo 作りたい | new-repo | new-repo |
| dotfiles の worktree 片付けて | wt | wt |

不発動・誤発動はなし。「infra」「projects.json」という語が重なる 5 番でも、「projects.json 自体の編集は broadcast の対象外」と正しく切り分けた。

### テストの限界

skill スキルは、読み込み元の canonical path を親が host trace や invocation metadata から客観確認するよう求めているが、この環境ではそれができず、subagent の自己申告に留まっている (4 本とも一時コピーのみを読んだと報告)。使い捨て profile・skill root での隔離も行えていない。実動テストとしての厳密性はその分低い。

### 対象 surface の最終検証

未実施。今回の変更は本文 1 行の言い換えで、frontmatter・ツール名・引数展開・ホスト固有機能のいずれにも触れていないため、Claude Code / Codex 間で挙動差が出る変更ではないと判断した。公式ドキュメントの取得による静的検証は行っていないので、両ホスト実動同等とは主張しない。

## cloud-bump

`home/.agents/**` に触れるため、merge 後に `/cloud-bump` が必要。
