### PR TITLE
feat: request cloud-bump approval via AskUserQuestion in Claude Code

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -31,6 +31,8 @@ cloud 配信対象に触れる PR を作成した時点では bump せず、マ�
 
 Claude Code / Codex とも、`claude.ai/code` を開いた tab ID と bootstrap URL を最初に固定する。全 read、network 観察、fetch、click の直前に、固定した tab ID・`https://claude.ai` origin・`/code` で始まる path が一致することを確認する。不一致なら環境設定を送受信せず停止する。
 
+Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。
+
 Codex で承認を求めるときは、ユーザーへ「`$cloud-bump 承認` と返信してください」と案内して turn を終える。次の発話で skill を明示的に再起動し、Chrome 接続と GET 結果が承認前と一致することを確認してから POST する。単なる「承認します」という返信を、skill を再読せずに処理しない。
 
 ## init_script の更新 (内部 API)


### PR DESCRIPTION
# 概要

cloud-bump の POST 前差分承認を、Claude Code ではテキスト返信でなく AskUserQuestion (選択式 UI) で求めるようにする。Codex のテキスト承認フロー (`$cloud-bump 承認`) は AskUserQuestion が無い host なので変更しない。

変更は「権限」節への 1 段落の追加のみ。frontmatter・description・Codex 段落・JS ブロックは不変。

# テスト記録 (/skill のドキュメント TDD)

## インタビュー

省略。依頼文に発動場面・前提・置き場・完成イメージ (承認して POST する / キャンセル の 2 択、差分の可視化、ターンまたぎ安全策の維持) が全て一意に書かれていたため。

## RED: 現行版で失敗を再現

- シナリオ: 現行版 SKILL.md の作業コピーを一時ディレクトリに置き、スキルを与えない subagent (sonnet — frontmatter `model: sonnet` の実運用読者と同じ) に「この作業コピーに従って init_script を bump して」と現実の依頼として投げた。ブラウザ不可のため GET 結果は fixture (digest・環境名・bump 行) で代替し、POST 直前で停止させた
- 観察された失敗 (逐語): 差分を表で提示した後、**「「承認します」等でお答えください。」** とテキスト返信の承認を要求した。選択式 UI は使われなかった
- 読み込み元の客観確認: subagent transcript (`agent-aa7e64c5824b36271.jsonl`) の tool_use を親が抽出。Read は作業コピーの canonical path 1 件のみ。Skill ツール呼び出し・インストール済みスキルの読み込みなし

## GREEN: 最小限の修正

「権限」節の Codex 承認段落の直前に、Claude Code の承認段落を 1 つ追加:

> Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。

ターンまたぎの既存安全策 (skill 再起動による javascript_tool 許可の再適用、承認後 fresh GET の digest 照合) は削除せず参照で接続した。

## REFACTOR: 編集版の読者テスト

- RED と同一のタスク・fixture を、編集版の作業コピーで新しい subagent (sonnet) に投げた
- 結果: 合格。読者は差分 (環境名・digest・現在/更新後 bump 行) を提示し、「1. 承認して POST する 2. キャンセル」の 2 択で承認を求めた
- 客観証拠: transcript (`agent-a70f23d6e16890f2c.jsonl`) に `ToolSearch {query: "select:AskUserQuestion"}` と `ToolSearch {query: "ask user question confirm choice"}` の 2 回の取得試行が記録されている。subagent には AskUserQuestion が配布されないため取得できず、読者は「この作業コピーのセッションには AskUserQuestion 相当のツールがなく、通常のチャット返信でお伺いしています」と明示して同一選択肢のチャット代替に劣化した。ツール不在時の劣化も透明かつ安全 (承認なしでは POST しない) だったため、追加の防御は書いていない (観察されていない失敗への対策は書かない)
- 読み込み元は編集版作業コピーのみ。Skill ツール・インストール済みスキルの読み込みなし

## 発動テスト (description は未変更)

インストール済みスキルの description 一覧 8 件を subagent に見せ、本文なしで発話ごとの選択を判定させた。8/8 期待どおり:

- 発動: 「cloud-setup.yaml の paths に触れる PR がマージされたので反映して」「cloud 環境の setup script を bump しといて」「くらうどの init script ばんぷして」→ cloud-bump。「dotfiles の home/.agents 配下のスキルを変更する PR を作って」→ skill + cloud-bump (予告用途)
- 不発動: 「brain に routine を追加したい」→ routine、「依存パッケージのバージョン bump の PR」→ なし、「worktree 切って作業したい」→ wt、「Web Clipper のテンプレを直したい」→ update-web-clipper

## 最終検証: Claude Code / Codex 同等性

参照した公式情報 (すべて 2026-08-10 に fresh 取得):

- [Claude Code skills.md](https://code.claude.com/docs/en/skills.md) — allowed-tools: "Tools Claude can use without asking permission during the turn that invokes this skill. The grant clears when you send your next message."。`disallowed-tools` の説明文に `AskUserQuestion` がツール名として明記
- [Claude Code tools-reference](https://code.claude.com/docs/en/tools-reference) — AskUserQuestion: 選択式質問、Other 自由入力、Permission required: No。タイムアウト時は「選択済みの option のみ提出」して閉じる → 未選択クローズでは「承認して POST する」が選ばれないため POST に進まず安全側
- [Agent Skills specification](https://agentskills.io/specification) — 本文は "There are no format restrictions"。body のみの変更はスペック互換
- [Codex build-skills](https://learn.chatgpt.com/docs/build-skills) — Codex skills に選択式 UI ツールの記載なし → Codex はテキスト承認継続が正しい

実測ホスト: Claude Code 2.1.220 (本セッション。AskUserQuestion の tool schema が実在することを直接確認)、Codex CLI 0.145.0 (インストール確認のみ、実動未実施)。

surface 別の結果:

| 観点 | Claude Code local | Codex CLI |
|---|---|---|
| 承認 UI (AskUserQuestion) | 実動合格 (main loop v2.1.220 に schema 実在。subagent には非配布で、読者テストで不在時の安全な劣化も観測) | 該当なし (テキスト承認を本文で維持) |
| 読者テスト (本文どおり動くか) | 実動合格 (subagent 読者テスト) | 静的合格 (実動未確認。Codex 手順は無変更で、入力・出力・決定権・停止条件が不変) |
| allowed-tools のターン内有効・次メッセージで失効 | 静的合格 (skills.md 引用どおり) | 該当なし |
| 発動 (description) | 実動合格 (選択テスト 8/8) | 静的合格 (description 無変更) |
| frontmatter | 変更なし | 変更なし |

未確認事項 (誠実な記録): AskUserQuestion の回答受領後も allowed-tools の許可が同一ターン内で存続する点は、公式ドキュメントに直接の明記がなく静的判定 (回答は「next message」ではなく tool result として返る)。仮に失効しても POST 時に permission prompt が出るだけで、承認なし POST は起きない。ターンをまたいだ場合の再起動規則も本文に維持済み。

判定: **静的同等・実動未確認** (Claude Code local は実動合格、Codex CLI は実動未実施のため)。

# マージ後の作業 (予告)

`home/.agents/skills/**` は `.github/workflows/cloud-setup.yaml` の `paths` 対象。本 PR は cloud-bump skill 自身の変更なので、**マージ後に `/cloud-bump` の実行が必要** (実行時にこの新しい AskUserQuestion 承認フローが初めて実動する)。
