### PR TITLE
chore: add hcl2json to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -145,6 +145,9 @@ if OS.mac? && !ENV["CI"]
   # GNU grep, egrep and fgrep https://www.gnu.org/software/grep/
   brew "grep"
 
+  # Convert HCL to JSON https://github.com/tmccombs/hcl2json
+  brew "hcl2json"
+
   # Command-line benchmarking tool https://github.com/sharkdp/hyperfine
   brew "hyperfine"
 


### PR DESCRIPTION
## 概要

hcl2json を Brewfile に追加する。

## 背景

nozomiishii/infra の self-hosted runner セットアップ ([infra#176](https://github.com/nozomiishii/infra/pull/176)) が、対象 repo の導出に main.tf の `locals.repositories` を読む。awk によるテキストパースは tofu fmt のレイアウトに結合して壊れやすいため、正規の HCL パーサーである [hcl2json](https://github.com/tmccombs/hcl2json) で JSON 化して jq で抽出する方式に変更した。その実行前提を Brewfile で配布する。

## cloud-bump 判定

Brewfile は [cloud-setup.yaml](.github/workflows/cloud-setup.yaml) の `paths` に該当しないため、マージ後の /cloud-bump は不要。
