### PR TITLE
fix: open find-note results in obsidian

### DIFF
--- a/home/.agents/skills/find-note/SKILL.md
+++ b/home/.agents/skills/find-note/SKILL.md
@@ -23,20 +23,26 @@ git remote が `nozomiishii/brain` を指す clone を、現在の task、ホス
 
 - 内容の grep を主にする。ファイル名の一致だけでは拾えない。Terraform で探すと OpenTofu ノートの本文にだけ書いてある、のような表記ゆれが普通にある
 - 検索語は 1 語に決め打ちせず、日本語と英語、ツールの別名、エラーメッセージの断片を並べて試す
-- ヒットしたらファイル本文を読み、要点と、現在のホストで開けるノートへの Markdown リンクを報告する
+- ヒットしたらファイル本文を読み、要点と、Obsidian で開くノートへの Markdown リンクを報告する
 
-Claude Code では cwd 相対のリンクを使う。cwd は予測できないので、ノート1件ごとにこう作る:
+リンク先には `obsid.net` の HTTPS 中継 URL を使う。vault 名と vault ルートからのノート相対パスを別々に URL エンコードし、`file` から末尾の `.md` を外す。ノート1件ごとにこう作る:
 
 ```sh
-python3 - "<ノートの絶対パス>" <<'PY'
-import os, sys
-target = sys.argv[1]
-rel = os.path.relpath(target, os.getcwd()).replace(" ", "%20")
-print(f"[{os.path.basename(target)}]({rel})")
+python3 - "<vault ルートの絶対パス>" "<ノートの絶対パス>" <<'PY'
+import sys
+from pathlib import Path
+from urllib.parse import quote, urlencode
+
+vault_root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+relative = target.relative_to(vault_root).with_suffix("").as_posix()
+query = urlencode(
+    {"vault": vault_root.name, "file": relative},
+    quote_via=quote,
+)
+print(f"[{relative}（Obsidian で開く）](https://obsid.net/?{query})")
 PY
 ```
-
-Codex では現在の response rules に従う。通常は `$HOME` などを展開した絶対パスを Markdown リンクの target にする。スペースを含む target は山括弧で囲む。
 
 ## 調べる順番
 


### PR DESCRIPTION
## 概要

- `find-note` の検索結果を `obsid.net` の HTTPS 中継 URL で返すように変更
- vault 名と vault ルートからの相対パスを個別に URL エンコード
- `file` パラメータから末尾の `.md` を除去
- Claude Code と Codex のホスト固有ローカルファイルリンクを共通手順へ統合

## 背景

Codex App では `obsidian://` の Markdown リンク、`.webloc`、ローカルファイルリンクから Obsidian の対象ノートを開けなかった。`https://obsid.net/?vault=...&file=...` は実際にクリックして対象ノートを開けることが確認済みのため、この形式を検索結果の正本にする。

## テスト記録

### RED

一時 profile の現行版 `SKILL.md` だけを読ませ、テスト用 brain vault から HDMI キャプチャカードのノートを検索した。

- 読み込み元: `/private/tmp/find-note-obsid-net-a01b/red/profile/skills/find-note/SKILL.md`
- 観察された失敗: `該当ノート: [HDMIキャプチャカードとMacBook ProでMac miniを初期設定する.md](</private/tmp/find-note-obsid-net-a01b/red/repo/brain/main/HDMIキャプチャカードとMacBook ProでMac miniを初期設定する.md>)`
- 観察された挙動: Codex 固有の絶対ファイルリンクになり、確認済みの `obsid.net` 形式を返さなかった
- 言い訳: なし

### GREEN / REFACTOR

同じ fixture と依頼を変更後の一時 skill に渡した。

- 読み込み元: `/private/tmp/find-note-obsid-net-a01b/green/profile/skills/find-note/SKILL.md`
- 結果: `vault=brain`、`file=main%2F...`、末尾 `.md` なしの `obsid.net` Markdown リンクを返した
- 表示名: `main/HDMIキャプチャカードとMacBook ProでMac miniを初期設定する（Obsidian で開く）`
- 新しい抜け・言い訳: なし

### 発動テスト

本文を見せず、`find-note`・`doc`・`find-docs` の description だけで判定した。

| 発話 | 期待 | 判定 |
| --- | --- | --- |
| brain に HDMI キャプチャのメモがあった気がする。探して | find-note | find-note |
| このエラー、前にも踏んだ気がするんだけど直し方を調べて | find-note | find-note |
| find-not で OpenTofu の過去メモを見つけたい | find-note | find-note |
| home/.agents/skills/find-note/SKILL.md を使って、Terraform の記録を探して | find-note | find-note |
| 今日決めた運用を brain にメモしておいて | doc | doc |
| 最新の Terraform provider API を公式ドキュメントで確認して | find-docs | find-docs |
| この repo の README に書いてあるセットアップ手順を要約して | none | none |

### URL と文書の検証

- 動作確認済みの HDMI ノート URL と生成結果が完全一致
- 日本語と空白を含む vault 名、階層区切り、日本語と空白を含むノート相対パスの percent-encoding を検証
- `pnpm prettier home/.agents/skills/find-note/SKILL.md --check`
- `pnpm exec markdownlint-cli2 - < home/.agents/skills/find-note/SKILL.md`
- `pnpm test`
- `git diff --check`

## 互換性検証

公式情報は 2026-08-12T19:27:47+09:00 に取得した。

- [Agent Skills specification](https://agentskills.io/specification): `SKILL.md` の共通 frontmatter と Markdown 本文、progressive disclosure を確認
- [Claude Code skills](https://code.claude.com/docs/en/slash-commands): `.claude/skills`、`--add-dir` での skill 検出、description による暗黙発動を確認
- [Codex skills](https://learn.chatgpt.com/docs/build-skills): `.agents/skills`、description による暗黙発動、`agents/openai.yaml` の invocation policy を確認

| Surface | 結果 | 根拠 |
| --- | --- | --- |
| Codex App（version 非公開） | 実動合格 | 一時 skill の canonical path を固定した subagent が確認済み URL を生成 |
| Codex CLI 0.145.0 | 実動合格 | read-only の一時 repo で `.agents/skills/find-note/SKILL.md` を読み、確認済み URL を生成 |
| Claude Code CLI 2.1.220 | 静的合格（実動未確認） | `--add-dir` 配下の一時 `.claude/skills` を watch することを debug log で確認。モデル実行は OAuth セッション期限切れで開始前に停止 |
| Claude Code cloud / Codex cloud | 静的合格（実動未確認） | `scripts/cloud/setup.sh` が同じ skill を `~/.claude/skills` と `~/.agents/skills` にコピー。本文は共通 Markdown と Python 3 のみを使用 |

目的・入力・出力・停止条件は両ホストで同じ。ホスト固有のローカルファイルリンク分岐は削除した。暗黙呼び出し設定は変更していない。

## cloud-bump

変更した `home/.agents/**` は `.github/workflows/cloud-setup.yaml` の `paths` に一致する。マージ前には bump せず、マージ後に `/cloud-bump` の実行が必要。
