### PR TITLE
chore: drop the dead projects.json symlinks for Cursor and Antigravity

### DIFF
--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -370,7 +370,6 @@ mkdir -p "$HOME/Library/Application Support/Cursor/User/"
 
 ln -sf "$HOME/Library/Application Support/Code/User/keybindings.json" "$HOME/Library/Application Support/Cursor/User/"
 ln -sf "$HOME/Library/Application Support/Code/User/settings.json" "$HOME/Library/Application Support/Cursor/User/"
-ln -sf "$HOME/Library/Application Support/Code/User/projects.json" "$HOME/Library/Application Support/Cursor/User/"
 
 snippets_dir="$HOME/Library/Application Support/Cursor/User/snippets"
 if [ -d "$snippets_dir" ]; then
@@ -386,7 +385,6 @@ mkdir -p "$HOME/Library/Application Support/Antigravity/User/"
 
 ln -sf "$HOME/Library/Application Support/Code/User/keybindings.json" "$HOME/Library/Application Support/Antigravity/User/"
 ln -sf "$HOME/Library/Application Support/Code/User/settings.json" "$HOME/Library/Application Support/Antigravity/User/"
-ln -sf "$HOME/Library/Application Support/Code/User/projects.json" "$HOME/Library/Application Support/Antigravity/User/"
 
 snippets_dir="$HOME/Library/Application Support/Antigravity/User/snippets"
 if [ -d "$snippets_dir" ]; then


### PR DESCRIPTION
## 何をしたか

`scripts/darwin/macos.sh` から、Cursor と Antigravity 向けに `projects.json` の symlink を張る 2 行を消した。リンク切れを作るだけの行だった。

## なぜ

リンク元の `~/Library/Application Support/Code/User/projects.json` が存在しない。Project Manager 拡張が読むのは `projectManager.projectsLocation` で指したディレクトリなので、`Code/User/projects.json` は作られることがない。

実際にこうなっていた。

| パス | 状態 |
| --- | --- |
| `Code/User/projects.json` | 存在しない (リンク元) |
| `Cursor/User/projects.json` | 存在しない |
| `Antigravity/User/projects.json` | リンク切れの symlink |

手元に残っていた `Antigravity/User/projects.json` のリンク切れも消した。この PR の後は再生成されない。

同じブロックの `keybindings.json`、`settings.json`、`snippets` は実体があって機能しているので触っていない。

## 経緯

`projects.json` を workspaces repo から infra repo に移した作業 ([nozomiishii/infra#164](https://github.com/nozomiishii/infra/pull/164)) の調査中に見つけた。移設とは関係なく、元から死んでいた行。

## 検証

- `bash -n scripts/darwin/macos.sh` が通ることを確認
- `scripts/` 配下に `projects.json` への参照が残っていないことを確認
- リンク切れを消した後、3 つのパスすべてに `projects.json` が存在しないことを確認
