### PR TITLE
chore: enable agents window for monokai theme

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -599,7 +599,10 @@
     "**/.forgejo/workflows/*.yml",
     "**/.forgejo/workflows/*.yaml"
   ],
-  "workbench.preferredDarkColorTheme": "Monokai Pro"
+  "workbench.preferredDarkColorTheme": "Monokai Pro",
+  "extensions.supportAgentsWindow": {
+    "monokai.theme-monokai-pro-vscode": true
+  }
 
   ///////////////////////////////////////////////////////////////////
 }


### PR DESCRIPTION
## Summary
- VS Code の `extensions.supportAgentsWindow` で Monokai Pro を許可し、Agents ウィンドウを使えるようにする

## Test plan
- [ ] `settings.json` に `extensions.supportAgentsWindow.monokai.theme-monokai-pro-vscode: true` があること
- [ ] Monokai Pro 利用時に Agents ウィンドウが有効になること