### PR TITLE
fix: keep the setup running when a package install fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,37 @@ OS_NAME="$(uname -s)"
 yellow='\033[1;33m'
 reset='\033[0m'
 
+# アプリのインストールなど一部のステップが落ちても、残りのステップは走らせて
+# セットアップを最後まで進める。1 つの配布元が落ちただけで symlink や toolchain の
+# セットアップまで巻き添えで止まるのを防ぐ。
+# 失敗は握りつぶさず FAILED_STEPS に積み、最後にまとめて報告して非ゼロで終了する。
+FAILED_STEPS=()
+
+run_step() {
+  local label="$1"
+  shift
+
+  if "$@"; then
+    return 0
+  fi
+
+  echo -e "⚠️  ${label} failed — continuing with the remaining steps" >&2
+  FAILED_STEPS+=("$label")
+  return 0
+}
+
+# homebrew.sh が失敗して brew が無い状態でも、後続ステップに進めるようにする。
+load_brew_shellenv() {
+  local brew_bin="$1"
+
+  if [ ! -x "$brew_bin" ]; then
+    echo -e "⚠️  ${brew_bin} not found — skipping shellenv" >&2
+    return 0
+  fi
+
+  eval "$("$brew_bin" shellenv)"
+}
+
 # request_admin_privileges is kept in this file (not extracted to a script)
 # because it manages main-process state: it sets an EXIT trap and starts a
 # background sudo keepalive. Running it in a subshell would not affect the
@@ -132,36 +163,59 @@ if [[ "$OS_NAME" == "Darwin" ]]; then
   request_admin_privileges
   request_documents_access
   clone_dotfiles_repo
-  bash "$SCRIPT_DIR/scripts/nix.sh"
-  bash "$SCRIPT_DIR/scripts/homebrew.sh"
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-  bash "$SCRIPT_DIR/scripts/symlink.sh"
-  bash "$SCRIPT_DIR/scripts/darwin/macos.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
-  bash "$SCRIPT_DIR/scripts/default_apps.sh"
-  bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
+  run_step "nix.sh" bash "$SCRIPT_DIR/scripts/nix.sh"
+  run_step "homebrew.sh" bash "$SCRIPT_DIR/scripts/homebrew.sh"
+  load_brew_shellenv /opt/homebrew/bin/brew
+  run_step "symlink.sh" bash "$SCRIPT_DIR/scripts/symlink.sh"
+  run_step "darwin/macos.sh" bash "$SCRIPT_DIR/scripts/darwin/macos.sh"
+  run_step "toolchains/node.sh" bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
+  run_step "toolchains/python.sh" bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
+  run_step "toolchains/ruby.sh" bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
+  run_step "toolchains/rust.sh" bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
+  run_step "toolchains/terraform.sh" bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  run_step "toolchains/claude-code.sh" bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  run_step "toolchains/pm.sh" bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
+  run_step "default_apps.sh" bash "$SCRIPT_DIR/scripts/default_apps.sh"
+  run_step "darwin/open_config_apps.sh" bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
 fi
 
 if [[ "$OS_NAME" == "Linux" ]]; then
   clone_dotfiles_repo
-  bash "$SCRIPT_DIR/scripts/nix.sh"
-  bash "$SCRIPT_DIR/scripts/zsh.sh"
-  bash "$SCRIPT_DIR/scripts/homebrew.sh"
-  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-  bash "$SCRIPT_DIR/scripts/symlink.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
-  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
+  run_step "nix.sh" bash "$SCRIPT_DIR/scripts/nix.sh"
+  run_step "zsh.sh" bash "$SCRIPT_DIR/scripts/zsh.sh"
+  run_step "homebrew.sh" bash "$SCRIPT_DIR/scripts/homebrew.sh"
+  load_brew_shellenv /home/linuxbrew/.linuxbrew/bin/brew
+  run_step "symlink.sh" bash "$SCRIPT_DIR/scripts/symlink.sh"
+  run_step "toolchains/node.sh" bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
+  run_step "toolchains/python.sh" bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
+  run_step "toolchains/ruby.sh" bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
+  run_step "toolchains/rust.sh" bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
+  run_step "toolchains/terraform.sh" bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  run_step "toolchains/claude-code.sh" bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  run_step "toolchains/pm.sh" bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
+fi
+
+# 失敗したステップがあっても最後までは実行している。ここで初めて非ゼロを返す。
+# bash 3.2 では set -u 下の "${FAILED_STEPS[@]}" が空配列で unbound variable に
+# なるため、件数でガードしてから展開する。
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+  echo -e "${yellow}"
+  printf '%s\n' \
+    "" \
+    "⚠️  セットアップは最後まで実行しましたが、失敗したステップがあります:" \
+    ""
+  printf '      - %s\n' "${FAILED_STEPS[@]}"
+  printf '%s\n' \
+    "" \
+    "    ログを確認して、個別に再実行してください:" \
+    "      bash $SCRIPT_DIR/scripts/<script>" \
+    "" \
+    "    Homebrew だけ入れ直す場合:" \
+    "      make -C \"$SCRIPT_DIR\" homebrew" \
+    "" \
+    ""
+  echo -e "${reset}"
+  exit 1
 fi
 
 echo -e "${yellow}"

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -29,6 +29,52 @@ fix_brew_link_conflicts() {
   done
 }
 
+# brew bundle は fetch を全件まとめて 1 回の `brew fetch` に渡し、1 件でも失敗
+# すると install フェーズに一切進まない (Library/Homebrew/bundle/installer.rb の
+# "Failed to fetch" → return false)。到達不能な配布元が 1 つあるだけで、ダウン
+# ロード済みのものまで含めて全パッケージが巻き添えになる。
+# そのため bundle が通らなかったときは、エントリを 1 件ずつ入れ直して
+# 1 件の失敗が他に波及しないようにする。
+install_entries_individually() {
+  local brewfile="$1"
+  local failed=()
+  local name
+
+  # tap を先に入れる。nozomiishii/tap/brooklyn は tap が無いと解決できない。
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    brew tap "$name" || failed+=("tap $name")
+  done < <(brew bundle list --file="$brewfile" --tap)
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    brew install --formula "$name" || failed+=("brew $name")
+  done < <(brew bundle list --file="$brewfile" --formula)
+
+  # cask は macOS 専用。brew bundle 本体は Skipper で Linux の cask を除外するが、
+  # Lister は Skipper を通さない (Library/Homebrew/bundle/lister.rb) ため
+  # `brew bundle list --cask` は Linux でも Brewfile の cask を返してしまう。
+  # そのまま流すと Linux で必ず失敗するので、ここで OS を見て飛ばす。
+  if [[ "$OS_NAME" == "Darwin" ]]; then
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      brew install --cask "$name" || failed+=("cask $name")
+    done < <(brew bundle list --file="$brewfile" --cask)
+  fi
+
+  # 通常経路の `brew bundle --cleanup` と同じ状態に揃える。cleanup は Brewfile に
+  # 無いものだけを消すので、入れ損ねたエントリには触れない。
+  brew bundle cleanup --force --file="$brewfile" || true
+
+  # bash 3.2 では set -u 下の "${failed[@]}" が空配列で unbound variable になる。
+  # 件数でガードしてから展開する。
+  if [ "${#failed[@]}" -gt 0 ]; then
+    echo "⚠️  個別インストールでも失敗したエントリ:" >&2
+    printf '  - %s\n' "${failed[@]}" >&2
+    return 1
+  fi
+}
+
 trust_brew_bundle_formulae() {
   if ! brew help trust >/dev/null 2>&1; then
     return 0
@@ -72,6 +118,7 @@ trust_brew_bundle_formulae
 max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1
 backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
+install_failed=0
 
 # Brewfile を正にする（入れて、Brewfile にないものを削除。App Store は対象外）。
 # install と cleanup は一体にする（分けると node 等の依存を巻き添え削除するため）。
@@ -86,8 +133,9 @@ while [ "$attempt" -le "$max_attempts" ]; do
     break
   fi
   if [ "$attempt" -eq "$max_attempts" ]; then
-    echo "brew bundle failed after ${max_attempts} attempts"
-    exit 1
+    echo "brew bundle failed after ${max_attempts} attempts — falling back to individual installs"
+    install_entries_individually "$SCRIPT_DIR/Brewfile" || install_failed=1
+    break
   fi
 
   fix_brew_link_conflicts
@@ -98,3 +146,10 @@ done
 
 # 古いバージョン・キャッシュを削除してディスクを空ける
 brew cleanup --verbose
+
+# 入れられるものは入れ切った上で、残った失敗は呼び出し元に伝える。
+# make homebrew 単体実行と lefthook の post-merge で失敗を検知できる状態を保つ。
+# install.sh から呼ばれた場合は、この非ゼロを受け取っても後続ステップを続行する。
+if [ "$install_failed" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## 背景

Mac mini のセットアップ中に `brew bundle` が AppCleaner の fetch で落ち、**stow / starship を含む 85 パッケージが 1 つも入らないまま install.sh が停止**した。symlink.sh 以降（macOS 設定・全 toolchain・default_apps）が丸ごとスキップされ、セットアップが完了しなかった。

引き金は DNS 側の事情だったが（Cloudflare for Families が `freemacsoft.net` をアダルト誤判定して `0.0.0.0` を返していた）、この PR はそこには触れず、**1 つの配布元が落ちるだけでセットアップ全体が死ぬ構造**だけを直す。

## 原因

失敗が 3 層で増幅されていた。

1. `brew bundle` は fetch を全件まとめて 1 回の `brew fetch` に渡し、失敗すると install フェーズに一切進まない（`Library/Homebrew/bundle/installer.rb` の `Failed to fetch` → `return false`）。ダウンロード済みのものすら入らない
2. `scripts/homebrew.sh` がリトライ枯渇時に `exit 1`
3. `install.sh` は `set -Ceuo pipefail` 配下なので、そこで即死

5 回のリトライは、恒久的な到達不能に対しては 200 秒を捨てるだけで無意味だった。

## 変更内容

### scripts/homebrew.sh

bundle が通らなかったときに、個別インストールへフォールバックする。tap → formula → cask の順に 1 件ずつ入れるので、1 件の失敗が他に波及しない。入れ切った後に `brew bundle cleanup --force` で通常経路と同じ状態に揃え、残った失敗があれば非ゼロで返す（`make homebrew` 単体実行と lefthook の post-merge では今まで通り失敗を検知できる）。

cask ループは macOS 限定にしている。`Lister` は `Skipper` を通さないため `brew bundle list --cask` が Linux でも cask を返してしまい、そのまま流すと Linux CI で偽の失敗が出るため。

### install.sh

各ステップを `run_step` で包み、失敗しても記録して次へ進む。`brew shellenv` は brew 不在でも死なないようガードした。最後に失敗一覧を出して `exit 1` する（失敗があるときは完了メッセージを出さない）。

前提条件である `ensure_xcode_clt` / `request_admin_privileges` / `request_documents_access` / `clone_dotfiles_repo` は、失敗したら続行しても意味がないので従来通り即時終了のまま。

## 検証

| 項目 | 結果 |
| --- | --- |
| bash 3.2 構文チェック（`/bin/bash -n`） | 両ファイル OK |
| shellcheck | 警告なし |
| フォールバック: macOS / 1 件失敗 | 他は全部入り、失敗一覧を出して exit 1 |
| フォールバック: macOS / 全成功 | exit 0（空配列ガード動作） |
| フォールバック: Linux | cask をスキップして exit 0 |
| run_step: 途中失敗 | 最後まで到達、2 件記録、スクリプトは死なない |

初回セットアップ時は Homebrew 版 bash が無く `/bin/bash` 3.2 で走るため、bash 3.2 互換で書いている。空配列の `"${arr[@]}"` が `set -u` 下で `unbound variable` になる件は実際に踏んだので、展開箇所はすべて件数ガードを入れた。

実 brew は呼ばずスタブで検証したので、実機での最終確認は Mac mini での再実行時に行う。

## スコープ外

- `appcleaner` の Brewfile からの削除 / Pearcleaner への置き換え
- Mac mini の DNS 設定変更
- リトライ回数・バックオフ秒数の見直し
