### PR TITLE
feat: add journal-daily-summary launchd agent

### DIFF
--- a/home/Library/LaunchAgents/local.journal-daily-summary.plist
+++ b/home/Library/LaunchAgents/local.journal-daily-summary.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>local.journal-daily-summary</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-l</string>
+    <string>-c</string>
+    <!-- node を Homebrew/バージョンマネージャの PATH で解決し、$HOME を bash 展開で解決するためログインシェルで起動 -->
+    <string>cd "$HOME/Code/nozomiishii/brain" &amp;&amp; exec node --import tsx scripts/journal-daily-summary.ts</string>
+  </array>
+
+  <!-- 毎日 19:30 JST に発火 (20:00 のジャーナルタイム前に振り返り材料を揃える) -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>19</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/journal-daily-summary.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/journal-daily-summary.log</string>
+</dict>
+</plist>

--- a/home/Library/LaunchAgents/local.journal-daily-summary.plist
+++ b/home/Library/LaunchAgents/local.journal-daily-summary.plist
@@ -10,8 +10,10 @@
     <string>/bin/bash</string>
     <string>-l</string>
     <string>-c</string>
-    <!-- node を Homebrew/バージョンマネージャの PATH で解決し、$HOME を bash 展開で解決するためログインシェルで起動 -->
-    <string>cd "$HOME/Code/nozomiishii/brain" &amp;&amp; exec node --import tsx scripts/journal-daily-summary.ts</string>
+    <!-- claude CLI を PATH で解決し、$HOME を bash 展開で解決するためログインシェルで起動。
+         収集・要約の手順は brain の .agents/skills/journal-summary/SKILL.md が正本で、
+         launchd はヘッドレスの claude にスキルを実行させる薄いトリガー -->
+    <string>cd "$HOME/Code/nozomiishii/brain" &amp;&amp; exec claude -p "/journal-summary" --permission-mode bypassPermissions --model sonnet</string>
   </array>
 
   <!-- 毎日 19:30 JST に発火 (20:00 のジャーナルタイム前に振り返り材料を揃える) -->


### PR DESCRIPTION
## 概要

[brain#425](https://github.com/nozomiishii/brain/pull/425) で追加される `/journal-summary` skill (今日やったこと (GitHub / Claude Code / Codex) を集約して当日のデイリーノートに `## summary` を書く) を、毎日 19:30 JST にヘッドレスの claude で起動する launchd 設定を追加する。20:00 のジャーナルタイム前に振り返り材料を揃えるのが目的。

収集・要約の手順は brain repo の `.agents/skills/journal-summary/SKILL.md` が正本で、launchd はヘッドレスの claude にスキルを実行させる薄いトリガーに徹する (ノートへの書き込みは skill が `scripts/journal-upsert-summary.ts` 経由で行う。commit / push はしない)。

## 変更内容

- `home/Library/LaunchAgents/local.journal-daily-summary.plist` を新規作成 (形式は `local.downloads-to-desktop.plist` を踏襲)
  - `ProgramArguments`: `/bin/bash -l -c` で `cd "$HOME/Code/nozomiishii/brain" && exec claude -p "/journal-summary" --permission-mode bypassPermissions --model sonnet` を実行。ログインシェル経由で claude CLI の PATH を解決する
  - `--permission-mode bypassPermissions` は、gh・セッションファイル読み取り・ヘルパー実行を無人で通すために必要
  - `StartCalendarInterval`: 19:30
  - `RunAtLoad` / `KeepAlive` は付けない (定時実行のみ。常駐の downloads-to-desktop とはここが異なる)
  - ログ: `/tmp/journal-daily-summary.log`
- `~/Library/LaunchAgents` への symlink は `scripts/symlink.sh` の stow が `home/` 配下全体を対象にするため、個別の追加作業は不要

## 検証

- `plutil -lint` で構文 OK。`plutil -p` で `&amp;&amp;` が `&&` にデコードされ、意図どおりのコマンドラインが bash に渡ることを確認
- 設計転換前の旧構成 (`node --import tsx scripts/journal-daily-summary.ts`) では、同形式のコマンドライン実行で `brain/journal/` 当日ノートへの `## summary` 追記を確認済み
- 新コマンドライン (claude ヘッドレス実行) の発火確認は、この Mac の claude CLI が OAuth 失効中のためマージ後の反映手順に含めている。`launchctl bootstrap` も作成セッションの権限制約で実行できなかったため同様

## マージ後の反映手順

brain#425 のマージ後に実施する:

1. ヘッドレス実行は claude CLI のログインが前提。現在この Mac の CLI は OAuth 失効中なので、先にターミナルで claude にログインする
2. 反映と手動発火:

```bash
cd ~/Code/nozomiishii/dotfiles
git pull
make link
launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/local.journal-daily-summary.plist
launchctl start local.journal-daily-summary
cat /tmp/journal-daily-summary.log
```

3. `/tmp/journal-daily-summary.log` と `brain/journal/` 当日ノートの `## summary` 追記を確認する

## cloud bump 要否

**不要**。変更ファイル `home/Library/LaunchAgents/**` は `.github/workflows/cloud-setup.yaml` の `paths` (`home/.agents/**` / `home/.claude/**` / `home/.codex/**` / `home/AGENTS.md` / `scripts/cloud/**`) のいずれにも該当しない。