### PR TITLE
feat: add raycast-backup skill

### DIFF
--- a/home/.agents/skills/raycast-backup/SKILL.md
+++ b/home/.agents/skills/raycast-backup/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: raycast-backup
+description: >-
+  Raycast の設定をエクスポートして dotfiles のバックアップを更新する PR を作る。
+  ユーザーが「Raycast のバックアップを取って」「Raycast 設定を保存・退避したい」
+  「rbk をやって」と言ったときに使用する。
+---
+
+# /raycast-backup
+
+エクスポートから PR 作成までは [raycast_backup.sh](../../../.config/raycast/scripts/raycast_backup.sh) が正本。手順を再発明せず、このスクリプトを 1 回実行する。過去に skill → CLI 化 → skill 復帰の経緯があり ([dotfiles#999](https://github.com/nozomiishii/dotfiles/pull/999), [#1004](https://github.com/nozomiishii/dotfiles/pull/1004), [#1010](https://github.com/nozomiishii/dotfiles/pull/1010))、alias `rbk` とこの skill は同じスクリプトを共有する。
+
+## 前提
+
+- ローカルの macOS セッション専用。cloud セッションでは実行できないことを伝えて停止する
+- Raycast が起動している (`pgrep -x Raycast`)。export の passphrase は Raycast に保存済みでプロンプトは出ない
+- `gh auth status` が通る
+
+## 実行
+
+エクスポート中の約 10 秒、キーボードとマウスが自動操作に使われる。実行の直前に、画面を数秒自動操作するので手を離して待ってほしいと一言伝えてから実行する。追加の承認待ちは不要。
+
+スクリプトは osascript で System Events を操作するため、ホストの sandbox 内では動かない。
+
+- Claude Code: Bash を `dangerouslyDisableSandbox: true` で実行する
+- Codex: sandbox 外での実行 (escalated permissions) の承認を得て実行する
+
+```bash
+"$HOME/.config/raycast/scripts/raycast_backup.sh"
+```
+
+## 実行後
+
+- `PR: <url>` が出たら URL をリンクとして提示する。ブラウザは開かない (スクリプトが TTY 判定で抑制する)
+- PR の diff が `home/.config/raycast/backup/Raycast.rayconfig` 1 ファイルだけであることを確認する
+- 「バックアップ対象に変更なし。」で終わったらその旨を伝えて終わる。export は暗号化のため、設定が同じでもバイト差分が出て PR ができるのが通常
+
+## 失敗時
+
+- osascript の error 1002 は実行元アプリに Accessibility 権限がないのが原因。System Settings > Privacy & Security > Accessibility で実行元 (Claude Code / ターミナル) への付与をユーザーに依頼して停止する
+- `no new .rayconfig produced` は保存ダイアログ操作の delay 不足が疑い。再実行は 1 回まで。それでも失敗したらターミナルでの `rbk` 実行を提案して停止する

--- a/home/.agents/skills/raycast-backup/SKILL.md
+++ b/home/.agents/skills/raycast-backup/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # /raycast-backup
 
-エクスポートから PR 作成までは [raycast_backup.sh](../../../.config/raycast/scripts/raycast_backup.sh) が正本。手順を再発明せず、このスクリプトを 1 回実行する。過去に skill → CLI 化 → skill 復帰の経緯があり ([dotfiles#999](https://github.com/nozomiishii/dotfiles/pull/999), [#1004](https://github.com/nozomiishii/dotfiles/pull/1004), [#1010](https://github.com/nozomiishii/dotfiles/pull/1010))、alias `rbk` とこの skill は同じスクリプトを共有する。
+エクスポートから PR 作成までは [raycast_backup.sh](../../../.config/raycast/scripts/raycast_backup.sh) が正本。手順を再発明せず、このスクリプトを 1 回実行する。alias `rbk` とこの skill は同じスクリプトを共有する。
 
 ## 前提
 
@@ -39,3 +39,7 @@ description: >-
 
 - osascript の error 1002 は実行元アプリに Accessibility 権限がないのが原因。System Settings > Privacy & Security > Accessibility で実行元 (Claude Code / ターミナル) への付与をユーザーに依頼して停止する
 - `no new .rayconfig produced` は保存ダイアログ操作の delay 不足が疑い。再実行は 1 回まで。それでも失敗したらターミナルでの `rbk` 実行を提案して停止する
+
+## 経緯
+
+設計判断を調べるときだけ参照する。skill → CLI 化 → skill 復帰の履歴は [dotfiles#999](https://github.com/nozomiishii/dotfiles/pull/999), [#1004](https://github.com/nozomiishii/dotfiles/pull/1004), [#1010](https://github.com/nozomiishii/dotfiles/pull/1010)。

--- a/home/.config/raycast/scripts/raycast_backup.sh
+++ b/home/.config/raycast/scripts/raycast_backup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Raycast 設定を export し、origin/main 基点の専用ブランチで PR を作ってブラウザで開く。
-# ターミナルから実行する（alias: rbk）。
+# Raycast 設定を export し、origin/main 基点の専用ブランチで PR を作る。
+# ターミナルから実行する（alias: rbk）ほか、/raycast-backup skill からも呼ばれる。
+# TTY 実行時だけ PR をブラウザで開く。
 #
 # 前提（初回のみ）:
 #   - Raycast でこのコマンドの外部起動確認を「Always Run Command」で抑制済み。
@@ -122,4 +123,5 @@ url="$(cd "$wt" && gh pr create --base main --title "chore: update Raycast confi
 pr_created=1
 
 echo "PR: $url"
-if [ -n "$url" ]; then open "$url"; fi
+# 対話ターミナル (TTY) から実行したときだけブラウザで開く。agent 実行ではリンク提示に留める。
+if [ -n "$url" ] && [ -t 1 ]; then open "$url"; fi


### PR DESCRIPTION
## 概要

raycast_backup.sh (alias: `rbk`) を `/raycast-backup` スキルとして Claude Code / Codex から実行できるようにする。ターミナル作業が減ったため、agent セッションからバックアップを取れるようにする。skill → CLI 化の経緯 (#999 → #1004 → #1010) を踏まえ、今回は CLI を残したまま skill を復帰させ、同じスクリプトを共有する。

## 変更内容

- `home/.agents/skills/raycast-backup/SKILL.md` を追加
- raycast_backup.sh の PR ブラウザ自動オープンを TTY 実行時のみに変更。agent 実行ではリンク提示に留め、フォーカス強奪を減らす

## テスト記録 (/skill のドキュメント TDD)

### RED (スキルなし、計画提示のみで実行なし)

- シナリオ: 「Raycast の設定バックアップを取って dotfiles の backup を更新する PR を作って」
- 観察された失敗
  - スクリプトの「PR URL をブラウザで開く」挙動を問題視せず温存
  - 13 tool calls / 212 秒かけて script の存在・経緯・cloud-setup paths を毎回再発見
  - 「Accessibility 権限がどのプロセスに帰属するか実行してみないと不明」と述べたまま実行を計画

### GREEN

観察された失敗だけに対処: 正本スクリプトへの誘導と経緯リンク、実行直前のユーザー予告 (約 10 秒の画面自動操作)、sandbox 外実行の指定 (Claude Code / Codex 別)、ブラウザ非オープンとリンク提示、失敗分岐 (osascript error 1002 / no new .rayconfig)。

### REFACTOR (読者テスト)

- Claude Code: SKILL.md を読ませた subagent が意図どおりの計画を提示 (4 tool calls / 82 秒)。逸脱・新しい言い訳なし
- Codex CLI 0.145.0: `codex exec --sandbox read-only` で同一依頼。意図どおり。読み込み元の canonical path (worktree の SKILL.md) を出力で確認

### 発動テスト

- 発動すべき 5 発話 (typo「raycsat」、口語、「rbk やっといて」含む) → 全て raycast-backup を選択
- 発動すべきでない近縁 5 発話 (「Raycast のスニペット設定を変えたい」「brain のバックアップ取って」「Time Machine のバックアップ設定」「raycast_backup.sh をリファクタして」等) → 全て不選択
- 10/10 で description 修正不要

### 最終検証 (2026-08-10 取得の公式情報)

- [Agent Skills](https://agentskills.io): SKILL.md + name/description の最小要件に適合
- [Claude Code skills](https://code.claude.com/docs/en/skills.md): personal skills は `~/.claude/skills/` (symlink 追従)。`disable-model-invocation` 既定 false で暗黙呼び出し許可
- [Codex skills](https://learn.chatgpt.com/docs/build-skills): `$HOME/.agents/skills` から読み込み。`allow_implicit_invocation` 既定 true で暗黙呼び出し許可 (openai.yaml 不要)
- 両ホストとも暗黙呼び出しを許可する設計のため、ゲート設定は置かない
- surface 別判定: Claude Code local = 読者テスト実動合格 / Codex CLI local = 読者テスト実動合格。スクリプト本体の実行はテストでは未実施 (画面自動操作を伴うため)。実行系は静的同等・実動未確認。マージ後に確認実行を 1 回行う
- cloud セッションは対象外。SKILL.md 冒頭でローカル専用と明記し停止を指示

## マージ後の作業

- cloud-setup.yaml の tarball paths (`home/.agents/skills/`) に触れるため、マージ後に /cloud-bump の実行が必要
- `~/.agents/skills/` への per-skill symlink は post-merge hook (symlink job) が自動 restow するため手動作業不要。Claude Code 側は `home/.claude/skills` → `../.agents/skills` 経由で即時反映
- `/raycast-backup` の確認実行を 1 回 (エクスポート約 10 秒の画面自動操作あり)
