### PR TITLE
chore: drop the Antigravity editor config

### DIFF
--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -378,21 +378,6 @@ fi
 ln -sf "$HOME/Library/Application Support/Code/User/snippets" "$snippets_dir"
 
 # ----------------------------------------------------------------
-# Antigravity
-# ----------------------------------------------------------------
-# Ensure the directory exists
-mkdir -p "$HOME/Library/Application Support/Antigravity/User/"
-
-ln -sf "$HOME/Library/Application Support/Code/User/keybindings.json" "$HOME/Library/Application Support/Antigravity/User/"
-ln -sf "$HOME/Library/Application Support/Code/User/settings.json" "$HOME/Library/Application Support/Antigravity/User/"
-
-snippets_dir="$HOME/Library/Application Support/Antigravity/User/snippets"
-if [ -d "$snippets_dir" ]; then
-  rm -rf "$snippets_dir"
-fi
-ln -sf "$HOME/Library/Application Support/Code/User/snippets" "$snippets_dir"
-
-# ----------------------------------------------------------------
 # Loginwindow
 # ----------------------------------------------------------------
 echo '- 🪟 window'


### PR DESCRIPTION
## 何をしたか

Antigravity をもう使わないので、`scripts/darwin/macos.sh` から設定のブロックを丸ごと消した。

VS Code の `keybindings.json` / `settings.json` / `snippets` を Antigravity に symlink していた箇所。Cursor 向けの同じ処理は残している。

## 調べた範囲

dotfiles 内で Antigravity に触れているのは `scripts/darwin/macos.sh` のこのブロックだけだった。Brewfile にエントリは無く、手動でインストールしたものと思われる。この PR の後、repo 内に `antigravity` の文字列は残らない。

## 手元でやること

この PR は「もう設定を作らない」だけで、既にあるものは消えない。アプリを使わないなら手元でこれも消す。

```sh
rm -rf "$HOME/Library/Application Support/Antigravity"
```

`/Applications/Antigravity.app` も残っているので、アプリごと消すならそちらも。

## 検証

- `bash -n scripts/darwin/macos.sh` が通ることを確認
- repo 内に `antigravity` の言及が残っていないことを確認 (大文字小文字を無視して検索)

## 関連

[#1518](https://github.com/nozomiishii/dotfiles/pull/1518) が merge されたので、この PR は main を base にしている。
