### PR TITLE
feat: enable mise shell completion for zsh

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -1,6 +1,5 @@
 # https://mise.jdx.dev/configuration.html
 [tools]
-# per-repo の node は devEngines.runtime、pnpm の版は pnpm 自身が packageManager を読んで切替
 node = "24.19.0"
 bun = "1.3.14"
 pnpm = "11.21.0"
@@ -10,13 +9,11 @@ ruby = "4.0.6"
 "npm:typescript-language-server" = "5.3.0"
 "npm:@devcontainers/cli" = "0.88.0"
 "npm:@antfu/ni" = "30.5.0"
-# Brewfile のフォーマッタ。VS Code の ruby 拡張が Brewfile を Ruby 扱いにするため必要
+# Brewfile のフォーマット用
 "gem:rufo" = "0.18.2"
 # mise の zsh 補完用
 usage = "5.1.0"
 
-# precompiled バイナリだけを使い、ruby-build でのソースビルドには落とさない。
-# 落ちないので openssl / libyaml を Brewfile に持たなくてよい。
-# precompiled が無い版を指定した場合は無言でビルドせず即エラーになる。
+# precompiled のみ使う。ソースビルドしないので openssl / libyaml が不要
 [settings.ruby]
 compile = false

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -12,8 +12,7 @@ ruby = "4.0.6"
 "npm:@antfu/ni" = "30.5.0"
 # Brewfile のフォーマッタ。VS Code の ruby 拡張が Brewfile を Ruby 扱いにするため必要
 "gem:rufo" = "0.18.2"
-# mise の zsh 補完が内部で呼ぶ CLI。無いとタブを押した時点でエラーになる
-# https://mise.jdx.dev/installing-mise.html#autocompletion
+# mise の zsh 補完用
 usage = "5.1.0"
 
 # precompiled バイナリだけを使い、ruby-build でのソースビルドには落とさない。

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -12,6 +12,9 @@ ruby = "4.0.6"
 "npm:@antfu/ni" = "30.5.0"
 # Brewfile のフォーマッタ。VS Code の ruby 拡張が Brewfile を Ruby 扱いにするため必要
 "gem:rufo" = "0.18.2"
+# mise の zsh 補完が内部で呼ぶ CLI。無いとタブを押した時点でエラーになる
+# https://mise.jdx.dev/installing-mise.html#autocompletion
+usage = "5.1.0"
 
 # precompiled バイナリだけを使い、ruby-build でのソースビルドには落とさない。
 # 落ちないので openssl / libyaml を Brewfile に持たなくてよい。

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -85,6 +85,12 @@ if command -v direnv >/dev/null; then
 fi
 
 # mise
+# activate が設定するのは env と PATH だけ。補完は別途読み込む必要がある。
+# 生成される補完スクリプトは末尾で compdef を呼ぶので、compinit 済みならここで source すれば効く。
+# 補完の実行には usage CLI が要る (~/.config/mise/config.toml で導入)。
+# https://mise.jdx.dev/installing-mise.html#autocompletion
 if command -v mise >/dev/null; then
   eval "$(mise activate zsh)"
+  # shellcheck source=/dev/null
+  source <(mise completion zsh)
 fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -85,12 +85,9 @@ if command -v direnv >/dev/null; then
 fi
 
 # mise
-# activate が設定するのは env と PATH だけ。補完は別途読み込む必要がある。
-# 生成される補完スクリプトは末尾で compdef を呼ぶので、compinit 済みならここで source すれば効く。
-# 補完の実行には usage CLI が要る (~/.config/mise/config.toml で導入)。
-# https://mise.jdx.dev/installing-mise.html#autocompletion
 if command -v mise >/dev/null; then
   eval "$(mise activate zsh)"
+  # https://mise.jdx.dev/installing-mise.html#autocompletion
   # shellcheck source=/dev/null
   source <(mise completion zsh)
 fi


### PR DESCRIPTION
## 概要

`home/.zshrc` の mise ブロックは `eval "$(mise activate zsh)"` だけで、補完が読み込まれていなかった。[公式ドキュメント](https://mise.jdx.dev/installing-mise.html#autocompletion) のとおり `mise activate` が設定するのは env と PATH だけで、補完は別扱い。実際 `mise activate zsh` の出力 87 行に `compdef` / `fpath` は 1 つも無い。

そのため `mise <TAB>` が何も出ず、mise task の usage spec に書いた `complete` も効かない状態だった。

## 変更

| ファイル | 内容 |
| --- | --- |
| `home/.zshrc` | mise ブロックで `source <(mise completion zsh)` を実行 |
| `home/.config/mise/config.toml` | 補完が内部で呼ぶ `usage` CLI を追加 |

`usage` は任意の依存ではない。生成される補完スクリプトは `usage complete-word` に候補生成を委ねているので、無いとタブを押した時点で `Error: usage CLI not found` が出て補完が死ぬ。

### fpath ではなく source にした理由

公式が案内するのは `mise completion zsh > /usr/local/share/zsh/site-functions/_mise` だが、これは sudo が要る共有パスで、AGENTS.md のポータビリティ方針に合わないため採らなかった。

代わりに、既存の carapace (`source <(carapace _carapace zsh)`) や fzf (`source <(fzf --zsh)`) と同じ source 方式に揃えた。

- 生成物の末尾に `compdef _mise mise` のフォールバックがあるため、compinit (`.zshrc` 12 行目) より後で source しても効く
- **compinit や fpath の並びを一切触らずに済む**
- mise 本体を更新しても補完が自動で追従する (生成物を repo に持たない)

## 検証

変更後の `.zshrc` を `ZDOTDIR` で読み込んだ zsh で確認した。

**1. 補完関数が mise に紐づく**

```
_mise defined : 1
_comps[mise]  : _mise
usage on PATH : ~/.local/share/mise/installs/usage/5.1.0/usage
```

**2. `mise run <TAB>` でタスク名が出る**

```
lint
plan
```

**3. `mise run plan <TAB>` で usage spec の `complete` が発火する**

`complete "stack" run="./list.sh"` を書いたテスト用 task で、スクリプトの出力がそのまま候補になった。

```
github
cloudflare
aws
```

**4. 既存の補完と共存する**

`fzf-tab` の widget は生きたまま、`_comps[git]` は従来どおり carapace が担当。mise は carapace の対象外 (`carapace --list` に無い) なので競合しない。

**5. 起動コスト**

`mise completion zsh` の生成は 20ms。zsh 起動全体で見ると差は測定ノイズに埋もれる (7 回平均: before 0.319s / after 0.300s)。

## 反映方法

マージ後、`~/.zshrc` は symlink 済みなので `make link` は不要。`usage` の導入のみ必要。

```sh
mise install
```

## 補足

`.github/workflows/cloud-setup.yaml` の `paths` は `home/.agents/**` `home/.claude/**` `home/.codex/**` `home/AGENTS.md` `scripts/cloud/**`。今回触った 2 ファイルはどちらも対象外なので、cloud-bump は不要。
