### PR TITLE
fix: use japanese issue titles in retro skill

### DIFF
--- a/home/.agents/skills/retro/SKILL.md
+++ b/home/.agents/skills/retro/SKILL.md
@@ -49,7 +49,7 @@ description: >-
 issue 本文をドラフトしてユーザーに提示する。
 issue 作成は外向き操作なので、作成前に必ず承認を取る。
 
-- issue タイトル: Conventional Commits（英語）
+- issue タイトル: 内容を表す日本語。Conventional Commits 形式 (`feat:` 等の type prefix) は使わない。一覧で PR と見分けがつかなくなるため
 - issue 本文: 日本語
 - セッション内容は要約して本文に書く
 
@@ -61,7 +61,7 @@ issue 作成は外向き操作なので、作成前に必ず承認を取る。
 TITLE_FILE=$(mktemp)
 BODY_FILE=$(mktemp)
 cat > "$TITLE_FILE" <<'RETRO_TITLE_7D8A4F'
-<type>: <subject>
+<内容を表す日本語タイトル>
 RETRO_TITLE_7D8A4F
 cat > "$BODY_FILE" <<'RETRO_BODY_C2E91B'
 （日本語の issue 本文。session URL は書かない）


### PR DESCRIPTION
## 概要

retro スキルが issue タイトルを英語 Conventional Commits で作るルールになっており、issue 一覧で PR と見分けがつかない ([nozomiishii/language#39](https://github.com/nozomiishii/language/issues/39) など)。issue タイトルを内容を表す日本語に変更する。

変更は 2 箇所:

- ドラフト規約: 「Conventional Commits（英語）」→「内容を表す日本語。Conventional Commits 形式は使わない。一覧で PR と見分けがつかなくなるため」
- 作成コマンドのテンプレート: `<type>: <subject>` → `<内容を表す日本語タイトル>`

コミット・PR タイトルの Conventional Commits 運用は変えない。

## テスト記録 (/skill のドキュメント TDD)

### シナリオ

「brew bundle が LaunchAgent plist の symlink を実ファイルで上書きする問題を issue に切り出す」という現実的な依頼を、作業コピーの SKILL.md だけを読ませた subagent に実行させ、ドラフト提示で停止させる。

### RED (現行版で失敗を再現)

読者は 52 行目「issue タイトル: Conventional Commits（英語）」を逐語引用した上で、タイトルを次のとおり英語 CC で作成した:

> `fix: relink LaunchAgent plist symlinks after brew bundle overwrites them`

installed 版と作業コピーは cmp で同一であることを確認済み (読み込み元の差が結果に影響しない状態で観察)。

### GREEN (最小編集)

観察された失敗の根拠 2 箇所 (52 行目の規約・64 行目のテンプレート) だけを書き換えた。理由 (一覧で PR と紛らわしい) を残し、将来の編集で英語 CC へ戻されるのを防ぐ。

### REFACTOR (編集後の読者テスト)

同じ依頼に「急ぎ」「この repo は commitlint で英語 CC に統一している」という時間・一貫性の圧力を加えて実行。読者は新ルールを逐語引用し、圧力に対して「手順書は issue タイトルについて明示的に Conventional Commits 形式は使わないと定めている」と明示的に断った上で、prefix なしの日本語タイトルを提示した:

> `brew bundle 実行後に LaunchAgent plist の symlink が実ファイルで上書きされ dotfiles 管理から外れる`

installed 版 (旧ルール) と作業コピー (新ルール) は内容が異なるため、新ルール準拠の出力自体が作業コピーを読んだことの客観的な確認になっている。

### 発動テスト

該当なし。frontmatter (name / description) は非変更で、発動挙動に変化はない。

### 最終検証 (surface 別)

diff は markdown body のプロースのみ。frontmatter・ツール権限・パス解決・暗黙呼び出し設定に変更なし。公式情報 (2026-08-10 18:46 UTC 取得):

- [Agent Skills specification](https://agentskills.io/specification): Body content は「There are no format restrictions」
- [Claude Code skills](https://code.claude.com/docs/en/skills): SKILL.md 本文は呼び出し時に読み込まれる指示
- [Codex build-skills](https://learn.chatgpt.com/docs/build-skills): 本文は「Skill instructions for ChatGPT or Codex to follow」で固有の書式制約なし

| surface | 結果 | 根拠 |
| --- | --- | --- |
| Claude Code (subagent) | 実動合格 | 上記 RED / REFACTOR |
| Codex CLI 0.145.0 (`codex exec --sandbox read-only`, 使い捨て CODEX_HOME) | 実動合格 | 同一依頼で日本語タイトル「brew bundle 後に LaunchAgent の plist を再リンクする仕組みを追加する」を提示し、新ルールの行を逐語引用 |

両 surface とも実動同等。

## マージ後の作業

`home/.agents/**` は cloud 配信対象 (cloud-setup.yaml の paths) のため、マージ後に /cloud-bump の実行が必要。

## 補足

既存 issue の日本語化 (12 repo・41 件) はこの PR とは別に実施済み。
