### PR TITLE
fix: pin mise.binPath to absolute path to prevent approval dialog

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -402,6 +402,11 @@
   "redhat.telemetry.enabled": true,
 
   // ----------------------------------------------------------------
+  // mise
+  // ----------------------------------------------------------------
+  "mise.binPath": "~/.local/bin/mise",
+
+  // ----------------------------------------------------------------
   // Extensions
   // ----------------------------------------------------------------
   "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue",


### PR DESCRIPTION
## 概要

- mise-vscode 拡張の `binPath` 既定値 `"mise"` が `path.resolve` でワークスペース内のファイルと誤判定され、新しいディレクトリや worktree を開くたびにセキュリティ承認ダイアログが表示されていた
- `"mise.binPath": "~/.local/bin/mise"` を設定し、絶対パス指定で誤判定を防止

## テスト

- [ ] Cursor で新しいディレクトリを開いたときに mise の承認ダイアログが出ないことを確認