### PR TITLE
fix: keep the install unattended after brew resets the sudo timestamp

### DIFF
--- a/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
+++ b/docs/decisions/Xcode CLT は softwareupdate ヘッドレスで導入する.md
@@ -14,7 +14,7 @@ Date: 2026-08-12
 - Homebrew install.sh と同じ sudo 付き softwareupdate ヘッドレス方式で CLT をインストールし、curl 1 回で最後まで走り切らせる
   - placeholder ファイル `/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress` を置いて `softwareupdate -l` に CLT を列挙させ、ラベルを `softwareupdate -i` に渡す
 - ラベル取得やインストールに失敗したときだけ、従来どおり `xcode-select --install` で GUI を開いて exit 1 し、再実行を促す
-- Darwin の呼び出し順は request_admin_privileges → request_documents_access → ensure_xcode_clt とし、人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約する。CLT の長いダウンロード中は sudo keepalive が効いているので、以降は無人で走る
+- Darwin の呼び出し順は request_admin_privileges → request_documents_access → ensure_xcode_clt とし、人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約する。CLT の長いダウンロード中もインストール中限定の NOPASSWD sudoers が効いているので、以降は無人で走る
 
 ## Consequences — 決定がもたらすもの
 

--- a/install.sh
+++ b/install.sh
@@ -63,9 +63,15 @@ load_brew_shellenv() {
 }
 
 # request_admin_privileges is kept in this file (not extracted to a script)
-# because it manages main-process state: it sets an EXIT trap and starts a
-# background sudo keepalive. Running it in a subshell would not affect the
-# current process, so it must remain here.
+# because it manages main-process state: it sets an EXIT trap. Running it in
+# a subshell would not affect the current process, so it must remain here.
+#
+# timestamp_timeout + keepalive (sudo -n true) の延命方式は使わない。
+# brew は起動するたびに `sudo --reset-timestamp` で sudo の認証キャッシュを
+# 破棄するため (Library/Homebrew/brew.sh)、homebrew.sh 以降の sudo が tty で
+# 再プロンプトしてしまう。そこでインストール中だけ NOPASSWD を付与し、
+# 終了時に EXIT trap で取り除く。
+# @See https://github.com/Homebrew/brew/commit/2adf25dcaf
 request_admin_privileges() {
   if [ "${CI:-false}" = "true" ]; then
     return
@@ -75,23 +81,20 @@ request_admin_privileges() {
   sudo -v
 
   SUDOERS_FILE="/etc/sudoers.d/temp_dotfiles_installer"
-  sudo sh -c "echo 'Defaults timestamp_timeout=120' > ${SUDOERS_FILE}"
-  sudo chmod 0440 "${SUDOERS_FILE}"
   # bash の EXIT trap は 1 本のみ。placeholder の掃除もここに集約する
   # (ensure_xcode_clt で trap を新設すると sudoers の掃除を上書きして壊す)
-  trap 'sudo rm -f "${SUDOERS_FILE}" "${CLT_PLACEHOLDER}"' EXIT
+  trap 'sudo rm -f "${SUDOERS_FILE}" "${SUDOERS_FILE}.tmp" "${CLT_PLACEHOLDER}"' EXIT
 
-  sudo -v
-
-  (
-    while true; do
-      sleep 10
-      # subshell は set -e を継承する。一時的な失敗で keepalive が静かに死ぬと
-      # 後半の sudo が tty で再プロンプトして無人実行が止まるため、失敗を握りつぶす
-      sudo -n true || true
-      kill -0 "$$" || exit
-    done
-  ) 2>/dev/null &
+  # 壊れた sudoers.d ファイルは sudo 自体を使用不能にするため、反映前に検証する。
+  # includedir は '.' を含むファイル名を無視するので、.tmp のまま検証してから mv する
+  sudo sh -c "echo '$(id -un) ALL=(ALL) NOPASSWD: ALL' > ${SUDOERS_FILE}.tmp"
+  sudo chmod 0440 "${SUDOERS_FILE}.tmp"
+  if ! sudo visudo -c -f "${SUDOERS_FILE}.tmp" > /dev/null; then
+    sudo rm -f "${SUDOERS_FILE}.tmp"
+    echo "⚠️ Failed to validate ${SUDOERS_FILE}.tmp — aborting so sudo stays usable" >&2
+    exit 1
+  fi
+  sudo mv "${SUDOERS_FILE}.tmp" "${SUDOERS_FILE}"
 }
 
 # ~/Documents 初回アクセスの TCC ダイアログを、パスワード入力直後のユーザーが
@@ -205,7 +208,7 @@ echo -e "${reset}"
 if [[ "$OS_NAME" == "Darwin" ]]; then
   # 人間の操作 (パスワード入力・TCC ダイアログ) を先頭に集約する。
   # ensure_xcode_clt は sudo を使い、CLT のダウンロードに数十分かかることがあるため、
-  # sudoers + keepalive を先に確立してからヘッドレスで走らせる
+  # NOPASSWD sudoers を先に確立してからヘッドレスで走らせる
   request_admin_privileges
   request_documents_access
   ensure_xcode_clt


### PR DESCRIPTION
## 問題

`curl | bash` のインストールで先頭に 1 回パスワードを入れたあと、`darwin/macos.sh` の最初の sudo (`sudo nvram`) で再びパスワードを求められ、無人実行が止まっていた。

## 原因

brew は起動するたびに `sudo --reset-timestamp` を実行して sudo の認証キャッシュを破棄する (Homebrew/brew@2adf25dcaf、`Library/Homebrew/brew.sh` の起動処理。オプトアウト不可)。

このため `timestamp_timeout=120` + keepalive (`sudo -n true`) の延命方式では、homebrew.sh の `brew update` / `brew bundle` が走った時点でチケットが破棄され、以降 keepalive は失敗し続ける (#1532 で入れた `|| true` が失敗を握りつぶすため、ループは生きているのに延命効果がない)。次に tty で sudo を使う macos.sh の nvram で再プロンプトしていた。

## 変更

- タイムスタンプ延命方式をやめ、インストール中だけ `/etc/sudoers.d/temp_dotfiles_installer` に `<user> ALL=(ALL) NOPASSWD: ALL` を置く方式に変更。brew が何度チケットを破棄しても影響を受けない
- 壊れた sudoers ファイルは sudo 自体を使用不能にするため、`.tmp` 名 (includedir は `.` を含むファイル名を無視する) のまま `visudo -c` で検証してから mv で反映
- 不要になった keepalive ループと 2 回目の `sudo -v` を削除
- 撤去は従来どおり EXIT trap。ADR の keepalive 記述も現状に合わせて更新

## レビュー観点

- インストール中はユーザーのプロセスがパスワードなしで sudo できる。従来の 2 時間タイムスタンプ + keepalive も同等の露出があり、期間はインストール中に限定され EXIT trap で撤去される。SIGKILL などで trap が走らず残った場合も、次回実行時に上書きされる
- `make macos` など個別スクリプトの対話実行は従来どおり (通常の sudo プロンプト、TouchID 有効)

## cloud-bump

変更ファイルは `install.sh` と `docs/decisions/` のみで、cloud-setup.yaml の `paths` に触れていないため、マージ後の /cloud-bump は不要。