### PR TITLE
chore: gate the oss skill by push permission

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -31,7 +31,8 @@
 ユーザー本人や開発環境の情報が必要なときは `~/Code/nozomiishii/brain/brain/PROFILE.md` を参照する。
 
 ## 外部リポジトリ
-- 外部リポジトリを変更する操作は /oss スキルを使用する
+- push 権限のないリポジトリを変更する操作は /oss スキルを使用する
+  - 判定に迷ったら `gh repo view <repo> --json viewerPermission` で確認する
 
 ## ドキュメント作成
 - /doc スキルを使用する


### PR DESCRIPTION
## 概要

/oss スキルの発動条件を「外部リポジトリ」から「push 権限のないリポジトリ」基準に書き換える。

## 背景

brain の CI 移行作業 ([brain#437](https://github.com/nozomiishii/brain/pull/437)) の流れで、自分所有の nozomiishii/workflows への変更を「外部リポジトリ → /oss 対象」と誤判定した。「外部」という単語が所有権の意味かセッション範囲の意味か曖昧で、エージェントが単語のパターンマッチで誤りやすい。push 権限基準なら境界が /oss の目的 (直接 push できない repo への投稿を安全に進める) と一致し、`gh repo view --json viewerPermission` で機械的に判定できる。

## 変更内容

- `home/AGENTS.md` の「外部リポジトリ」セクションを 2 行に書き換え
  - push 権限のないリポジトリを変更する操作は /oss スキルを使用する
  - 判定に迷ったら `gh repo view <repo> --json viewerPermission` で確認する

## 意味の変化

- 「他人の repo だが collaborator として write 権限を持つ」ケースが /oss 対象外になる
- `home/.agents/skills/oss/SKILL.md` 側の定義 (「ユーザーおよび所属 Organization の管理外」) は今回変更しない。基準の正本が一時的に 2 箇所になるため、ズレが気になったらスキル側の追従を別 PR で行う

## マージ後の運用

`home/AGENTS.md` は cloud 配信対象 (`.github/workflows/cloud-setup.yaml` の `paths`) のため、**マージ後に /cloud-bump の実行が必要**。bump しない限り cloud の新規セッションは最大 7 日前のスナップショットで起動する。