### PR TITLE
chore: remove tenv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,11 +47,7 @@ jobs:
       - name: Run install (PR branch)
         if: github.event_name == 'pull_request'
         run: bash ./install.sh
-        env:
-          TENV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run install (from URL)
         if: github.event_name != 'pull_request'
         run: curl -L https://nozomiishii.dev/dotfiles/install | bash
-        env:
-          TENV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Brewfile
+++ b/Brewfile
@@ -58,9 +58,6 @@ if OS.mac? && !ENV["CI"]
   # GitHub command-line tool. https://github.com/cli/cli
   brew "gh"
 
-  # OpenTofu / Terraform / Terragrunt / Terramate / Atmos version manager https://tofuutils.github.io/tenv/
-  brew "tenv"
-
   # Password manager that keeps all passwords secure behind one password. https://1password.com
   cask "1Password"
 


### PR DESCRIPTION
## 概要

infra repo が OpenTofu の版管理を tenv から mise に移行した (nozomiishii/infra#179) ため、dotfiles から tenv を撤去する。

tenv が `/opt/homebrew/bin/tofu` を提供し続けると、mise の tool が未インストールのときに tenv 側の版が黙って使われてしまう。版の解決先を mise 一本にするために撤去する。

## 変更内容

- `Brewfile`: `brew "tenv"` と直前のコメント行を削除
- `.github/workflows/ci.yaml`: `TENV_GITHUB_TOKEN` を削除 (2 箇所)。Brewfile から tenv が消えると参照先の無い dead config になるため。どちらも `env:` の中身がこれ 1 つだけだったので `env:` ごと削除した

`grep -rn 'tenv\|TENV'` で repo 全体を確認済み。残りの参照は無し (`dotenv` の部分一致のみ)。

## マージ順序の注意

**nozomiishii/infra#179 が main にマージされた後にマージすること。**

先にこちらをマージすると、infra の main checkout にはまだ `mise.toml` が無いため、tenv も mise も `tofu` を提供できず、どこからも解決できなくなる。

## ローカル環境について

### `brew uninstall tenv` は手動で実行しない

`scripts/homebrew.sh` が `brew bundle --cleanup --force` で Brewfile を正としているため、bootstrap (`make homebrew`) が tenv を消す。lefthook の post-merge hook が Brewfile の変更を検知して `make homebrew` を走らせるので、main を pull した時点で自動的に片付く。

### `~/.tenv` に残る Terraform / Terragrunt

`~/.tenv` (約 988MB) には OpenTofu 以外に **Terraform / Terragrunt の実体も残っている**。tenv を消すとこれらの解決手段も同時に失われる。今後使う予定があるなら、各 repo の `mise.toml` に入れる必要がある。

ディレクトリ自体の削除は別途手動で判断する (この PR では触らない)。

## 確認したこと

- `pnpm format` を実行。`ci.yaml` は origin/main の時点で既に prettier の指摘対象だったため、本 PR では整形しない (無関係な差分を混ぜないため)
- cloud 配信対象 (`cloud-setup.yaml` の paths: `home/.agents/**`, `home/.claude/**`, `home/.codex/**`, `home/AGENTS.md`, `scripts/cloud/**`) には触れていないため、マージ後の cloud bump は不要
