### PR TITLE
fix: keep raycast runtime data out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ home/.codex/config.toml
 
 # SuperWhisper regenerates this on launch — let the app own it
 home/Documents/superwhisper/modes/default.json
+
+# Raycast は extensions/ ai/ などをランタイムに作る。管理対象は backup と scripts だけ
+home/.config/raycast/*
+!home/.config/raycast/backup/
+!home/.config/raycast/scripts/

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -31,6 +31,7 @@ runtime_dirs=(
   "$HOME/.claude"
   "$HOME/.codex"
   "$HOME/.config"
+  "$HOME/.config/raycast"
   "$HOME/.local/bin"
   "$HOME/.ssh"
   "$HOME/Documents/superwhisper/modes"


### PR DESCRIPTION
## 課題

`~/.config/raycast` が repo へのディレクトリ symlink に畳まれており (stow の tree folding)、Raycast がランタイムに作る `extensions/` (219MB) と `ai/` が repo の working tree に書き込まれていた。

## 変更

| ファイル | 内容 | 役割 |
| --- | --- | --- |
| `scripts/symlink.sh` | `runtime_dirs` に `$HOME/.config/raycast` を追加 | stow の前に実 dir を作り、folding を防ぐ |
| `.gitignore` | Raycast 配下を許可リスト化 | 万一書き込まれてもコミットさせない |

結果、`~/.config/raycast` は実 dir になり、`backup` と `scripts` だけが repo への symlink になる。

## 既存マシンでの追加手順

`make link` だけでは畳み込みは解けない。一度だけ手で入れ替える。

```bash
osascript -e 'quit app "Raycast"'
rm ~/.config/raycast && mkdir -p ~/.config/raycast
mv home/.config/raycast/extensions home/.config/raycast/ai ~/.config/raycast/
make link
open -a Raycast
```