### PR TITLE
feat: set mouse tracking speed to fastest

### DIFF
--- a/scripts/darwin/macos.sh
+++ b/scripts/darwin/macos.sh
@@ -319,6 +319,14 @@ defaults write NSGlobalDomain com.apple.trackpad.forceClick -bool false
 defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 0
 
 # ----------------------------------------------------------------
+# Mouse
+# ----------------------------------------------------------------
+echo "- 🖱 Mouse"
+
+# Tracking Speed => 0: Slow 3: Fast
+defaults write NSGlobalDomain com.apple.mouse.scaling -float 3
+
+# ----------------------------------------------------------------
 # Display
 # ----------------------------------------------------------------
 echo "- 🖥 Display"


### PR DESCRIPTION
## 概要

マウスのトラッキングスピードを最速にする設定を `scripts/darwin/macos.sh` に追加しました。

## 変更内容

- Trackpad セクションの直後に Mouse セクションを新設
- `defaults write NSGlobalDomain com.apple.mouse.scaling -float 3` を追加(システム設定 UI での最速値)

## 補足

- 既存の Trackpad の Tracking Speed 設定(`com.apple.trackpad.scaling -float 3`)と同じ形式・同じ値に揃えています
- `com.apple.mouse.scaling` は UI の上限(3.0)を超える値も受け付けますが、今回は Trackpad と揃えて 3 にしています
- 反映には `macos.sh` の再実行と再ログイン(またはマウスの抜き差し)が必要です