### PR TITLE
chore: drop appcleaner and revert the install fallback

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -244,9 +244,6 @@ if OS.mac? && !ENV["CI"]
   # Write, edit, and chat about your code with AI https://cursor.sh/
   cask "cursor"
 
-  # FreeMacSoft AppCleaner https://freemacsoft.net/appcleaner/
-  cask "appcleaner"
-
   # Lock/unlock Apple computers using the proximity of a bluetooth low energy device https://github.com/ts1/BLEUnlock
   cask "bleunlock"
 

--- a/install.sh
+++ b/install.sh
@@ -31,37 +31,6 @@ CLT_PLACEHOLDER="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 yellow='\033[1;33m'
 reset='\033[0m'
 
-# アプリのインストールなど一部のステップが落ちても、残りのステップは走らせて
-# セットアップを最後まで進める。1 つの配布元が落ちただけで symlink や toolchain の
-# セットアップまで巻き添えで止まるのを防ぐ。
-# 失敗は握りつぶさず FAILED_STEPS に積み、最後にまとめて報告して非ゼロで終了する。
-FAILED_STEPS=()
-
-run_step() {
-  local label="$1"
-  shift
-
-  if "$@"; then
-    return 0
-  fi
-
-  echo -e "⚠️  ${label} failed — continuing with the remaining steps" >&2
-  FAILED_STEPS+=("$label")
-  return 0
-}
-
-# homebrew.sh が失敗して brew が無い状態でも、後続ステップに進めるようにする。
-load_brew_shellenv() {
-  local brew_bin="$1"
-
-  if [ ! -x "$brew_bin" ]; then
-    echo -e "⚠️  ${brew_bin} not found — skipping shellenv" >&2
-    return 0
-  fi
-
-  eval "$("$brew_bin" shellenv)"
-}
-
 # request_admin_privileges is kept in this file (not extracted to a script)
 # because it manages main-process state: it sets an EXIT trap. Running it in
 # a subshell would not affect the current process, so it must remain here.
@@ -213,59 +182,36 @@ if [[ "$OS_NAME" == "Darwin" ]]; then
   request_documents_access
   ensure_xcode_clt
   clone_dotfiles_repo
-  run_step "nix.sh" bash "$SCRIPT_DIR/scripts/nix.sh"
-  run_step "homebrew.sh" bash "$SCRIPT_DIR/scripts/homebrew.sh"
-  load_brew_shellenv /opt/homebrew/bin/brew
-  run_step "symlink.sh" bash "$SCRIPT_DIR/scripts/symlink.sh"
-  run_step "darwin/macos.sh" bash "$SCRIPT_DIR/scripts/darwin/macos.sh"
-  run_step "toolchains/node.sh" bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
-  run_step "toolchains/python.sh" bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
-  run_step "toolchains/ruby.sh" bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
-  run_step "toolchains/rust.sh" bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
-  run_step "toolchains/terraform.sh" bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
-  run_step "toolchains/claude-code.sh" bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
-  run_step "toolchains/pm.sh" bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
-  run_step "default_apps.sh" bash "$SCRIPT_DIR/scripts/default_apps.sh"
-  run_step "darwin/open_config_apps.sh" bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
+  bash "$SCRIPT_DIR/scripts/nix.sh"
+  bash "$SCRIPT_DIR/scripts/homebrew.sh"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+  bash "$SCRIPT_DIR/scripts/symlink.sh"
+  bash "$SCRIPT_DIR/scripts/darwin/macos.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
+  bash "$SCRIPT_DIR/scripts/default_apps.sh"
+  bash "$SCRIPT_DIR/scripts/darwin/open_config_apps.sh"
 fi
 
 if [[ "$OS_NAME" == "Linux" ]]; then
   clone_dotfiles_repo
-  run_step "nix.sh" bash "$SCRIPT_DIR/scripts/nix.sh"
-  run_step "zsh.sh" bash "$SCRIPT_DIR/scripts/zsh.sh"
-  run_step "homebrew.sh" bash "$SCRIPT_DIR/scripts/homebrew.sh"
-  load_brew_shellenv /home/linuxbrew/.linuxbrew/bin/brew
-  run_step "symlink.sh" bash "$SCRIPT_DIR/scripts/symlink.sh"
-  run_step "toolchains/node.sh" bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
-  run_step "toolchains/python.sh" bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
-  run_step "toolchains/ruby.sh" bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
-  run_step "toolchains/rust.sh" bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
-  run_step "toolchains/terraform.sh" bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
-  run_step "toolchains/claude-code.sh" bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
-  run_step "toolchains/pm.sh" bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
-fi
-
-# 失敗したステップがあっても最後までは実行している。ここで初めて非ゼロを返す。
-# bash 3.2 では set -u 下の "${FAILED_STEPS[@]}" が空配列で unbound variable に
-# なるため、件数でガードしてから展開する。
-if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
-  echo -e "${yellow}"
-  printf '%s\n' \
-    "" \
-    "⚠️  セットアップは最後まで実行しましたが、失敗したステップがあります:" \
-    ""
-  printf '      - %s\n' "${FAILED_STEPS[@]}"
-  printf '%s\n' \
-    "" \
-    "    ログを確認して、個別に再実行してください:" \
-    "      bash $SCRIPT_DIR/scripts/<script>" \
-    "" \
-    "    Homebrew だけ入れ直す場合:" \
-    "      make -C \"$SCRIPT_DIR\" homebrew" \
-    "" \
-    ""
-  echo -e "${reset}"
-  exit 1
+  bash "$SCRIPT_DIR/scripts/nix.sh"
+  bash "$SCRIPT_DIR/scripts/zsh.sh"
+  bash "$SCRIPT_DIR/scripts/homebrew.sh"
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+  bash "$SCRIPT_DIR/scripts/symlink.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/node.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/python.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/ruby.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/rust.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/terraform.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/claude-code.sh"
+  bash "$SCRIPT_DIR/scripts/toolchains/pm.sh"
 fi
 
 echo -e "${yellow}"

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -29,52 +29,6 @@ fix_brew_link_conflicts() {
   done
 }
 
-# brew bundle は fetch を全件まとめて 1 回の `brew fetch` に渡し、1 件でも失敗
-# すると install フェーズに一切進まない (Library/Homebrew/bundle/installer.rb の
-# "Failed to fetch" → return false)。到達不能な配布元が 1 つあるだけで、ダウン
-# ロード済みのものまで含めて全パッケージが巻き添えになる。
-# そのため bundle が通らなかったときは、エントリを 1 件ずつ入れ直して
-# 1 件の失敗が他に波及しないようにする。
-install_entries_individually() {
-  local brewfile="$1"
-  local failed=()
-  local name
-
-  # tap を先に入れる。nozomiishii/tap/brooklyn は tap が無いと解決できない。
-  while IFS= read -r name; do
-    [ -n "$name" ] || continue
-    brew tap "$name" || failed+=("tap $name")
-  done < <(brew bundle list --file="$brewfile" --tap)
-
-  while IFS= read -r name; do
-    [ -n "$name" ] || continue
-    brew install --formula "$name" || failed+=("brew $name")
-  done < <(brew bundle list --file="$brewfile" --formula)
-
-  # cask は macOS 専用。brew bundle 本体は Skipper で Linux の cask を除外するが、
-  # Lister は Skipper を通さない (Library/Homebrew/bundle/lister.rb) ため
-  # `brew bundle list --cask` は Linux でも Brewfile の cask を返してしまう。
-  # そのまま流すと Linux で必ず失敗するので、ここで OS を見て飛ばす。
-  if [[ "$OS_NAME" == "Darwin" ]]; then
-    while IFS= read -r name; do
-      [ -n "$name" ] || continue
-      brew install --cask "$name" || failed+=("cask $name")
-    done < <(brew bundle list --file="$brewfile" --cask)
-  fi
-
-  # 通常経路の `brew bundle --cleanup` と同じ状態に揃える。cleanup は Brewfile に
-  # 無いものだけを消すので、入れ損ねたエントリには触れない。
-  brew bundle cleanup --force --file="$brewfile" || true
-
-  # bash 3.2 では set -u 下の "${failed[@]}" が空配列で unbound variable になる。
-  # 件数でガードしてから展開する。
-  if [ "${#failed[@]}" -gt 0 ]; then
-    echo "⚠️  個別インストールでも失敗したエントリ:" >&2
-    printf '  - %s\n' "${failed[@]}" >&2
-    return 1
-  fi
-}
-
 trust_brew_bundle_formulae() {
   if ! brew help trust >/dev/null 2>&1; then
     return 0
@@ -118,7 +72,6 @@ trust_brew_bundle_formulae
 max_attempts="${BREW_BUNDLE_MAX_ATTEMPTS:-5}"
 attempt=1
 backoff_base="${BREW_BUNDLE_BACKOFF_SEC:-20}"
-install_failed=0
 
 # Brewfile を正にする（入れて、Brewfile にないものを削除。App Store は対象外）。
 # install と cleanup は一体にする（分けると node 等の依存を巻き添え削除するため）。
@@ -133,9 +86,8 @@ while [ "$attempt" -le "$max_attempts" ]; do
     break
   fi
   if [ "$attempt" -eq "$max_attempts" ]; then
-    echo "brew bundle failed after ${max_attempts} attempts — falling back to individual installs"
-    install_entries_individually "$SCRIPT_DIR/Brewfile" || install_failed=1
-    break
+    echo "brew bundle failed after ${max_attempts} attempts"
+    exit 1
   fi
 
   fix_brew_link_conflicts
@@ -146,10 +98,3 @@ done
 
 # 古いバージョン・キャッシュを削除してディスクを空ける
 brew cleanup --verbose
-
-# 入れられるものは入れ切った上で、残った失敗は呼び出し元に伝える。
-# make homebrew 単体実行と lefthook の post-merge で失敗を検知できる状態を保つ。
-# install.sh から呼ばれた場合は、この非ゼロを受け取っても後続ステップを続行する。
-if [ "$install_failed" -ne 0 ]; then
-  exit 1
-fi


### PR DESCRIPTION
## 背景

#1532 の個別インストールフォールバックは、実機 (Mac mini) で期待通りに動かなかった。`brew bundle` が fetch で落ちた後のフォールバックでもパッケージが 1 つも入らず、複雑さに見合う効果がなかったため、実装ごと取り下げてシンプルな構成に戻す。

根本原因は `appcleaner` cask の配布元 `freemacsoft.net` が Cloudflare for Families (1.1.1.3) にアダルト誤分類されて `0.0.0.0` に解決されること。この cask を Brewfile から外せば、セットアップを止めていた要因そのものが消える。

## 変更内容

- **Revert #1532** — install.sh の `run_step` / 失敗サマリと、homebrew.sh の個別インストールフォールバックを削除し、元の実装に戻す（#1535 の sudoers 変更はそのまま）
- **Brewfile から `appcleaner` を削除** — アプリの削除は Raycast 組み込みの Uninstall Application で代替する。ゴミ箱監視ポップアップが必要になったら手動インストールか Pearcleaner を検討する

## 影響

- 次回 `make homebrew` (post-merge hook 含む) の `--cleanup` で、導入済みマシンから AppCleaner.app がアンインストールされる
- Mac mini のセットアップは、この変更を pull した後の再実行で最後まで通る見込み

## 検証

- `/bin/bash -n install.sh scripts/homebrew.sh` OK
- `git diff 51b60eb4~1 HEAD -- scripts/homebrew.sh` が空 (完全に元通り)
- install.sh の残差分は #1535 のみであることを確認
