### PR TITLE
chore: simplify cloud-bump skill structure

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -31,6 +31,8 @@ cloud 配信対象に触れる PR を作成した時点では bump せず、マ�
 
 Claude Code / Codex とも、`claude.ai/code` を開いた tab ID と bootstrap URL を最初に固定する。全 read、network 観察、fetch、click の直前に、固定した tab ID・`https://claude.ai` origin・`/code` で始まる path が一致することを確認する。不一致なら環境設定を送受信せず停止する。
 
+Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。
+
 Codex で承認を求めるときは、ユーザーへ「`$cloud-bump 承認` と返信してください」と案内して turn を終える。次の発話で skill を明示的に再起動し、Chrome 接続と GET 結果が承認前と一致することを確認してから POST する。単なる「承認します」という返信を、skill を再読せずに処理しない。
 
 ## init_script の更新 (内部 API)

--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -12,197 +12,39 @@ allowed-tools: mcp__claude-in-chrome__javascript_tool
 
 # /cloud-bump
 
-cloud 環境の setup script は毎セッション走らない。環境スナップショットの再構築時にだけ走り、再構築のトリガーは Setup script 欄の変更・allowed network hosts の変更・約 7 日のキャッシュ失効だけ ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))。main にマージして tarball が再デプロイされても、bump しない限り新規セッションは最大 7 日前のスナップショットで起動する。「マージされたので自動で反映済み」は誤り。設計の経緯は [dotfiles#1347](https://github.com/nozomiishii/dotfiles/issues/1347)。
+cloud 環境の setup script は毎セッション走らない。再構築のトリガーは Setup script 欄の変更・allowed network hosts の変更・約 7 日のキャッシュ失効だけで ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))、main にマージしても bump しない限り新規セッションは最大 7 日前のスナップショットで起動する。「マージされたので自動で反映済み」は誤り。設計の経緯は [dotfiles#1347](https://github.com/nozomiishii/dotfiles/issues/1347)。
 
 ## 発火の判定
 
-判定リストの正本は `.github/workflows/cloud-setup.yaml` の `paths`。スキルに書き写さず、workflow ファイルを読んで diff と突き合わせる。触れていなければ bump 不要と伝えて終わる。
-
-bump してよいのは main にマージ済みの変更だけ。マージ前に bump すると古い main でスナップショットが焼き直されるだけになる。
-
-cloud 配信対象に触れる PR を作成した時点では bump せず、マージ後に /cloud-bump の実行が必要なことを PR 作成の報告に書いて予告する。マージ後の bump は忘れられやすく、予告がないとユーザーはセッションを閉じてから気づけない。
+- 判定リストの正本は `.github/workflows/cloud-setup.yaml` の `paths`。スキルに書き写さず、workflow ファイルを読んで diff と突き合わせる。触れていなければ bump 不要と伝えて終わる
+- bump してよいのは main にマージ済みの変更だけ。マージ前に bump すると古い main でスナップショットが焼き直されるだけになる
+- cloud 配信対象に触れる PR を作成した時点では bump せず、マージ後に /cloud-bump の実行が必要なことを PR 作成の報告に書いて予告する
+- ユーザーが bump を明示的に依頼した場合もこの判定を省略しない。判定を終える前に「手順」へ進まない
 
 ## 権限
 
 - Claude Code: JS 実行の許可は frontmatter の allowed-tools で与える。settings.json に javascript_tool の常時 allow を置かない。許可はこのスキルを起動したターンだけ有効で、次のユーザーメッセージで消える ([skills.md](https://code.claude.com/docs/en/skills.md))。承認待ちでターンをまたいだら、POST の前にスキルを起動し直して許可を再適用する
-- Codex: 最初に `$chrome:control-chrome` を読み、既存の Chrome セッションを選ぶ。本文の `javascript_tool` や UI 操作を literal なツール名として呼ばず、browser-client の Playwright 評価・ネットワーク観察・クリックへ読み替える。最初に、page origin への GET と POST、ネットワーク観察を実行できる capability があるか確認する。capability が欠けていれば API 操作を試さず停止し、「手順」末尾の手動フォールバック URL を案内する。承認でターンをまたいだら `$cloud-bump` を再度読み、Chrome 接続と GET 結果を再確認してから POST する
+- Codex: 最初に `$chrome:control-chrome` を読み、既存の Chrome セッションを選ぶ。本文と scripts/ の JavaScript を literal なツール名として呼ばず、browser-client の Playwright 評価・ネットワーク観察・クリックへ読み替える。最初に、page origin への GET と POST、ネットワーク観察を実行できる capability があるか確認する。capability が欠けていれば API 操作を試さず停止し、「手順」末尾の手動フォールバック URL を案内する。承認でターンをまたいだら `$cloud-bump` を再度読み、Chrome 接続と GET 結果を再確認してから POST する
 
-どちらの環境でも POST 前の差分承認を省略しない。
+## 承認
 
-Claude Code / Codex とも、`claude.ai/code` を開いた tab ID と bootstrap URL を最初に固定する。全 read、network 観察、fetch、click の直前に、固定した tab ID・`https://claude.ai` origin・`/code` で始まる path が一致することを確認する。不一致なら環境設定を送受信せず停止する。
+どちらの環境でも POST 前の差分承認を省略しない。`claude.ai/code` を開いた tab ID と bootstrap URL を最初に固定し、全 read、network 観察、fetch、click の直前に、固定した tab ID・`https://claude.ai` origin・`/code` で始まる path が一致することを確認する。不一致なら環境設定を送受信せず停止する。
 
 Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。
 
 Codex で承認を求めるときは、ユーザーへ「`$cloud-bump 承認` と返信してください」と案内して turn を終える。次の発話で skill を明示的に再起動し、Chrome 接続と GET 結果が承認前と一致することを確認してから POST する。単なる「承認します」という返信を、skill を再読せずに処理しない。
 
-## init_script の更新 (内部 API)
+## 手順
 
-claude.ai の未文書化 API で init_script を直接更新する。公式 API ではないため、動かなくなったら「エンドポイントの再発見」セクションの手順で調査し直す。
+claude.ai の未文書化 API を使う。エンドポイント・レスポンス構造・POST 必須フィールド・動かなくなったときの再発見手順は [references/api.md](references/api.md) を読む。
 
-### 手順
-
-Claude in Chrome で <https://claude.ai/code> を開き、JS で API を叩く。
-
-GET で現在の環境設定を取得:
-
-```js
-const assertClaudeContext = () => {
-  if (location.origin !== 'https://claude.ai' || !location.pathname.startsWith('/code')) {
-    throw new Error('unexpected tab origin or path');
-  }
-};
-const canonicalize = value => Array.isArray(value)
-  ? value.map(canonicalize)
-  : value && typeof value === 'object'
-    ? Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalize(value[key])]))
-    : value;
-const sha256 = async value => {
-  const bytes = new TextEncoder().encode(JSON.stringify(canonicalize(value)));
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
-  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
-};
-const orgId = '<network-log-derived-org-id>';
-const envId = '<network-log-derived-env-id>';
-if (!/^[A-Za-z0-9_-]{8,128}$/.test(orgId)) throw new Error('invalid orgId');
-if (!/^[A-Za-z0-9_-]{8,128}$/.test(envId)) throw new Error('invalid envId');
-const endpoint = `https://claude.ai/v1/environment_providers/private/organizations/${encodeURIComponent(orgId)}/environments/${encodeURIComponent(envId)}`;
-assertClaudeContext();
-const getResp = await fetch(endpoint);
-if (!getResp.ok) throw new Error(`GET failed: ${getResp.status}`);
-const env = await getResp.json();
-const originalInit = String(env.config.init_script ?? '');
-const now = new Date();
-const pad = value => String(value).padStart(2, '0');
-const proposedBumpLine = `# bump ${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-const snapshotDigest = await sha256(env);
-({
-  snapshotDigest,
-  environmentId: env.environment_id ?? envId,
-  name: env.name,
-  currentBumpLine: originalInit.match(/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?=\n|$)/)?.[0] ?? null,
-  proposedBumpLine
-});
-```
-
-org_id と env_id は GET のレスポンス、または環境セレクタ操作時のネットワークログから取得する。環境が複数あるときは、どれを bump するかユーザーに確認する。
-
-この GET call が返した `snapshotDigest`、環境名、現在の bump 行、`proposedBumpLine` だけを会話に控え、差分承認を得る。env 全体や `config.environment` を会話へ出さない。
-
-承認後は別の JavaScript call で GET を再実行する。次の block の `approvedSnapshotDigest` と `approvedBumpLine` を承認済みの実値へ置換する。fresh GET の digest が一致した場合だけ、init_script の先頭行を更新して POST する。前の call の lexical binding は使わない。
-
-```js
-const assertClaudeContext = () => {
-  if (location.origin !== 'https://claude.ai' || !location.pathname.startsWith('/code')) {
-    throw new Error('unexpected tab origin or path');
-  }
-};
-const canonicalize = value => Array.isArray(value)
-  ? value.map(canonicalize)
-  : value && typeof value === 'object'
-    ? Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalize(value[key])]))
-    : value;
-const sha256 = async value => {
-  const bytes = new TextEncoder().encode(JSON.stringify(canonicalize(value)));
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
-  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
-};
-const orgId = '<network-log-derived-org-id>';
-const envId = '<network-log-derived-env-id>';
-const approvedSnapshotDigest = '<approved-snapshot-sha256>';
-const approvedBumpLine = '<approved-bump-line>';
-if (!/^[A-Za-z0-9_-]{8,128}$/.test(orgId)) throw new Error('invalid orgId');
-if (!/^[A-Za-z0-9_-]{8,128}$/.test(envId)) throw new Error('invalid envId');
-if (!/^[a-f0-9]{64}$/.test(approvedSnapshotDigest)) throw new Error('invalid approved snapshot digest');
-if (!/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/.test(approvedBumpLine)) throw new Error('invalid approved bump line');
-const endpoint = `https://claude.ai/v1/environment_providers/private/organizations/${encodeURIComponent(orgId)}/environments/${encodeURIComponent(envId)}`;
-
-assertClaudeContext();
-const getResp = await fetch(endpoint);
-if (!getResp.ok) throw new Error(`GET failed: ${getResp.status}`);
-const env = await getResp.json();
-if (await sha256(env) !== approvedSnapshotDigest) {
-  throw new Error('environment changed after approval');
-}
-const originalInit = String(env.config.init_script ?? '');
-const bumpPattern = /^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?=\n|$)/;
-const stripBump = value => value.replace(/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?:\n|$)/, '');
-const updatedInit = bumpPattern.test(originalInit)
-  ? originalInit.replace(bumpPattern, approvedBumpLine)
-  : `${approvedBumpLine}\n${originalInit}`;
-
-if (stripBump(updatedInit) !== stripBump(originalInit)) {
-  throw new Error('init_script body changed outside the bump line');
-}
-
-const updated = {
-  name: env.name,
-  description: env.description ?? '',
-  config: { ...env.config, init_script: updatedInit }
-};
-assertClaudeContext();
-const resp = await fetch(endpoint, {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify(updated)
-});
-if (!resp.ok) throw new Error(`POST failed: ${resp.status}`);
-
-assertClaudeContext();
-const verifyResp = await fetch(endpoint);
-if (!verifyResp.ok) throw new Error(`verification GET failed: ${verifyResp.status}`);
-const after = await verifyResp.json();
-const beforeRest = { ...env.config }; delete beforeRest.init_script;
-const afterRest = { ...after.config }; delete afterRest.init_script;
-if (after.config.init_script !== updatedInit ||
-    after.name !== env.name || (after.description ?? '') !== (env.description ?? '') ||
-    JSON.stringify(afterRest) !== JSON.stringify(beforeRest)) {
-  throw new Error('POST verification mismatch');
-}
-```
-
-- 承認前 call は safe summary と snapshot digest を返す。承認後 call は context guard、endpoint、GET、更新、検証 GET を自己完結させる
-- 変更は先頭の日時コメント行 `# bump YYYY-MM-DD HH:MM` の追加・更新のみ。他の行に触れない。再構築のトリガーは欄のテキストが変わることなので、同日に複数回 bump しても変化が出るよう時刻まで書く
-- POST 前に差分を提示して承認を得る
-- POST 後は同じ endpoint を GET し、bump 行以外の init_script 本文と他 field が承認前の値から変わっていないことを検証する
-- POST が失敗したら手動フォールバック: <https://claude.ai/code> で下部バーの環境タブ（雲アイコン）→ 歯車アイコン → 「Update cloud environment」ダイアログの Setup script 欄を手で書き換える
+1. Claude in Chrome で <https://claude.ai/code> を開く
+2. [scripts/get-env-summary.js](scripts/get-env-summary.js) を読み、`<network-log-derived-org-id>` と `<network-log-derived-env-id>` を実値に置換した文字列を javascript_tool で実行する。ファイル自体は書き換えない。環境が複数あるときは、どれを bump するかユーザーに確認する
+3. 返った `snapshotDigest`・環境名・現在の bump 行・`proposedBumpLine` だけを会話に控え、「承認」の作法で差分承認を得る。env 全体や `config.environment` を会話へ出さない
+4. 承認後、[scripts/post-bump.js](scripts/post-bump.js) を読み、`<approved-snapshot-sha256>` と `<approved-bump-line>` を承認済みの実値に置換した文字列を、別の JavaScript call として実行する。script が fresh GET の digest 照合・bump 行だけの書き換え検証・POST・検証 GET まで自己完結する。前の call の lexical binding は使わない
+5. POST が失敗したら手動フォールバック: <https://claude.ai/code> で下部バーの環境タブ（雲アイコン）→ 歯車アイコン → 「Update cloud environment」ダイアログの Setup script 欄を手で書き換える
 
 init_script が非 0 で終了する状態になると新規セッションが全て起動不能になる。欄を壊さないことを何より優先する。
-
-### API レスポンス構造
-
-```json
-{
-  "environment_id": "env_...",
-  "name": "Default",
-  "config": {
-    "environment_type": "anthropic",
-    "sub_type": "ccr",
-    "cwd": "/home/user",
-    "init_script": "# bump ...\ncurl ...",
-    "environment": {},
-    "languages": [{ "name": "python", "version": "3.11" }, ...],
-    "network_config": { "allowed_hosts": ["*"], "allow_default_hosts": true }
-  }
-}
-```
-
-UI の「Setup script」は `config.init_script`、「Environment variables」は `config.environment`。
-
-### POST リクエストの必須フィールド
-
-`name`, `description`, `config` が必要。`description` は GET に既存値があればそのまま返し、既存の説明文を空文字列で上書きしない。GET に `description` が無い環境では空文字列で補う。実測では undefined は JSON.stringify で field ごと脱落して 400 (`description: Field required`)、null も 400、空文字列は成功する。
-
-## エンドポイントの再発見
-
-API が変更されて動かなくなった場合の調査手順。
-
-- Claude in Chrome で <https://claude.ai/code> を開く
-- ネットワーク観察が利用できることを確認し、ログをクリアする。利用できなければ手動フォールバック URL を案内して止まる
-- 下部バーの環境タブ（雲アイコン）→ 歯車アイコンでダイアログを開く
-- ダイアログを開いた時点の GET リクエストの URL からエンドポイントのパス・org_id・env_id が分かる
-- ダイアログ表示と GET だけを観察する。Setup script や他の項目は変更せず、「Save changes」をクリックしない
-- GET のレスポンスと、既存の frontend bundle 内の request 定義から method、URL、payload のフィールド名を確認する
-- 読み取りだけで POST の仕様を特定できなければ、環境を変更せず手動フォールバック URL を案内して止まる。再発見のための試験 POST はユーザー承認前に行わない
 
 ## 反映範囲
 

--- a/home/.agents/skills/cloud-bump/references/api.md
+++ b/home/.agents/skills/cloud-bump/references/api.md
@@ -1,0 +1,49 @@
+# cloud 環境 内部 API リファレンス
+
+/cloud-bump が使う claude.ai の未文書化 API の詳細。公式 API ではないため、動かなくなったら「エンドポイントの再発見」で調査し直す。
+
+## エンドポイント
+
+`https://claude.ai/v1/environment_providers/private/organizations/{org_id}/environments/{env_id}`
+
+GET で現在の環境設定を取得し、同じ URL への POST で更新する。org_id と env_id は GET のレスポンス、または環境セレクタ操作時のネットワークログから取得する。
+
+## API レスポンス構造
+
+```json
+{
+  "environment_id": "env_...",
+  "name": "Default",
+  "config": {
+    "environment_type": "anthropic",
+    "sub_type": "ccr",
+    "cwd": "/home/user",
+    "init_script": "# bump ...\ncurl ...",
+    "environment": {},
+    "languages": [{ "name": "python", "version": "3.11" }, ...],
+    "network_config": { "allowed_hosts": ["*"], "allow_default_hosts": true }
+  }
+}
+```
+
+UI の「Setup script」は `config.init_script`、「Environment variables」は `config.environment`。
+
+## POST リクエストの必須フィールド
+
+`name`, `description`, `config` が必要。`description` は GET に既存値があればそのまま返し、既存の説明文を空文字列で上書きしない。GET に `description` が無い環境では空文字列で補う。実測では undefined は JSON.stringify で field ごと脱落して 400 (`description: Field required`)、null も 400、空文字列は成功する。
+
+## bump 行の形式
+
+変更は init_script 先頭の日時コメント行 `# bump YYYY-MM-DD HH:MM` の追加・更新のみで、他の行に触れない。再構築のトリガーは欄のテキストが変わることなので、同日に複数回 bump しても変化が出るよう時刻まで書く。
+
+## エンドポイントの再発見
+
+API が変更されて動かなくなった場合の調査手順。
+
+- Claude in Chrome で <https://claude.ai/code> を開く
+- ネットワーク観察が利用できることを確認し、ログをクリアする。利用できなければ手動フォールバック URL を案内して止まる
+- 下部バーの環境タブ（雲アイコン）→ 歯車アイコンでダイアログを開く
+- ダイアログを開いた時点の GET リクエストの URL からエンドポイントのパス・org_id・env_id が分かる
+- ダイアログ表示と GET だけを観察する。Setup script や他の項目は変更せず、「Save changes」をクリックしない
+- GET のレスポンスと、既存の frontend bundle 内の request 定義から method、URL、payload のフィールド名を確認する
+- 読み取りだけで POST の仕様を特定できなければ、環境を変更せず手動フォールバック URL を案内して止まる。再発見のための試験 POST はユーザー承認前に行わない

--- a/home/.agents/skills/cloud-bump/scripts/get-env-summary.js
+++ b/home/.agents/skills/cloud-bump/scripts/get-env-summary.js
@@ -1,0 +1,39 @@
+// /cloud-bump 承認前ステップ: 現在の環境設定を GET し、差分承認に使う safe summary を返す。
+// 実行前に <network-log-derived-org-id> と <network-log-derived-env-id> を実値へ置換する (このファイル自体は書き換えない)。
+// claude.ai/code を開いた固定 tab で javascript_tool (Codex は Playwright 評価) として実行する。
+const assertClaudeContext = () => {
+  if (location.origin !== 'https://claude.ai' || !location.pathname.startsWith('/code')) {
+    throw new Error('unexpected tab origin or path');
+  }
+};
+const canonicalize = value => Array.isArray(value)
+  ? value.map(canonicalize)
+  : value && typeof value === 'object'
+    ? Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalize(value[key])]))
+    : value;
+const sha256 = async value => {
+  const bytes = new TextEncoder().encode(JSON.stringify(canonicalize(value)));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+};
+const orgId = '<network-log-derived-org-id>';
+const envId = '<network-log-derived-env-id>';
+if (!/^[A-Za-z0-9_-]{8,128}$/.test(orgId)) throw new Error('invalid orgId');
+if (!/^[A-Za-z0-9_-]{8,128}$/.test(envId)) throw new Error('invalid envId');
+const endpoint = `https://claude.ai/v1/environment_providers/private/organizations/${encodeURIComponent(orgId)}/environments/${encodeURIComponent(envId)}`;
+assertClaudeContext();
+const getResp = await fetch(endpoint);
+if (!getResp.ok) throw new Error(`GET failed: ${getResp.status}`);
+const env = await getResp.json();
+const originalInit = String(env.config.init_script ?? '');
+const now = new Date();
+const pad = value => String(value).padStart(2, '0');
+const proposedBumpLine = `# bump ${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
+const snapshotDigest = await sha256(env);
+({
+  snapshotDigest,
+  environmentId: env.environment_id ?? envId,
+  name: env.name,
+  currentBumpLine: originalInit.match(/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?=\n|$)/)?.[0] ?? null,
+  proposedBumpLine
+});

--- a/home/.agents/skills/cloud-bump/scripts/post-bump.js
+++ b/home/.agents/skills/cloud-bump/scripts/post-bump.js
@@ -1,0 +1,70 @@
+// /cloud-bump 承認後ステップ: fresh GET の digest 照合が通った場合だけ init_script の bump 行を更新して POST し、検証 GET まで行う。
+// 実行前に <network-log-derived-org-id> <network-log-derived-env-id> <approved-snapshot-sha256> <approved-bump-line> を実値へ置換する (このファイル自体は書き換えない)。
+// 承認前 call の lexical binding は使わず、この 1 call で自己完結させる。
+const assertClaudeContext = () => {
+  if (location.origin !== 'https://claude.ai' || !location.pathname.startsWith('/code')) {
+    throw new Error('unexpected tab origin or path');
+  }
+};
+const canonicalize = value => Array.isArray(value)
+  ? value.map(canonicalize)
+  : value && typeof value === 'object'
+    ? Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalize(value[key])]))
+    : value;
+const sha256 = async value => {
+  const bytes = new TextEncoder().encode(JSON.stringify(canonicalize(value)));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+};
+const orgId = '<network-log-derived-org-id>';
+const envId = '<network-log-derived-env-id>';
+const approvedSnapshotDigest = '<approved-snapshot-sha256>';
+const approvedBumpLine = '<approved-bump-line>';
+if (!/^[A-Za-z0-9_-]{8,128}$/.test(orgId)) throw new Error('invalid orgId');
+if (!/^[A-Za-z0-9_-]{8,128}$/.test(envId)) throw new Error('invalid envId');
+if (!/^[a-f0-9]{64}$/.test(approvedSnapshotDigest)) throw new Error('invalid approved snapshot digest');
+if (!/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/.test(approvedBumpLine)) throw new Error('invalid approved bump line');
+const endpoint = `https://claude.ai/v1/environment_providers/private/organizations/${encodeURIComponent(orgId)}/environments/${encodeURIComponent(envId)}`;
+
+assertClaudeContext();
+const getResp = await fetch(endpoint);
+if (!getResp.ok) throw new Error(`GET failed: ${getResp.status}`);
+const env = await getResp.json();
+if (await sha256(env) !== approvedSnapshotDigest) {
+  throw new Error('environment changed after approval');
+}
+const originalInit = String(env.config.init_script ?? '');
+const bumpPattern = /^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?=\n|$)/;
+const stripBump = value => value.replace(/^# bump \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?:\n|$)/, '');
+const updatedInit = bumpPattern.test(originalInit)
+  ? originalInit.replace(bumpPattern, approvedBumpLine)
+  : `${approvedBumpLine}\n${originalInit}`;
+
+if (stripBump(updatedInit) !== stripBump(originalInit)) {
+  throw new Error('init_script body changed outside the bump line');
+}
+
+const updated = {
+  name: env.name,
+  description: env.description ?? '',
+  config: { ...env.config, init_script: updatedInit }
+};
+assertClaudeContext();
+const resp = await fetch(endpoint, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(updated)
+});
+if (!resp.ok) throw new Error(`POST failed: ${resp.status}`);
+
+assertClaudeContext();
+const verifyResp = await fetch(endpoint);
+if (!verifyResp.ok) throw new Error(`verification GET failed: ${verifyResp.status}`);
+const after = await verifyResp.json();
+const beforeRest = { ...env.config }; delete beforeRest.init_script;
+const afterRest = { ...after.config }; delete afterRest.init_script;
+if (after.config.init_script !== updatedInit ||
+    after.name !== env.name || (after.description ?? '') !== (env.description ?? '') ||
+    JSON.stringify(afterRest) !== JSON.stringify(beforeRest)) {
+  throw new Error('POST verification mismatch');
+}


### PR DESCRIPTION
# 概要

cloud-bump の SKILL.md (209 行) を要点だけの 51 行に再構成し、細部を Agent Skills 仕様の標準ディレクトリへ切り出す。

- `scripts/get-env-summary.js` (39 行) — 承認前 GET + safe summary。旧本文の JS block 1 を verbatim 移動 + 使い方ヘッダコメント
- `scripts/post-bump.js` (70 行) — fresh GET digest 照合 → bump 行のみ POST → 検証 GET。旧 JS block 2 を verbatim 移動
- `references/api.md` (49 行) — エンドポイント・レスポンス構造・POST 必須フィールド・bump 行形式・エンドポイント再発見手順。情報は削除せず退避
- 本文に残したのは発火の判定・権限・承認 (AskUserQuestion / Codex、tab 固定)・5 step の手順・init_script 破壊防止・反映範囲

**Stacked PR**: base は #1515 (`cloud-bump-ask-user-question`)。#1515 の AskUserQuestion 承認段落を前提に、その本文を verbatim で保持している。マージ順は #1515 → 本 PR。

構成の根拠 ([Agent Skills specification](https://agentskills.io/specification)、2026-08-10 取得):

> Keep your main SKILL.md under 500 lines. Move detailed reference material to separate files.

> Agents load these on demand, so smaller files mean less use of context.

`scripts/`・`references/` は仕様の標準 optional directories で、参照は「relative paths from the skill root」規約に従った。[Codex build-skills](https://learn.chatgpt.com/docs/build-skills) も「A skill is a directory with a `SKILL.md` file plus optional scripts and references」と同一構成 (2026-08-10 取得)。

# テスト記録 (/skill のドキュメント TDD)

## インタビュー

細部 (API 構造・再発見手順) の行き先を AskUserQuestion で確認 → 回答 [No preference] のため推奨案 (references/ 退避、削除しない) を採用。スキルディレクトリ構成の仕様確認の依頼には agentskills.io の原文引用で回答した。

## RED: 現行版の失敗

直したい失敗は文書の肥大そのもの: 現行 209 行のうち 122 行が JS code block で、スキル起動のたびに全量が context にロードされる (仕様の progressive disclosure に反する構造)。挙動のベースラインは同セッションの #1515 読者テスト (fixture タスクで発火判定 → safe summary → 承認要求まで完遂) を使用。

## GREEN: 再構成

上記の 4 ファイル構成へ分割。JS は verbatim 移動 (ロジック変更なし)、本文の安全策 (差分承認の省略禁止、tab ID 固定、ターンまたぎ時の skill 再起動 + fresh GET digest 照合、env 全体を会話に出さない、init_script 破壊防止最優先、手動フォールバック) はすべて本文に残した。

## REFACTOR: 読者テスト (2 回)

1 回目 (再構成直後): 読者 (sonnet subagent、作業コピーのみ参照) は 4 ファイル全読 → safe summary のみ提示 → AskUserQuestion を ToolSearch で取得試行 (transcript に記録) → 不在を明示して同一 2 択のテキスト代替 → post-bump.js の placeholder 4 箇所置換・ファイル非改変・自己完結 call・lexical binding 不使用まで正しく計画して停止。**ただし新しい抜け穴**: 「すでに bump 実施を明示的に依頼されているため、要否判定はスキップ」と発火の判定を省略した (旧版の読者 2 回は同一依頼文で判定を実行していた)。

対処: 発火の判定に 1 行追加 — 「ユーザーが bump を明示的に依頼した場合もこの判定を省略しない。判定を終える前に「手順」へ進まない」。

2 回目 (対処後): 合格。読者は最初に `git show origin/main:.github/workflows/cloud-setup.yaml` で判定を実行して bump 要と判定してから手順に進み、承認フロー・POST 計画は 1 回目と同水準で正確だった。読み込み元は transcript で客観確認 (作業コピー 4 ファイル + read-only git 照会のみ。Skill ツール・インストール済みスキルへの接触なし)。

## 発動テスト

description は無変更。同セッション・同一 description で実施済みの選択テスト (8 発話 8/8 正解、#1515 のテスト記録参照) を再利用。

## 最終検証: Claude Code / Codex 同等性

公式情報 (すべて 2026-08-10 取得):

- [Agent Skills specification](https://agentskills.io/specification) — scripts/・references/ の標準構成、relative path 参照、progressive disclosure、"under 500 lines" 推奨
- [Codex build-skills](https://learn.chatgpt.com/docs/build-skills) — 同一のディレクトリ構成 (SKILL.md + optional scripts and references)。パス解決の詳細は未記載のため spec の相対パス規約を共通基準とした
- [Claude Code skills.md](https://code.claude.com/docs/en/skills.md) / [tools-reference](https://code.claude.com/docs/en/tools-reference) — #1515 の検証結果を同セッションで再利用 (allowed-tools のターン規則、AskUserQuestion の存在と挙動)

実測ホスト: Claude Code 2.1.220 (スキル起動時に base directory が本文と共に提示され、相対パスが解決できることを本セッションの skill 起動で直接観測)、Codex CLI 0.145.0 (インストール確認のみ)。

surface 別の結果:

| 観点 | Claude Code local | Codex CLI |
|---|---|---|
| 読者テスト (分割後も本文どおり動くか) | 実動合格 (subagent 読者テスト 2 回目) | 静的合格 (実動未確認。scripts は「Playwright 評価へ読み替え」の既存規則で解釈され、構成は Codex 公式 doc と同一) |
| scripts/ の読み取り + placeholder 置換 (ファイル非改変) | 実動合格 (読者が置換後文字列の実行を正しく計画) | 静的合格 (実動未確認) |
| references/ の on-demand 参照 | 実動合格 (読者が api.md を必要時に参照) | 静的合格 (実動未確認) |
| 承認フロー (AskUserQuestion / テキスト) | 実動合格 (#1515 と同水準を維持) | 該当なし (Codex 段落は無変更) |
| 発動 (description) | 実動合格 (同セッションの 8/8 を再利用) | 静的合格 (description 無変更) |

判定: **静的同等・実動未確認** (Claude Code local は実動合格、Codex CLI は実動未実施のため)。

# 配信の確認

cloud-setup.yaml の tarball は `home/.agents/skills/` をディレクトリごと含むため、scripts/・references/ も cloud へ配信される (workflow の `tar czf` 対象を確認済み)。

# マージ後の作業 (予告)

`home/.agents/skills/**` は cloud-setup.yaml の `paths` 対象。#1515 → 本 PR の順でマージ後、**/cloud-bump の実行が必要**。
