### PR TITLE
feat: install Xcode CLT headlessly so curl | bash runs to completion

### DIFF
--- a/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
+++ b/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
@@ -1,0 +1,24 @@
+# Xcode CLT は softwareupdate ヘッドレスで導入する
+
+Status: accepted
+Date: 2026-08-12
+
+## Context — 判断を迫られた状況
+
+素の Mac で `curl -fsSL https://dotfiles.nozo.sh | bash` を叩くと、Xcode Command Line Tools (CLT) が無い場合に Apple の GUI インストーラーを開いて exit 1 し、CLT インストール完了後にもう一度 curl を叩く 2 段階インストールになっていた。CLT のダウンロードは数時間かかることがあり、その完了を見張って再実行する手間が大きい。
+
+経緯は 2 転している。[#1440](https://github.com/nozomiishii/dotfiles/pull/1440) までは softwareupdate で CLI から直接インストールする方式だったが、sudo なしで `softwareupdate -i` を実行する弱点があった。[#1464](https://github.com/nozomiishii/dotfiles/pull/1464) で「GUI を開いて exit 1 し、再実行を促す」方式に置き換えたことで、この 2 段階が生まれた。
+
+## Decision — 決めたこと
+
+- Homebrew install.sh と同じ sudo 付き softwareupdate ヘッドレス方式で CLT をインストールし、curl 1 回で最後まで走り切らせる
+  - placeholder ファイル `/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress` を置いて `softwareupdate -l` に CLT を列挙させ、ラベルを `softwareupdate -i` に渡す
+- ラベル取得やインストールに失敗したときだけ、従来どおり `xcode-select --install` で GUI を開いて exit 1 し、再実行を促す
+- Darwin の呼び出し順は request_admin_privileges → request_documents_access → ensure_xcode_clt とし、人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約する。CLT の長いダウンロード中は sudo keepalive が効いているので、以降は無人で走る
+
+## Consequences — 決定がもたらすもの
+
+- 素の Mac でも curl 1 回でセットアップが完走する。GUI ダイアログの承諾クリックと再実行が不要になる
+- #1464 が意図した「CLT が無くて exit するとき sudo を無駄に聞かない」性質は失われるが、exit するのはヘッドレス失敗の稀なケースだけなので許容する
+- ラベル抽出は softwareupdate -l の出力フォーマットに依存する。フォーマットが変わって取れなくなっても GUI フォールバックで従来の挙動に戻るだけで、インストール自体は塞がらない
+- placeholder の掃除は request_admin_privileges の EXIT trap に集約している。bash の EXIT trap は 1 本しか持てないため、trap を増やすときは既存 trap に追記する

--- a/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
+++ b/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
@@ -19,6 +19,7 @@ Date: 2026-08-12
 ## Consequences — 決定がもたらすもの
 
 - 素の Mac でも curl 1 回でセットアップが完走する。GUI ダイアログの承諾クリックと再実行が不要になる
+- CI の素の Mac 相当環境 (CLT と Xcode を削除した macos-latest) で、ヘッドレスインストールが 3 分強で完走することを実機確認済み ([run 31592485654](https://github.com/nozomiishii/dotfiles/actions/runs/31592485654))
 - #1464 が意図した「CLT が無くて exit するとき sudo を無駄に聞かない」性質は失われるが、exit するのはヘッドレス失敗の稀なケースだけなので許容する
 - ラベル抽出は softwareupdate -l の出力フォーマットに依存する。フォーマットが変わって取れなくなっても GUI フォールバックで従来の挙動に戻るだけで、インストール自体は塞がらない
 - placeholder の掃除は request_admin_privileges の EXIT trap に集約している。bash の EXIT trap は 1 本しか持てないため、trap を増やすときは既存 trap に追記する

--- a/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
+++ b/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
@@ -7,7 +7,7 @@ Date: 2026-08-12
 
 素の Mac で `curl -fsSL https://dotfiles.nozo.sh | bash` を叩くと、Xcode Command Line Tools (CLT) が無い場合に Apple の GUI インストーラーを開いて exit 1 し、CLT インストール完了後にもう一度 curl を叩く 2 段階インストールになっていた。CLT のダウンロードは数時間かかることがあり、その完了を見張って再実行する手間が大きい。
 
-経緯は 2 転している。[#1440](https://github.com/nozomiishii/dotfiles/pull/1440) までは softwareupdate で CLI から直接インストールする方式だったが、sudo なしで `softwareupdate -i` を実行する弱点があった。[#1464](https://github.com/nozomiishii/dotfiles/pull/1464) で「GUI を開いて exit 1 し、再実行を促す」方式に置き換えたことで、この 2 段階が生まれた。
+経緯は 2 転している。[#1440](https://github.com/nozomiishii/dotfiles/pull/1440) までは softwareupdate で CLI から直接インストールする方式だった (sudo なしで `softwareupdate -i` を実行する弱点があった)。[#1464](https://github.com/nozomiishii/dotfiles/pull/1464) は新しい Mac へ導入する前に敵対的レビューで直せる箇所を直す依頼から生まれた PR で、softwareupdate 方式が実機で壊れた記録はない。実動検証できない headless インストールより Apple 公式の `xcode-select --install` を開いて安全に終了する方が確実、という安全側の設計判断で置き換えられ、この 2 段階が生まれた (当時の Codex セッションの記録より)。
 
 ## Decision — 決めたこと
 

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,9 @@ DOTFILES_REPO="https://github.com/nozomiishii/dotfiles.git"
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Code/nozomiishii/dotfiles}"
 OS_NAME="$(uname -s)"
 
+# この placeholder があると softwareupdate -l が CLT をアップデート対象として列挙する
+CLT_PLACEHOLDER="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+
 # ----------------------------------------------------------------
 # utils
 # ----------------------------------------------------------------
@@ -43,7 +46,9 @@ request_admin_privileges() {
   SUDOERS_FILE="/etc/sudoers.d/temp_dotfiles_installer"
   sudo sh -c "echo 'Defaults timestamp_timeout=120' > ${SUDOERS_FILE}"
   sudo chmod 0440 "${SUDOERS_FILE}"
-  trap 'sudo rm -f "${SUDOERS_FILE}"' EXIT
+  # bash の EXIT trap は 1 本のみ。placeholder の掃除もここに集約する
+  # (ensure_xcode_clt で trap を新設すると sudoers の掃除を上書きして壊す)
+  trap 'sudo rm -f "${SUDOERS_FILE}" "${CLT_PLACEHOLDER}"' EXIT
 
   sudo -v
 
@@ -75,7 +80,12 @@ request_documents_access() {
 # ensure_xcode_clt はスクリプトに切り出さず、このファイルに置く。
 # repo の clone には git が必要で、素の Mac では git を使うのに Command Line Tools が要る。
 # つまり curl | bash 経路でこの処理が走る時点では、repo のスクリプトはまだ手元に存在しない。
+#
+# Homebrew install.sh と同じ softwareupdate ヘッドレス方式でインストールし、
+# curl | bash 一発で最後まで走り切れるようにする。失敗時だけ GUI インストーラーに
+# フォールバックして再実行を促す。
 # @See https://developer.apple.com/documentation/xcode/installing-the-command-line-tools
+# @See https://github.com/Homebrew/install/blob/master/install.sh
 ensure_xcode_clt() {
   echo "- 👨🏻‍🚀 Checking Xcode CLI tools..."
 
@@ -84,7 +94,41 @@ ensure_xcode_clt() {
     return
   fi
 
-  echo "- 👨🏻‍🚀 Xcode CLI tools not found. Opening Apple's installer..."
+  echo "- 👨🏻‍🚀 Xcode CLI tools not found. Installing them (this may take a while)..."
+  # 前回の中断で root 所有の残骸が残っていても上書きできるよう sudo で作る
+  sudo touch "${CLT_PLACEHOLDER}"
+
+  # ラベル例: "Command Line Tools for Xcode-16.4"
+  # ラベルが見つからないと grep が非ゼロ終了し pipefail でパイプ全体が失敗するため、
+  # || true で空文字に落として下のフォールバック判定に委ねる
+  local clt_label
+  clt_label="$(softwareupdate -l 2> /dev/null \
+    | grep -B 1 -E 'Command Line Tools' \
+    | awk -F'*' '/^ *\*/ {print $2}' \
+    | sed -e 's/^ *Label: //' -e 's/^ *//' \
+    | sort -V \
+    | tail -n 1 \
+    || true)"
+
+  if [ -n "${clt_label}" ]; then
+    echo "- 👨🏻‍🚀 Installing: ${clt_label}"
+    # 失敗しても set -e で即死させず、下の検証とフォールバックに進める
+    sudo softwareupdate -i "${clt_label}" --verbose || true
+  fi
+
+  sudo rm -f "${CLT_PLACEHOLDER}"
+
+  # インストール失敗時はディレクトリが無く、無条件に switch すると set -e で死ぬ
+  if [ -d /Library/Developer/CommandLineTools ]; then
+    sudo xcode-select --switch /Library/Developer/CommandLineTools
+  fi
+
+  if xcode-select -p &>/dev/null; then
+    echo "- 👨🏻‍🚀 Xcode CLI tools are ready to go 🎉"
+    return
+  fi
+
+  echo "⚠️ Automatic installation failed. Opening Apple's installer instead..." >&2
   if xcode-select --install; then
     echo "- 👨🏻‍🚀 The Xcode CLI tools installation was requested."
   else
@@ -128,9 +172,12 @@ printf '%s\n' \
 echo -e "${reset}"
 
 if [[ "$OS_NAME" == "Darwin" ]]; then
-  ensure_xcode_clt
+  # 人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約する。
+  # ensure_xcode_clt は sudo を使い、CLT のダウンロードに数十分かかることがあるため、
+  # sudoers + keepalive を先に確立してからヘッドレスで走らせる
   request_admin_privileges
   request_documents_access
+  ensure_xcode_clt
   clone_dotfiles_repo
   bash "$SCRIPT_DIR/scripts/nix.sh"
   bash "$SCRIPT_DIR/scripts/homebrew.sh"


### PR DESCRIPTION
## 概要

素の Mac で `curl -fsSL https://dotfiles.nozo.sh | bash` を叩くと、Xcode Command Line Tools (CLT) が無い場合に GUI インストーラーを開いて exit 1 し、CLT インストール完了後にもう一度 curl を叩く 2 段階インストールになっていた。Homebrew install.sh と同じ sudo 付き softwareupdate ヘッドレス方式に変更し、curl 1 回で最後まで走り切るようにする。

## 変更内容

- `ensure_xcode_clt` を softwareupdate ヘッドレス方式に置換
  - placeholder ファイルで `softwareupdate -l` に CLT を列挙させ、ラベルを `sudo softwareupdate -i` に渡す (Homebrew 互換のラベル抽出パイプライン)
  - ラベル取得やインストールに失敗したときだけ、従来どおり `xcode-select --install` で GUI を開いて exit 1 し、再実行を促す
- Darwin の呼び出し順を `request_admin_privileges` → `request_documents_access` → `ensure_xcode_clt` に変更し、人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約
  - CLT の長いダウンロード中は既存の sudo keepalive が効くため、以降は無人で走る
- placeholder の掃除を `request_admin_privileges` の EXIT trap に追記 (bash の EXIT trap は 1 本のみのため新設しない)
- 判断の経緯を ADR `docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md` に記録

## 経緯

- #1440 までは softwareupdate 方式だったが、sudo なしで `softwareupdate -i` を実行する弱点があった
- #1464 で「GUI を開いて exit 1」方式に置換され、2 段階インストールが生まれた
- 今回は sudo 付き + GUI フォールバックで走り切る方式に戻す

## 検証

- `bash -n install.sh` / `shellcheck install.sh` で指摘なし
- ラベル抽出パイプラインを実機で単体検証 (placeholder 設置 → `Command Line Tools for Xcode 26.6-26.6` が取れることを確認 → 掃除)
- `ensure_xcode_clt` を抽出し、xcode-select / softwareupdate / sudo をモックした 2 シナリオで検証
  - 正常系: ラベル取得 → インストール → 完走メッセージで return、placeholder 掃除済み
  - フォールバック系: ラベル 0 件 → GUI 案内 + exit 1、placeholder 掃除済み
- ヘッドレス経路そのものを素の Mac 相当環境で実機検証済み: macos-latest ランナーから CLT と Xcode を削除し (`xcode-select -p` が失敗する状態)、この PR の `ensure_xcode_clt` をそのまま実行して完走を確認 ([run 31592485654](https://github.com/nozomiishii/dotfiles/actions/runs/31592485654))
  - ラベル取得 → ダウンロード → インストール → `xcode-select -p` 成功、CLT の git 動作、placeholder 掃除済みまで確認。所要 3 分 10 秒
- CI (macos-latest) は CLT プリインストールのため早期 return 経路で完走を確認する

## 備考

- README の `xcode-select --install` 記載は Install Manually 節の手動手順として引き続き正しいため変更なし
- cloud-setup.yaml の paths に install.sh は含まれないため cloud-bump 不要
