### PR TITLE
chore: remove duplicate approval paragraph in cloud-bump skill

### DIFF
--- a/home/.agents/skills/cloud-bump/SKILL.md
+++ b/home/.agents/skills/cloud-bump/SKILL.md
@@ -32,8 +32,6 @@ cloud 環境の setup script は毎セッション走らない。再構築のト
 
 Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。
 
-Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で、AskUserQuestion で「承認して POST する」「キャンセル」の選択肢を出す。テキスト返信を待つ承認にしない。差分を質問文にも直前のメッセージにも示さないまま選択肢だけを出さない。「承認して POST する」が選ばれたときだけ POST に進む。回答は同一ターンに返るため allowed-tools の許可は有効のまま使える。回答が得られないままターンをまたいだ場合は、「権限」の規則どおりスキルを起動し直して許可を再適用し、承認後の fresh GET の digest 照合を経てから POST する。
-
 Codex で承認を求めるときは、ユーザーへ「`$cloud-bump 承認` と返信してください」と案内して turn を終える。次の発話で skill を明示的に再起動し、Chrome 接続と GET 結果が承認前と一致することを確認してから POST する。単なる「承認します」という返信を、skill を再読せずに処理しない。
 
 ## 手順


### PR DESCRIPTION
## 概要

[home/.agents/skills/cloud-bump/SKILL.md](https://github.com/nozomiishii/dotfiles/blob/main/home/.agents/skills/cloud-bump/SKILL.md) の「## 承認」セクションに、「Claude Code で承認を求めるときは、環境名・snapshot digest・現在の bump 行・proposedBumpLine を提示した上で…」で始まる同一段落が 2 回連続で書かれていた (#1517 マージ後の main、33 行目と 35 行目)。片方を削除する。意味内容の変更はない。

## テスト記録 (/skill ドキュメント TDD)

- **RED**: 現行版の目視確認で重複を再現。33 行目と 35 行目が一字一句同一の段落であることを確認した (単純な重複削除のため subagent での失敗再現は省略)
- **GREEN**: 重複段落の片方 (35 行目) を削除。2 行削除のみ
- **REFACTOR (読者テスト)**: 編集後の SKILL.md を read-only subagent に読ませ、承認セクションの指示を列挙させた。結果:
  - 承認セクション内に同一内容の段落の重複はないこと
  - Claude Code の承認手順 (4 点の提示、AskUserQuestion の選択肢、ターンまたぎ時の再起動) と Codex の承認手順、共通の POST 前確認がすべて欠落なく読み取れること
- **発動テスト**: description は無変更のため対象外
- **最終検証 (Claude Code / Codex 同等性)**: 変更は同一段落の削除のみで、frontmatter・ツール名・ホスト固有の手順に触れていない。両ホストで読み取れる意味内容は変更前と同一 (静的同等・実動未確認)

## マージ後の対応

このファイルは cloud-setup.yaml の paths (`home/.agents/**`) に含まれる cloud 配信対象。マージ後に /cloud-bump の実行が必要。