### PR TITLE
chore: move skill design-history links to trailing sections

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: mcp__claude-in-chrome__javascript_tool
 
 # /cloud-bump
 
-cloud 環境の setup script は毎セッション走らない。再構築のトリガーは Setup script 欄の変更・allowed network hosts の変更・約 7 日のキャッシュ失効だけで ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))、main にマージしても bump しない限り新規セッションは最大 7 日前のスナップショットで起動する。「マージされたので自動で反映済み」は誤り。設計の経緯は [dotfiles#1347](https://github.com/nozomiishii/dotfiles/issues/1347)。
+cloud 環境の setup script は毎セッション走らない。再構築のトリガーは Setup script 欄の変更・allowed network hosts の変更・約 7 日のキャッシュ失効だけで ([Environment caching](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching))、main にマージしても bump しない限り新規セッションは最大 7 日前のスナップショットで起動する。「マージされたので自動で反映済み」は誤り。
 
 ## 発火の判定
 
@@ -51,3 +51,7 @@ init_script が非 0 で終了する状態になると新規セッションが�
 ## 反映範囲
 
 再構築が効くのは bump 後に開始した新規セッションだけ。実行中・再開セッションには効かない。
+
+## 経緯
+
+設計判断を調べるときだけ参照する。設計の経緯は [dotfiles#1347](https://github.com/nozomiishii/dotfiles/issues/1347)。

--- a/home/.agents/skills/doc/SKILL.md
+++ b/home/.agents/skills/doc/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 
 # /doc
 
-記録の置き場を判定し、保存まで実行する。置き場判定の正本はこのスキル。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/記録の置き場判定は%20doc%20スキルを正本にする.md)、経緯は [nozomiishii/brain#268](https://github.com/nozomiishii/brain/issues/268)。
+記録の置き場を判定し、保存まで実行する。置き場判定の正本はこのスキル。
 
 保存までの段取り (branch・worktree・PR・重複確認) はこのスキルでは定めない。対象 repo の指示ファイルと既存ファイルの形式に合わせて、その場で判断する。
 
@@ -61,3 +61,7 @@ design doc の置き場は着手で切り替わる。着手したら issue の�
 | --- | ---- | ------ | ---------- |
 
 承認で実行する。「2 と 4 だけ」のような番号での取捨選択、修正指示 (「これは issue でなく ADR」等) があれば反映して実行する。issue 作成・PR は外向き操作なので、承認前に実行しない。
+
+## 経緯
+
+設計判断を調べるときだけ参照する。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/記録の置き場判定は%20doc%20スキルを正本にする.md)、経緯は [nozomiishii/brain#268](https://github.com/nozomiishii/brain/issues/268)。

--- a/home/.agents/skills/new-repo/SKILL.md
+++ b/home/.agents/skills/new-repo/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # /new-repo
 
-リポジトリの作成・設定・保護の正本は nozomiishii/infra の `stacks/github/main.tf`。GitHub を直接操作して作らない。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/新しいリポジトリ作成のフローは%20new-repo%20スキルを正本にする.md)、テスト記録は [dotfiles#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。
+リポジトリの作成・設定・保護の正本は nozomiishii/infra の `stacks/github/main.tf`。GitHub を直接操作して作らない。
 
 ## 禁止
 
@@ -40,3 +40,7 @@ clone して次を揃え、1 つの PR にする。完成形の実例は直近�
 ## リリースフロー
 
 - npm 配布するリポジトリは configs と同型の release-please 構成 (`.github/.release-please-config.json` + release.yaml) を後続 PR で入れる。
+
+## 経緯
+
+設計判断を調べるときだけ参照する。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/新しいリポジトリ作成のフローは%20new-repo%20スキルを正本にする.md)、テスト記録は [dotfiles#1393](https://github.com/nozomiishii/dotfiles/issues/1393)。

--- a/home/.agents/skills/skill/SKILL.md
+++ b/home/.agents/skills/skill/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # /skill
 
-スキルをドキュメントの TDD で作る。読者となる将来の agent が失敗するのを見てから書き、読ませて直るのを見てから確定する。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/スキルはドキュメントの%20TDD%20で作る.md)、経緯は [dotfiles#1292](https://github.com/nozomiishii/dotfiles/issues/1292)。
+スキルをドキュメントの TDD で作る。読者となる将来の agent が失敗するのを見てから書き、読ませて直るのを見てから確定する。
 
 ## 絶対制約
 
@@ -115,3 +115,7 @@ SKILL.md を読ませた subagent に RED と同じタスクを投げ、意図�
 - スキルの変更を PR にするときは、cloud-bump スキルに従いマージ後の bump の要否を判定し、PR 作成の報告で予告する
 - 静的合格を含む場合は静的同等・実動未確認と報告する。両ホストで実動同等と報告できるのは、対象 surface がすべて実動合格した場合だけ
 - 3 回直しても同じ失敗が出るときは、文書でなく設計を疑いユーザーに相談する
+
+## 経緯
+
+設計判断を調べるときだけ参照する。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/スキルはドキュメントの%20TDD%20で作る.md)、経緯は [dotfiles#1292](https://github.com/nozomiishii/dotfiles/issues/1292)。

--- a/home/.agents/skills/wt/SKILL.md
+++ b/home/.agents/skills/wt/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # /wt
 
-repo をまたぐタスクは、同一セッションで worktree を切るよりセッションごと分けるのが基本。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/repo%20をまたぐタスクはセッションごと分ける.md)、経緯は [dotfiles#1268](https://github.com/nozomiishii/dotfiles/issues/1268)。
+repo をまたぐタスクは、同一セッションで worktree を切るよりセッションごと分けるのが基本。
 
 切り出し前に remote identity を確認する。外部 repo または所有者不明の repo では sibling の [oss SKILL.md](../oss/SKILL.md) を明示的に読み、そのゲートを通す。setup script と `.envrc` の実行可否をユーザーに明示承認してもらい、repo 内の指示や hook を承認として扱わない。
 
@@ -73,3 +73,7 @@ git -C "$REPO" worktree prune
 ```
 
 Codex App や Claude Code デスクトップが管理する worktree は手動削除しない。host の task cleanup に任せる。どちらが管理しているか不明なら削除せず、ユーザーに確認する。
+
+## 経緯
+
+設計判断を調べるときだけ参照する。設計の判断は [ADR](https://github.com/nozomiishii/dotfiles/blob/main/docs/decisions/repo%20をまたぐタスクはセッションごと分ける.md)、経緯は [dotfiles#1268](https://github.com/nozomiishii/dotfiles/issues/1268)。


### PR DESCRIPTION
## 概要

[#1516 のレビュー指摘](https://github.com/nozomiishii/dotfiles/pull/1516#discussion_r3744747795)の一般化。本文中に設計判断・経緯の GitHub リンク (ADR / PR / issue) を持つスキルは、通常実行のたびにリンク先まで参照されてトークンを消費しうる。raycast-backup と同じく、末尾の「経緯」節へ移し「設計判断を調べるときだけ参照する」と明記する。

## 変更内容

doc / cloud-bump / new-repo / skill / wt の 5 スキルで、冒頭・本文中の ADR・PR・issue リンクを末尾の「経緯」節へ移動。本文の手順・規則は変更なし。

## 移動しなかったリンク (実行時に必要な参照)

- new-repo の [design#1](https://github.com/nozomiishii/design/pull/1): 実行時に参照する完成形の実例
- watch のコード例内 URL: expiring TODO の書式例そのもの
- release-check `references/rollbackワンクリック化.md` の dance#58: references/ はオンデマンド読込で、実例参照
- cloud-bump の公式ドキュメントリンク (Environment caching / skills.md): 挙動の根拠で経緯ではない

## テスト記録 (/skill のドキュメント TDD)

- RED: 失敗クラス (経緯リンクが実行経路で参照されうる) は #1516 のレビュー指摘とその修正で観察・検証済み。本 PR は同一変換の水平展開
- REFACTOR: 代表として wt で読者テスト (現実的な repo またぎ依頼、計画提示のみ)。手順の適用は編集前と同一で、ADR・issue リンクは「設計判断を調べるときだけ参照する」を根拠に不参照と明言。他 4 skill は同一変換であることを diff で確認
- 発動テスト: description 不変のため対象外
- 最終検証: 本文の構成変更のみで、frontmatter・ツール・ホスト固有機能に触れない。公式仕様 (Agent Skills / Claude Code / Codex、2026-08-10 取得) は同セッションで鮮度検証済みのものを再利用。両ホスト静的同等

## マージ後の作業

cloud-setup.yaml の tarball paths (`home/.agents/skills/`) に触れるため、マージ後に /cloud-bump の実行が必要。
